### PR TITLE
Clean up Salus exceptions

### DIFF
--- a/lib/salus.rb
+++ b/lib/salus.rb
@@ -45,7 +45,7 @@ module Salus
       # Try to send Salus reports to remote server or local files.
       begin
         processor.export_report
-      rescue => e # rubocop:disable Style/RescueStandardError
+      rescue StandardError => e
         raise e if ENV['RUNNING_SALUS_TESTS']
         puts "Could not send Salus report: (#{e.class}: #{e.message})"
       end

--- a/lib/salus/scanners/base.rb
+++ b/lib/salus/scanners/base.rb
@@ -3,6 +3,9 @@ require 'open3'
 module Salus::Scanners
   # Super class for all scanner objects.
   class Base
+    class UnhandledExitStatusError < StandardError; end
+    class InvalidScannerInvocationError < StandardError; end
+
     def initialize(repository:, report:, config:)
       @repository = repository
       @report = report
@@ -15,12 +18,12 @@ module Salus::Scanners
 
     # The scanning logic or something that calls a scanner.
     def run
-      raise NotImplementedError
+      raise NoMethodError
     end
 
     # Returns TRUE if this scanner is appropriate for this repo, ELSE false.
     def should_run?
-      raise NotImplementedError
+      raise NoMethodError
     end
 
     # Runs a command on the terminal.

--- a/lib/salus/scanners/bundle_audit.rb
+++ b/lib/salus/scanners/bundle_audit.rb
@@ -6,6 +6,8 @@ require 'salus/scanners/base'
 
 module Salus::Scanners
   class BundleAudit < Base
+    class UnvalidGemVulnError < StandardError; end
+
     def run
       # Ensure the DB is up to date
       unless Bundler::Audit::Database.update!(quiet: true)
@@ -72,7 +74,7 @@ module Salus::Scanners
         report_info("unpatched_gem", serialized_vuln)
         serialized_vuln
       else
-        raise NotImplementedError, "BundleAudit Scanner received a #{result} from the"\
+        raise UnvalidGemVulnError, "BundleAudit Scanner received a #{result} from the " \
                                    "bundler/audit gem, which it doesn't know how to handle"
       end
     end

--- a/lib/salus/scanners/pattern_search.rb
+++ b/lib/salus/scanners/pattern_search.rb
@@ -81,7 +81,7 @@ module Salus::Scanners
               errors << shell_return[:stderr]
             end
           else
-            raise NotImplementedError,
+            raise UnhandledExitStatusError,
                   "Unknown exit status #{shell_return[:exit_status].exitstatus} from sift "\
                     "(grep alternative).\n" \
                     "STDOUT: #{shell_return[:stdout]}\n" \

--- a/lib/salus/scanners/report_go_dep.rb
+++ b/lib/salus/scanners/report_go_dep.rb
@@ -9,7 +9,7 @@ module Salus::Scanners
     def run
       unless should_run?
         raise(
-          NotImplementedError,
+          InvalidScannerInvocationError,
           'Cannot report on Go dependencies without a Gopkg.lock file.'
         )
       end

--- a/lib/salus/scanners/report_node_modules.rb
+++ b/lib/salus/scanners/report_node_modules.rb
@@ -29,7 +29,7 @@ module Salus::Scanners
       elsif @repository.package_json_present?
         record_dependencies_from_package_json(record_modules: true)
       else
-        raise NotImplementedError,
+        raise InvalidScannerInvocationError,
               'Cannot report on Node modules without package.json, '\
                 'package-lock.json or yarn.lock files.'
       end

--- a/lib/salus/scanners/report_ruby_gems.rb
+++ b/lib/salus/scanners/report_ruby_gems.rb
@@ -13,7 +13,7 @@ module Salus::Scanners
       elsif @repository.gemfile_present?
         record_dependencies_from_gemfile
       else
-        raise NotImplementedError,
+        raise InvalidScannerInvocationError,
               'Cannot report on Ruby gems without a Gemfile or Gemfile.lock'
       end
     end

--- a/spec/lib/salus/scanners/base_spec.rb
+++ b/spec/lib/salus/scanners/base_spec.rb
@@ -10,13 +10,13 @@ describe Salus::Scanners::Base do
 
   describe '#run' do
     it 'should raise an exception since this is an abstract function' do
-      expect { scanner.run }.to raise_error(NotImplementedError)
+      expect { scanner.run }.to raise_error(NoMethodError)
     end
   end
 
   describe '#should_run?' do
     it 'should raise an exception since this is an abstract function' do
-      expect { scanner.should_run? }.to raise_error(NotImplementedError)
+      expect { scanner.should_run? }.to raise_error(NoMethodError)
     end
   end
 

--- a/spec/lib/salus/scanners/report_go_dep_spec.rb
+++ b/spec/lib/salus/scanners/report_go_dep_spec.rb
@@ -14,7 +14,7 @@ describe Salus::Scanners::ReportGoDep do
           config: blank_config
         )
         expect { scanner.run }.to raise_error(
-          NotImplementedError,
+          Salus::Scanners::Base::InvalidScannerInvocationError,
           'Cannot report on Go dependencies without a Gopkg.lock file.'
         )
       end

--- a/spec/lib/salus/scanners/report_node_modules_spec.rb
+++ b/spec/lib/salus/scanners/report_node_modules_spec.rb
@@ -14,7 +14,7 @@ describe Salus::Scanners::ReportNodeModules do
           config: blank_config
         )
         expect { scanner.run }.to raise_error(
-          NotImplementedError,
+          Salus::Scanners::Base::InvalidScannerInvocationError,
           'Cannot report on Node modules without package.json, '\
             'package-lock.json or yarn.lock files.'
         )

--- a/spec/lib/salus/scanners/report_ruby_gems_spec.rb
+++ b/spec/lib/salus/scanners/report_ruby_gems_spec.rb
@@ -14,7 +14,7 @@ describe Salus::Scanners::ReportRubyGems do
           config: blank_config
         )
         expect { scanner.run }.to raise_error(
-          NotImplementedError,
+          Salus::Scanners::Base::InvalidScannerInvocationError,
           'Cannot report on Ruby gems without a Gemfile or Gemfile.lock'
         )
       end


### PR DESCRIPTION
The big change was to get rid of `NotImplementedError`. This should
mostly be avoided for application code since it's not a subclass of
StandardError (and therefore cannot be caught in the usual way). Instead
use `NoMethodError` or something custom if `NoMethodError` doesn't fit.