### PR TITLE
[big refactor] implement and use a per-scan ScanReport class

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 ruby '2.4.4'
 
-gem 'activesupport', '~> 5.0', '>= 5.0.0.1'
+gem 'activesupport', '~> 5.2', '>= 5.2.1'
 gem 'brakeman', '~> 4.0'
 gem 'bugsnag', '~> 4.0'
 gem 'bundler', '~> 1.15'

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 ruby '2.4.4'
 
+gem 'activesupport', '~> 5.0', '>= 5.0.0.1'
 gem 'brakeman', '~> 4.0'
 gem 'bugsnag', '~> 4.0'
 gem 'bundler', '~> 1.15'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,11 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (5.2.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
     addressable (2.5.1)
       public_suffix (~> 2.0, >= 2.0.2)
     ast (2.4.0)
@@ -13,6 +18,7 @@ GEM
     byebug (9.0.6)
     charlock_holmes (0.7.6)
     coderay (1.1.1)
+    concurrent-ruby (1.0.5)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
@@ -26,11 +32,14 @@ GEM
       mime-types (>= 1.19)
       rugged (>= 0.25.1)
     hashdiff (0.3.4)
+    i18n (1.1.1)
+      concurrent-ruby (~> 1.0)
     json (2.1.0)
     method_source (0.8.2)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
+    minitest (5.11.3)
     multipart-post (2.0.0)
     parallel (1.12.1)
     parser (2.5.0.3)
@@ -79,8 +88,11 @@ GEM
     simplecov-html (0.10.2)
     slop (3.6.0)
     thor (0.19.4)
+    thread_safe (0.3.6)
     toml (0.1.2)
       parslet (~> 1.5.0)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
     unicode-display_width (1.3.0)
     webmock (3.0.1)
       addressable (>= 2.3.6)
@@ -91,6 +103,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activesupport (~> 5.0, >= 5.0.0.1)
   brakeman (~> 4.0)
   bugsnag (~> 4.0)
   bundler (~> 1.15)
@@ -112,4 +125,4 @@ RUBY VERSION
    ruby 2.4.4p296
 
 BUNDLED WITH
-   1.16.2
+   1.16.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,7 +103,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activesupport (~> 5.0, >= 5.0.0.1)
+  activesupport (~> 5.2, >= 5.2.1)
   brakeman (~> 4.0)
   bugsnag (~> 4.0)
   bundler (~> 1.15)

--- a/bin/report_python_modules
+++ b/bin/report_python_modules
@@ -4,6 +4,9 @@ import json
 from sys import argv
 from os import chdir
 
+# When run with no arguments, enumerate the dependencies in
+# ./requirements.txt; given an argument, enumerate the dependencies listed in
+# the requirements.txt in that directory
 if len(argv) > 1:
     chdir(argv[1])
 

--- a/bin/report_python_modules
+++ b/bin/report_python_modules
@@ -1,4 +1,11 @@
+#!/usr/bin/env python
+
 import json
+from sys import argv
+from os import chdir
+
+if len(argv) > 1:
+    chdir(argv[1])
 
 try: # for pip >= 10
     from pip._internal.req import parse_requirements

--- a/lib/salus.rb
+++ b/lib/salus.rb
@@ -28,7 +28,13 @@ module Salus
   URI_DELIMITER = ' '.freeze # space
 
   class << self
-    def scan(config: nil, quiet: false, verbose: false, repo_path: DEFAULT_REPO_PATH)
+    def scan(
+      config: nil,
+      quiet: false,
+      verbose: false,
+      output_stream: STDOUT,
+      repo_path: DEFAULT_REPO_PATH
+    )
       ### Configuration ###
       # Config option would be: --config="<uri x> <uri y> etc"
       configuration_directives = (ENV['SALUS_CONFIGURATION'] || config || '').split(URI_DELIMITER)
@@ -39,8 +45,8 @@ module Salus
       processor.scan_project
 
       ### Reporting ###
-      # Print report to stdout.
-      puts processor.string_report(verbose: verbose) unless quiet
+      # Print report to the given stream (STDOUT by default)
+      output_stream.puts(processor.string_report(verbose: verbose)) unless quiet
 
       # Try to send Salus reports to remote server or local files.
       begin
@@ -51,7 +57,7 @@ module Salus
       end
 
       # System exit with success or failure - useful for CI builds.
-      system_exit(processor.scan_succeeded? ? EXIT_SUCCESS : EXIT_FAILURE)
+      system_exit(processor.passed? ? EXIT_SUCCESS : EXIT_FAILURE)
     end
 
     private

--- a/lib/salus.rb
+++ b/lib/salus.rb
@@ -17,7 +17,7 @@ require 'salus/config'
 require 'salus/processor'
 
 module Salus
-  VERSION = '1.0.0'.freeze
+  VERSION = '2.0.0'.freeze
   DEFAULT_REPO_PATH = './repo'.freeze # This is inside the docker container at /home/repo.
 
   SafeYAML::OPTIONS[:default_mode] = :safe

--- a/lib/salus.rb
+++ b/lib/salus.rb
@@ -28,13 +28,7 @@ module Salus
   URI_DELIMITER = ' '.freeze # space
 
   class << self
-    def scan(
-      config: nil,
-      quiet: false,
-      verbose: false,
-      output_stream: STDOUT,
-      repo_path: DEFAULT_REPO_PATH
-    )
+    def scan(config: nil, quiet: false, verbose: false, repo_path: DEFAULT_REPO_PATH)
       ### Configuration ###
       # Config option would be: --config="<uri x> <uri y> etc"
       configuration_directives = (ENV['SALUS_CONFIGURATION'] || config || '').split(URI_DELIMITER)
@@ -45,8 +39,8 @@ module Salus
       processor.scan_project
 
       ### Reporting ###
-      # Print report to the given stream (STDOUT by default)
-      output_stream.puts(processor.string_report(verbose: verbose)) unless quiet
+      # Print report to stdout.
+      puts processor.string_report(verbose: verbose) unless quiet
 
       # Try to send Salus reports to remote server or local files.
       begin

--- a/lib/salus/config.rb
+++ b/lib/salus/config.rb
@@ -48,8 +48,8 @@ module Salus
       @active_scanners   = all_none_some(SCANNERS.keys, final_config['active_scanners'])
       @enforced_scanners = all_none_some(SCANNERS.keys, final_config['enforced_scanners'])
       @scanner_configs   = final_config['scanner_configs'] || {}
-      @project_name      = final_config['project_name'].to_s || ''
-      @custom_info       = final_config['custom_info'].to_s || ''
+      @project_name      = final_config['project_name']&.to_s
+      @custom_info       = final_config['custom_info']&.to_s
       @report_uris       = final_config['reports'] || []
     end
 
@@ -59,6 +59,17 @@ module Salus
 
     def scanner_enforced?(scanner_class)
       @enforced_scanners.include?(scanner_class.to_s)
+    end
+
+    def to_h
+      {
+        active_scanners: @active_scanners.to_a.sort,
+        enforced_scanners: @enforced_scanners.to_a.sort,
+        scanner_configs: @scanner_configs,
+        project_name: @project_name,
+        custom_info: @custom_info,
+        report_uris: @report_uris
+      }.compact
     end
 
     private

--- a/lib/salus/formatting.rb
+++ b/lib/salus/formatting.rb
@@ -1,0 +1,35 @@
+module Salus
+  module Formatting
+    INDENT_SIZE = 2
+    INDENT_STRING = (' ' * INDENT_SIZE).freeze
+
+    def wrapify(string, wrap)
+      return string if wrap.nil?
+
+      parts = []
+
+      string.each_line("\n").each do |line|
+        if line == "\n"
+          parts << "\n"
+          next
+        end
+
+        line = line.chomp
+        index = 0
+
+        while index < line.length
+          parts << line.slice(index, wrap) + "\n"
+          index += wrap
+        end
+      end
+
+      parts.join
+    end
+
+    def indent(text)
+      # each_line("\n") rather than split("\n") because the latter
+      # discards trailing empty lines. Also, don't indent empty lines
+      text.each_line("\n").map { |line| line == "\n" ? "\n" : (INDENT_STRING + line) }.join
+    end
+  end
+end

--- a/lib/salus/report.rb
+++ b/lib/salus/report.rb
@@ -70,10 +70,6 @@ module Salus
       @errors[error_origin] << error_data
     end
 
-    def has_failure?(source)
-      @scans.key?(source) && @scans[source].key?("passed") && @scans[source]["passed"] == false
-    end
-
     def configuration_source(source)
       @configuration['sources'] ||= []
       @configuration['sources'] << source

--- a/lib/salus/report.rb
+++ b/lib/salus/report.rb
@@ -54,11 +54,6 @@ module Salus
       @scans[scanner][log_type] = log
     end
 
-    def salus_info(type, message)
-      @info[type] ||= []
-      @info[type] << message
-    end
-
     def salus_runtime_error(error_data)
       salus_error('Salus', error_data)
     end

--- a/lib/salus/report.rb
+++ b/lib/salus/report.rb
@@ -89,7 +89,7 @@ module Salus
         # config files are YAML. Also, stringify the keys before serializing,
         # because the YAML module is sensitive to symbols vs strings. It's
         # annoying
-        stringified_config = YAML.dump(deep_stringify_keys(@config), indentation: 2)
+        stringified_config = YAML.dump(@config.deep_stringify_keys, indentation: INDENT_SIZE)
         output += "\n\n==== Salus Configuration\n\n"
         output += indent(wrapify(stringified_config, indented_wrap))
       end
@@ -138,15 +138,6 @@ module Salus
     end
 
     private
-
-    def deep_stringify_keys(datum)
-      case datum
-      when Hash then datum.map { |key, value| [key.to_s, deep_stringify_keys(value)] }.to_h
-      when Array then datum.map { |value| deep_stringify_keys(value) }
-      when Symbol then datum.to_s
-      else datum
-      end
-    end
 
     def write_report_to_file(report_file_path, report_string)
       File.open(report_file_path, 'w') { |file| file.write(report_string) }

--- a/lib/salus/scan_report.rb
+++ b/lib/salus/scan_report.rb
@@ -1,0 +1,58 @@
+require 'json'
+
+module Salus
+  class ScanReport
+    attr_reader :scanner_name, :logs, :info, :errors, :running_time
+
+    def initialize(scanner_name)
+      @scanner_name = scanner_name
+
+      @passed = nil
+      @running_time = nil
+      @logs = []
+      @info = {}
+      @errors = []
+    end
+
+    def record
+      started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      yield
+      @passed = true if @passed.nil?
+      @running_time = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at).round(2)
+    end
+
+    def pass
+      @passed = true
+    end
+
+    def fail
+      @passed = false
+    end
+
+    def passed?
+      @passed == true
+    end
+
+    def failed?
+      @passed == false
+    end
+
+    def log(string, verbose: false, color: nil, newline: true)
+      string += "\n" if newline
+      @logs << [string, verbose, color]
+    end
+
+    def info(type, value)
+      @info[type] ||= []
+      @info[type] << value
+    end
+
+    def to_h
+      {
+        passed: @passed,
+        running_time: running_time,
+        info: (@info.empty? ? nil : @info)
+      }.compact
+    end
+  end
+end

--- a/lib/salus/scan_report.rb
+++ b/lib/salus/scan_report.rb
@@ -2,23 +2,26 @@ require 'json'
 
 module Salus
   class ScanReport
-    attr_reader :scanner_name, :logs, :info, :errors, :running_time
+    attr_reader :scanner_name, :running_time
 
     def initialize(scanner_name)
       @scanner_name = scanner_name
-
       @passed = nil
       @running_time = nil
-      @logs = []
       @info = {}
       @errors = []
     end
 
     def record
-      started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      started_at = monotime
+
       yield
-      @passed = true if @passed.nil?
-      @running_time = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at).round(2)
+
+      # If the block failed to pass/fail the scan,
+      # default to pass if no errors were recorded
+      @passed = @errors.empty? if @passed.nil?
+    ensure
+      @running_time = (monotime - started_at).round(2)
     end
 
     def pass
@@ -37,22 +40,94 @@ module Salus
       @passed == false
     end
 
-    def log(string, verbose: false, color: nil, newline: true)
-      string += "\n" if newline
-      @logs << [string, verbose, color]
+    def info(type, value)
+      @info[type] = value
     end
 
-    def info(type, value)
-      @info[type] ||= []
-      @info[type] << value
+    def error(hsh)
+      @errors << hsh
+    end
+
+    def dependency(hsh)
+      @info[:dependencies] ||= []
+      @info[:dependencies] << hsh
     end
 
     def to_h
       {
-        passed: @passed,
-        running_time: running_time,
-        info: (@info.empty? ? nil : @info)
-      }.compact
+        scanner_name: scanner_name,
+        passed: passed?,
+        running_time: @running_time,
+        info: @info,
+        errors: @errors
+      }
+    end
+
+    def to_s(verbose:, wrap:)
+      banner = render_banner
+
+      # If the scan succeeded and verbose is false, just output the banner
+      # indicating pass/fail
+      return banner if @passed && !verbose
+
+      # Because we need to wrap indented paragraphs, correct the wrap
+      # by the indentation level
+      wrap = (wrap.nil? ? nil : wrap - 2)
+
+      output = banner
+
+      if !@info.empty? && verbose
+        stringified_info = indent(wrapify(JSON.pretty_generate(@info), wrap))
+        output += "\n\n ~~ Metadata:\n\n#{stringified_info}".chomp
+      end
+
+      if !@errors.empty?
+        stringified_errors = indent(wrapify(JSON.pretty_generate(@errors), wrap))
+        output += "\n\n ~~ Errors:\n\n#{stringified_errors}".chomp
+      end
+
+      output
+    end
+
+    private
+
+    def render_banner
+      banner = "==== #{@scanner_name}: #{@passed ? 'PASSED' : 'FAILED'}"
+      banner += " in #{@running_time}s" if @running_time
+      banner
+    end
+
+    def wrapify(string, wrap)
+      return string if wrap.nil?
+
+      parts = []
+
+      string.each_line("\n").each do |line|
+        if line == "\n"
+          parts << "\n"
+          next
+        end
+
+        line = line.chomp
+        index = 0
+
+        while index < line.length
+          parts << line.slice(index, wrap) + "\n"
+          index += wrap
+        end
+      end
+
+      parts.join
+    end
+
+    def indent(text)
+      # each_line("\n") rather than split("\n") because the latter
+      # discards trailing empty lines. Also, don't indent empty lines
+      text.each_line("\n").map { |line| line == "\n" ? "\n" : ('  ' + line) }.join
+    end
+
+    def monotime
+      Process.clock_gettime(Process::CLOCK_MONOTONIC)
     end
   end
 end

--- a/lib/salus/scanners/base.rb
+++ b/lib/salus/scanners/base.rb
@@ -1,4 +1,5 @@
 require 'open3'
+require 'salus/shell_result'
 
 module Salus::Scanners
   # Super class for all scanner objects.
@@ -30,9 +31,7 @@ module Salus::Scanners
     def run_shell(command, env: {}, stdin_data: '')
       # If we're passed a string, convert it to an array beofre passing to capture3
       command = command.split unless command.is_a?(Array)
-
-      stdout, stderr, exit_status = Open3.capture3(env, *command, stdin_data: stdin_data)
-      { stdout: stdout, stderr: stderr, exit_status: exit_status }
+      Salus::ShellResult.new(*Open3.capture3(env, *command, stdin_data: stdin_data))
     end
 
     # Add a log to the report that this scanner had no findings.

--- a/lib/salus/scanners/base.rb
+++ b/lib/salus/scanners/base.rb
@@ -68,10 +68,6 @@ module Salus::Scanners
       @report.salus_error(name, error_data)
     end
 
-    def report_recorded_failure?
-      @report.has_failure?(name)
-    end
-
     def record_dependency_info(info, dependency_file)
       report_info('dependency', { dependency_file: dependency_file }.merge(info))
     end

--- a/lib/salus/scanners/base.rb
+++ b/lib/salus/scanners/base.rb
@@ -44,7 +44,7 @@ module Salus::Scanners
       rescue StandardError => exception
         error_data = {
           message: "Unhandled exception running #{name}: #{exception.class}: #{exception}",
-          klass: exception.class,
+          error_class: exception.class,
           backtrace: exception.backtrace.take(5)
         }
 

--- a/lib/salus/scanners/brakeman.rb
+++ b/lib/salus/scanners/brakeman.rb
@@ -22,17 +22,17 @@ module Salus::Scanners
         #   - vulns found    - exit 3 and log to STDOUT
         #   - exception      - exit 1 and log to STDERR
 
-        if shell_return[:exit_status].success?
+        if shell_return.success?
           report_success
-        elsif shell_return[:exit_status].exitstatus == 3
+        elsif shell_return.status == 3
           report_failure
-          brakeman_report = JSON.parse(shell_return[:stdout])
-          report_stdout(shell_return[:stdout])
+          brakeman_report = JSON.parse(shell_return.stdout)
+          report_stdout(shell_return.stdout)
           report_info('brakeman_report', brakeman_report)
         else
-          report_info('exit_code', shell_return[:exit_status])
-          report_error('message' => shell_return[:stderr])
-          report_stderr(shell_return[:stderr])
+          report_info('exit_code', shell_return.status)
+          report_error('message' => shell_return.stderr)
+          report_stderr(shell_return.stderr)
         end
       end
     end

--- a/lib/salus/scanners/brakeman.rb
+++ b/lib/salus/scanners/brakeman.rb
@@ -22,18 +22,20 @@ module Salus::Scanners
         #   - vulns found    - exit 3 and log to STDOUT
         #   - exception      - exit 1 and log to STDERR
 
-        if shell_return.success?
-          report_success
-        elsif shell_return.status == 3
-          report_failure
-          brakeman_report = JSON.parse(shell_return.stdout)
+        return report_success if shell_return.success?
+
+        if shell_return.status == 3
           report_stdout(shell_return.stdout)
-          report_info('brakeman_report', brakeman_report)
+          report_info(:brakeman_report, JSON.parse(shell_return.stdout, symbolize_names: true))
         else
-          report_info('exit_code', shell_return.status)
-          report_error('message' => shell_return.stderr)
+          report_error(
+            "brakeman exited with an unexpected exit status",
+            status: shell_return.status
+          )
           report_stderr(shell_return.stderr)
         end
+
+        report_failure
       end
     end
 

--- a/lib/salus/scanners/bundle_audit.rb
+++ b/lib/salus/scanners/bundle_audit.rb
@@ -29,14 +29,17 @@ module Salus::Scanners
       end
 
       vulns = []
+      failed = false
+
       # Scan that mamma jamma, ignoring specified directories
       scanner.scan(ignore: @config['ignore']) do |result|
-        report_failure
         vulns.push(serialize_vuln(result))
+        failed = true
       end
 
-      if report_recorded_failure?
+      if failed
         report_stdout(JSON.pretty_generate(vulns))
+        report_failure
       else
         report_success
       end

--- a/lib/salus/scanners/npm_audit.rb
+++ b/lib/salus/scanners/npm_audit.rb
@@ -8,13 +8,13 @@ module Salus::Scanners
     ADVISORY_URL_REGEX = %r{^https://nodesecurity.io/advisories/(\d+)$}
 
     def run
-      exceptions = @config['exceptions']
-
+      exceptions = @config.fetch('exceptions', [])
       created_package_lock = false
+
       if !@repository.package_lock_json_present?
         Dir.chdir(@repository.path_to_repo) do
           report_info(
-            'package_lock_missing',
+            :package_lock_missing,
             'No package.lock file was found, so we generated one for you. As long as '\
               'you use yarn, this should be fine. If not, please check in a package-lock.json '\
               'file into your source control.'
@@ -24,45 +24,41 @@ module Salus::Scanners
         end
       end
 
-      Dir.chdir(@repository.path_to_repo) do
-        shell_return = run_shell('npm audit --json')
+      shell_return = nil
+      Dir.chdir(@repository.path_to_repo) { shell_return = run_shell('npm audit --json') }
 
-        if shell_return.success?
-          report_success
-        else
-          # Parse output
-          npm_audit_report = JSON.parse(shell_return.stdout)
-          report_stdout(shell_return.stdout)
+      return report_success if shell_return.success?
 
-          # Report scan output
-          report_info('npm_audit_output', npm_audit_report)
+      # Parse output
+      npm_audit_report = JSON.parse(shell_return.stdout, symbolize_names: true)
 
-          # Report ignored advisories after validating the keys all exist
-          exceptions&.each do |exception|
-            if exception.keys.sort != %w[advisory_id changed_by notes]
-              report_error("The exception #{exception} doesn't have a proper format! Please ensure"\
-              ' that each exception has an `advisory_id`, `changed_by`, and `notes` field!')
-            end
-            report_info('exceptions', exception)
-          end
+      # Report scan output
+      report_info(:npm_audit_output, npm_audit_report)
 
-          exception_ids = exceptions&.map { |x| x['advisory_id'] } || []
-          active_vuln_ids = npm_audit_report['advisories'].keys - exception_ids
-
-          active_vuln_ids.empty? ? report_success : report_failure
-        end
-
-        # Cleanup, mostly for local dev since we run in Docker normally
-        File.delete('package-lock.json') if created_package_lock
+      # FIXME(as3richa): emit some sort of warning or logline
+      # for exceptions that don't conform to the spec
+      exceptions = exceptions.select do |exception|
+        exception.is_a?(Hash) &&
+          exception.keys.sort == %w[advisory_id changed_by notes]
       end
+
+      report_info(:exceptions, exceptions)
+
+      exception_ids = exceptions.map { |exception| exception['advisory_id'] }
+      active_vuln_ids = npm_audit_report[:advisories].keys.map(&:to_s) - exception_ids
+
+      report_info(:vulnerabilities, active_vuln_ids)
+
+      active_vuln_ids.empty? ? report_success : report_failure
+    ensure
+      # Cleanup, mostly for local dev since we run in Docker normally
+      File.delete("#{@repository.path_to_repo}/package-lock.json") if created_package_lock
     end
 
     def should_run?
-      [
-        @repository.package_json_present?,
-        @repository.package_lock_json_present?,
+      @repository.package_json_present? ||
+        @repository.package_lock_json_present? ||
         @repository.yarn_lock_present?
-      ].any?
     end
   end
 end

--- a/lib/salus/scanners/npm_audit.rb
+++ b/lib/salus/scanners/npm_audit.rb
@@ -27,12 +27,12 @@ module Salus::Scanners
       Dir.chdir(@repository.path_to_repo) do
         shell_return = run_shell('npm audit --json')
 
-        if shell_return[:exit_status].success?
+        if shell_return.success?
           report_success
         else
           # Parse output
-          npm_audit_report = JSON.parse(shell_return[:stdout])
-          report_stdout(shell_return[:stdout])
+          npm_audit_report = JSON.parse(shell_return.stdout)
+          report_stdout(shell_return.stdout)
 
           # Report scan output
           report_info('npm_audit_output', npm_audit_report)

--- a/lib/salus/scanners/pattern_search.rb
+++ b/lib/salus/scanners/pattern_search.rb
@@ -48,13 +48,13 @@ module Salus::Scanners
           match['required'] ||= false
           match['message'] ||= ''
 
-          if shell_return[:exit_status].success? # hit
+          if shell_return.success? # hit
             if match['forbidden']
               failure_messages << "Forbidden pattern \"#{match['regex']}\" was found " \
                 "- #{match['message']}"
             end
 
-            hits = shell_return[:stdout].encode(
+            hits = shell_return.stdout.encode(
               "utf-8",
               invalid: :replace,
               undef: :replace
@@ -70,22 +70,22 @@ module Salus::Scanners
               )
             end
 
-          elsif [1, 2].include? shell_return[:exit_status].exitstatus
-            if shell_return[:stderr].empty?
+          elsif [1, 2].include?(shell_return.status)
+            if shell_return.stderr.empty?
               # If there were no hits, but the pattern was required add an error message.
               if match['required']
                 failure_messages << "Required pattern \"#{match['regex']}\" was not found " \
                   "- #{match['message']}"
               end
             else
-              errors << shell_return[:stderr]
+              errors << shell_return.stderr
             end
           else
             raise UnhandledExitStatusError,
-                  "Unknown exit status #{shell_return[:exit_status].exitstatus} from sift "\
+                  "Unknown exit status #{shell_return.status} from sift "\
                     "(grep alternative).\n" \
-                    "STDOUT: #{shell_return[:stdout]}\n" \
-                    "STDERR: #{shell_return[:stderr]}"
+                    "STDOUT: #{shell_return.stdout}\n" \
+                    "STDERR: #{shell_return.stderr}"
           end
         end
       end

--- a/lib/salus/scanners/pattern_search.rb
+++ b/lib/salus/scanners/pattern_search.rb
@@ -93,7 +93,7 @@ module Salus::Scanners
 
       report_info(:hits, all_hits)
       errors.each { |error| report_error('Call to sift failed', error) }
-      failure_messages.each { |message| report_error(message) }
+      report_info(:failure_messages, failure_messages)
 
       if errors.empty? && failure_messages.empty?
         report_success

--- a/lib/salus/scanners/repo_not_empty.rb
+++ b/lib/salus/scanners/repo_not_empty.rb
@@ -9,12 +9,11 @@ module Salus::Scanners
     def run
       # We check there is at least one item in this repo.
       if directory_empty?
-        report_failure
-        report_info(
-          'problem',
+        report_error(
           'Salus was run on a blank directory. This may indicate misconfiguration '\
           'such as not correctly voluming in the repository to be scanned.'
         )
+        report_failure
       else
         report_success
       end

--- a/lib/salus/scanners/report_go_dep.rb
+++ b/lib/salus/scanners/report_go_dep.rb
@@ -32,14 +32,12 @@ module Salus::Scanners
     private
 
     def record_dep_package(name:, reference:, version_tag:)
-      record_dependency_info(
-        {
-          type: 'go_dep_lock',
-          name: name,
-          reference: reference,
-          version_tag: version_tag
-        },
-        'Gopkg.lock'
+      report_dependency(
+        'Gopkg.lock',
+        type: 'go_dep_lock',
+        name: name,
+        reference: reference,
+        version_tag: version_tag
       )
     end
   end

--- a/lib/salus/scanners/report_node_modules.rb
+++ b/lib/salus/scanners/report_node_modules.rb
@@ -46,11 +46,11 @@ module Salus::Scanners
     def record_dependencies_from_yarn_lock
       shell_return = run_shell("bin/parse_yarn_lock #{@repository.path_to_repo}/yarn.lock")
 
-      unless shell_return[:exit_status].success?
-        raise ParseError, "Failed to parse yarn.lock file: #{shell_return[:stderr]}"
+      unless shell_return.success?
+        raise ParseError, "Failed to parse yarn.lock file: #{shell_return.stderr}"
       end
 
-      yarn_lock = JSON.parse(shell_return[:stdout])
+      yarn_lock = JSON.parse(shell_return.stdout)
 
       if yarn_lock['type'] != 'success'
         raise ParseError, '@yarnpkg/lockfile failed to parse the yarn.lock file.'

--- a/lib/salus/scanners/report_node_modules.rb
+++ b/lib/salus/scanners/report_node_modules.rb
@@ -82,9 +82,9 @@ module Salus::Scanners
       package_lock = JSON.parse(@repository.package_lock_json)
 
       # Record the lock file version.
-      record_dependency_info(
-        { type: 'package_lock_version', version: package_lock['lockfileVersion'].to_s },
-        'package-lock.json'
+      report_info(
+        :package_lock_version,
+        package_lock.fetch('lockfileVersion', '<unknown>').to_s
       )
 
       # Record each dependency.
@@ -103,14 +103,10 @@ module Salus::Scanners
 
       # Record the npm and node versions.
       if packages['engines']
-        record_dependency_info(
-          { type: 'node_version', version: packages['engines']['node'] },
-          'package.json'
-        )
-        record_dependency_info(
-          { type: 'npm_version', version: packages['engines']['npm'] },
-          'package.json'
-        )
+        node_version = packages['engines']['node']
+        npm_version = packages['engines']['npm']
+        report_info(:package_json_node_version, node_version) unless node_version.nil?
+        report_info(:package_json_npm_version, npm_version) unless npm_version.nil?
       end
 
       return unless record_modules
@@ -152,14 +148,12 @@ module Salus::Scanners
     end
 
     def record_node_module(dependency_file:, name:, version:, source:)
-      record_dependency_info(
-        {
-          type: 'node_module',
-          name: name,
-          version: version,
-          source: source
-        },
-        dependency_file
+      report_dependency(
+        dependency_file,
+        type: 'node_module',
+        name: name,
+        version: version,
+        source: source
       )
     end
   end

--- a/lib/salus/scanners/report_python_modules.rb
+++ b/lib/salus/scanners/report_python_modules.rb
@@ -10,8 +10,8 @@ module Salus::Scanners
       Dir.chdir(@repository.path_to_repo) do
         shell_return = run_shell('python', stdin_data: DEP_PARSER)
 
-        if shell_return[:exit_status].success?
-          dependencies = JSON.parse(shell_return[:stdout])
+        if shell_return.success?
+          dependencies = JSON.parse(shell_return.stdout)
           dependencies.each do |name, version|
             record_dependency_info(
               {
@@ -23,7 +23,7 @@ module Salus::Scanners
             )
           end
         else
-          report_error('message' => shell_return[:stderr])
+          report_error('message' => shell_return.stderr)
         end
       end
     end

--- a/lib/salus/scanners/report_python_modules.rb
+++ b/lib/salus/scanners/report_python_modules.rb
@@ -4,27 +4,23 @@ require 'salus/scanners/base'
 
 module Salus::Scanners
   class ReportPythonModules < Base
-    DEP_PARSER = File.read(File.join(__dir__, 'report_python_modules.py'))
-
     def run
-      Dir.chdir(@repository.path_to_repo) do
-        shell_return = run_shell('python', stdin_data: DEP_PARSER)
+      shell_return = run_shell(['bin/report_python_modules', @repository.path_to_repo])
 
-        if shell_return.success?
-          dependencies = JSON.parse(shell_return.stdout)
-          dependencies.each do |name, version|
-            record_dependency_info(
-              {
-                type: 'python_requirement',
-                name: name,
-                version: version
-              },
-              'requirements.txt'
-            )
-          end
-        else
-          report_error('message' => shell_return.stderr)
-        end
+      if !shell_return.success?
+        report_error(shell_return.stderr)
+        return
+      end
+
+      dependencies = JSON.parse(shell_return.stdout)
+
+      dependencies.each do |name, version|
+        report_dependency(
+          'requirements.txt',
+          type: 'python_requirement',
+          name: name,
+          version: version
+        )
       end
     end
 

--- a/lib/salus/scanners/report_ruby_gems.rb
+++ b/lib/salus/scanners/report_ruby_gems.rb
@@ -27,7 +27,7 @@ module Salus::Scanners
     def record_dependencies_from_gemfile_lock
       lockfile = Bundler::LockfileParser.new(@repository.gemfile_lock)
 
-      # N.B. lockfile.bundler_version is a Gem::Version
+      # lockfile.bundler_version isn't a string, so stringify it first
       report_info(:ruby_version, lockfile.ruby_version)
       report_info(:bundler_version, lockfile.bundler_version.to_s)
 

--- a/lib/salus/shell_result.rb
+++ b/lib/salus/shell_result.rb
@@ -1,0 +1,16 @@
+module Salus
+  class ShellResult
+    attr_reader :stdout, :stderr, :status
+
+    def initialize(stdout, stderr, process_status)
+      @stdout = stdout
+      @stderr = stderr
+      @success = process_status.success?
+      @status = process_status.exitstatus
+    end
+
+    def success?
+      @success
+    end
+  end
+end

--- a/salus-default.yaml
+++ b/salus-default.yaml
@@ -6,8 +6,6 @@
 
 config_version: 1
 
-project_name: Project
-
 # What scanners should run. "all" or "none" are acceptable as well
 active_scanners: all
 

--- a/spec/docker/docker_spec.rb
+++ b/spec/docker/docker_spec.rb
@@ -13,12 +13,13 @@ DOCKER_RUN_COMMAND = 'docker run -e RUNNING_SALUS_TESTS=true -t '\
   '--rm -v $(pwd):/home/repo salus-test'.freeze
 
 describe 'docker' do
-  let(:report_file_path) { 'spec/fixtures/docker/reports/salus_report.json' }
-
   it 'should build the latest image, run successfully and output the '\
      'report to the correctly volumed location' do
+    report_file_path = 'spec/fixtures/docker/reports/salus_report.json'
     # cleanup from preivous test if last cleanup failed
     remove_file(report_file_path)
+
+    expectation = JSON.parse(File.read('spec/fixtures/docker/expected_report.json'))
 
     stdout, stderr, exit_status = Open3.capture3(DOCKER_BUILD_COMMAND)
     expect(exit_status.success?).to eq(true), "STDOUT:\n#{stdout}\n\nSTDERR:\n#{stderr}"
@@ -27,9 +28,12 @@ describe 'docker' do
       stdout, stderr, exit_status = Open3.capture3(DOCKER_RUN_COMMAND)
     end
     expect(exit_status.success?).to eq(true), "STDOUT:\n#{stdout}\n\nSTDERR:\n#{stderr}"
-    expect(File.read(report_file_path)).to eq(
-      File.read('spec/fixtures/docker/expected_report.json').strip
-    )
+
+    # Running time is nondeterministic, so just zero it out
+    result = JSON.parse(File.read(report_file_path))
+    result['scans']['PatternSearch']['running_time'] = 0.0
+
+    expect(result).to eq(expectation)
 
     # remove report file that was generated from Salus execution
     remove_file(report_file_path)

--- a/spec/fixtures/docker/expected_report.json
+++ b/spec/fixtures/docker/expected_report.json
@@ -1,9 +1,13 @@
 {
-  "project_name": "Project",
+  "version": "1.0.0",
+  "passed": true,
   "scans": {
     "PatternSearch": {
+      "scanner_name": "PatternSearch",
+      "passed": true,
+      "running_time": 0.0,
       "info": {
-        "pattern_search_hit": [
+        "hits": [
           {
             "regex": "placeholder",
             "forbidden": false,
@@ -13,22 +17,15 @@
           }
         ]
       },
-      "passed": true
-    },
-    "overall": {
-      "passed": true
+      "errors": [
+
+      ]
     }
   },
-  "info": {
-  },
-  "errors": {
-  },
-  "version": "1.0.0",
-  "custom_info": "",
-  "configuration": {
-    "sources": [
-      "file:///salus.yaml"
-    ],
+  "errors": [
+
+  ],
+  "config": {
     "active_scanners": [
       "PatternSearch"
     ],
@@ -51,11 +48,14 @@
         ]
       }
     },
-    "reports": [
+    "report_uris": [
       {
         "uri": "file://./repo/reports/salus_report.json",
         "format": "json"
       }
+    ],
+    "sources": [
+      "file:///salus.yaml"
     ]
   }
 }

--- a/spec/fixtures/docker/expected_report.json
+++ b/spec/fixtures/docker/expected_report.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0",
+  "version": "2.0.0",
   "passed": true,
   "scans": {
     "PatternSearch": {
@@ -15,6 +15,9 @@
             "msg": "",
             "hit": "README.md:1:# placeholder"
           }
+        ],
+        "failure_messages": [
+
         ]
       },
       "errors": [

--- a/spec/fixtures/processor/local_uri/expected_report.json
+++ b/spec/fixtures/processor/local_uri/expected_report.json
@@ -1,17 +1,35 @@
 {
-  "project_name": "Project",
-  "scans": {
-  },
-  "info": {
-  },
-  "errors": {
-  },
   "version": "1.0.0",
-  "custom_info": "",
-  "configuration": {
-    "sources": [
-      "file:///salus.yaml"
-    ],
+  "passed": true,
+  "scans": {
+    "PatternSearch": {
+      "scanner_name": "PatternSearch",
+      "passed": true,
+      "running_time": 0.0,
+      "info": {
+        "hits": [
+
+        ]
+      },
+      "errors": [
+
+      ]
+    },
+    "RepoNotEmpty": {
+      "scanner_name": "RepoNotEmpty",
+      "passed": true,
+      "running_time": 0.0,
+      "info": {
+      },
+      "errors": [
+
+      ]
+    }
+  },
+  "errors": [
+
+  ],
+  "config": {
     "active_scanners": [
       "Brakeman",
       "BundleAudit",
@@ -24,19 +42,22 @@
       "ReportRubyGems"
     ],
     "enforced_scanners": [
-      "RepoNotEmpty",
       "Brakeman",
       "BundleAudit",
       "NPMAudit",
-      "PatternSearch"
+      "PatternSearch",
+      "RepoNotEmpty"
     ],
     "scanner_configs": {
     },
-    "reports": [
+    "report_uris": [
       {
         "uri": "file://spec/fixtures/processor/local_uri/salus_reports_folder/salus-report.json",
         "format": "json"
       }
+    ],
+    "sources": [
+      "file:///salus.yaml"
     ]
   }
 }

--- a/spec/fixtures/processor/local_uri/expected_report.json
+++ b/spec/fixtures/processor/local_uri/expected_report.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0",
+  "version": "2.0.0",
   "passed": true,
   "scans": {
     "PatternSearch": {
@@ -8,6 +8,9 @@
       "running_time": 0.0,
       "info": {
         "hits": [
+
+        ],
+        "failure_messages": [
 
         ]
       },

--- a/spec/fixtures/processor/remote_uri/expected_report.json
+++ b/spec/fixtures/processor/remote_uri/expected_report.json
@@ -1,17 +1,35 @@
 {
-  "project_name": "Project",
-  "scans": {
-  },
-  "info": {
-  },
-  "errors": {
-  },
   "version": "1.0.0",
-  "custom_info": "",
-  "configuration": {
-    "sources": [
-      "file:///salus.yaml"
-    ],
+  "passed": true,
+  "scans": {
+    "PatternSearch": {
+      "scanner_name": "PatternSearch",
+      "passed": true,
+      "running_time": 0.0,
+      "info": {
+        "hits": [
+
+        ]
+      },
+      "errors": [
+
+      ]
+    },
+    "RepoNotEmpty": {
+      "scanner_name": "RepoNotEmpty",
+      "passed": true,
+      "running_time": 0.0,
+      "info": {
+      },
+      "errors": [
+
+      ]
+    }
+  },
+  "errors": [
+
+  ],
+  "config": {
     "active_scanners": [
       "Brakeman",
       "BundleAudit",
@@ -24,19 +42,22 @@
       "ReportRubyGems"
     ],
     "enforced_scanners": [
-      "RepoNotEmpty",
       "Brakeman",
       "BundleAudit",
       "NPMAudit",
-      "PatternSearch"
+      "PatternSearch",
+      "RepoNotEmpty"
     ],
     "scanner_configs": {
     },
-    "reports": [
+    "report_uris": [
       {
         "uri": "https://nerv.tk3/salus-report",
         "format": "json"
       }
+    ],
+    "sources": [
+      "file:///salus.yaml"
     ]
   }
 }

--- a/spec/fixtures/processor/remote_uri/expected_report.json
+++ b/spec/fixtures/processor/remote_uri/expected_report.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0",
+  "version": "2.0.0",
   "passed": true,
   "scans": {
     "PatternSearch": {
@@ -8,6 +8,9 @@
       "running_time": 0.0,
       "info": {
         "hits": [
+
+        ],
+        "failure_messages": [
 
         ]
       },

--- a/spec/lib/salus/config_spec.rb
+++ b/spec/lib/salus/config_spec.rb
@@ -23,7 +23,8 @@ describe Salus::Config do
     context 'no initialization file given' do
       it 'should use the default config file' do
         config = Salus::Config.new
-        expect(config.project_name).to eq('Project')
+        expect(config.project_name).to be_nil
+        expect(config.custom_info).to be_nil
         expect(config.active_scanners).to eq(Set.new(Salus::Config::SCANNERS.keys))
         expect(config.enforced_scanners).not_to be_empty
         expect(config.scanner_configs).to be_empty

--- a/spec/lib/salus/processor_spec.rb
+++ b/spec/lib/salus/processor_spec.rb
@@ -91,12 +91,15 @@ describe Salus::Processor do
 
       expect(report_hsh[:project_name]).to eq('EVA-01')
       expect(report_hsh[:custom_info]).to eq('Purple unit')
-      expect(report_hsh[:version]).to eq('1.0.0')
+      expect(report_hsh[:version]).to eq('2.0.0')
       expect(report_hsh[:passed]).to eq(false)
       expect(report_hsh[:errors]).to eq([])
 
       expect(report_hsh[:scans]['BundleAudit'][:passed]).to eq(false)
       expect(report_hsh[:scans]['BundleAudit'][:info][:vulnerabilities].length).to be_positive
+
+      cves = report_hsh[:scans]['BundleAudit'][:info][:vulnerabilities].map { |vuln| vuln[:cve] }
+      expect(cves).to include('CVE-2016-6316')
     end
   end
 

--- a/spec/lib/salus/report_spec.rb
+++ b/spec/lib/salus/report_spec.rb
@@ -17,11 +17,6 @@ describe Salus::Report do
   let(:scanner_1_info_type_2_message_1) { 'Casper unit anomaly' }
   let(:scanner_1_stdout)                { 'Operational: C, B, M' }
   let(:scanner_2_stderr)                { 'Cannot scan full ratio.' }
-  let(:salus_info_type_1)               { 'Angel' }
-  let(:salus_info_type_2)               { 'Entry Plug' }
-  let(:salus_info_type_1_message_1)     { 'Approaching Tokyo 3.' }
-  let(:salus_info_type_1_message_2)     { 'Origins of Adam detected.' }
-  let(:salus_info_type_2_message_1)     { 'Malfunction ...' }
   let(:salus_error_1_class)             { 'EvaError' }
   let(:salus_error_2_class)             { 'SalusRuntime' }
   let(:salus_error_1_data)              { { 'message' => 'Cannot locate EVA02.', 'count' => 2 } }
@@ -44,9 +39,6 @@ describe Salus::Report do
     report.scan_stdout(scanner_1, scanner_1_stdout)
     report.scan_info(scanner_2, scanner_1_info_type_1, scanner_1_info_type_1_message_1)
     report.scan_stderr(scanner_2, scanner_2_stderr)
-    report.salus_info(salus_info_type_1, salus_info_type_1_message_1)
-    report.salus_info(salus_info_type_1, salus_info_type_1_message_2)
-    report.salus_info(salus_info_type_2, salus_info_type_2_message_1)
     report.salus_error(salus_error_1_class, salus_error_1_data)
     report.salus_error(salus_error_2_class, salus_error_2_data)
     report.salus_runtime_error(salus_runtime_error_data)
@@ -92,10 +84,6 @@ describe Salus::Report do
         }
       )
 
-      expect(obj['info'][salus_info_type_1]).to include(salus_info_type_1_message_1)
-      expect(obj['info'][salus_info_type_1]).to include(salus_info_type_1_message_2)
-      expect(obj['info'][salus_info_type_2]).to include(salus_info_type_2_message_1)
-
       expect(obj['errors'][salus_error_1_class]).to include(salus_error_1_data)
       expect(obj['errors'][salus_error_2_class]).to include(salus_error_2_data)
       expect(obj['errors']['Salus']).to include(salus_runtime_error_data)
@@ -120,8 +108,6 @@ describe Salus::Report do
       [
         scanner_1_info_type_1,
         scanner_1_info_type_1_message_1,
-        salus_info_type_1,
-        salus_info_type_1_message_2,
         config_source_1,
         config_source_2,
         config_directive,

--- a/spec/lib/salus/report_spec.rb
+++ b/spec/lib/salus/report_spec.rb
@@ -1,183 +1,176 @@
 require_relative '../../spec_helper.rb'
 
 describe Salus::Report do
-  let(:project_name)                    { 'eva00' }
-  let(:config_source_1)                 { 'file://./salus.yaml' }
-  let(:config_source_2)                 { 'https://salus-config.nerv.net/salus.yaml' }
-  let(:config_directive)                { 'active_scanners' }
-  let(:config_directive_value)          { 'A, B, C' }
-  let(:scanner_1)                       { 'MAGI' }
-  let(:scanner_2)                       { 'sync_ratio_check' }
-  let(:scanner_1_passed)                { true }
-  let(:scanner_2_passed)                { false }
-  let(:scanner_1_info_type_1)           { 'detection' }
-  let(:scanner_1_info_type_2)           { 'warning' }
-  let(:scanner_1_info_type_1_message_1) { 'detected infection' }
-  let(:scanner_1_info_type_1_message_2) { 'detected breach' }
-  let(:scanner_1_info_type_2_message_1) { 'Casper unit anomaly' }
-  let(:scanner_1_stdout)                { 'Operational: C, B, M' }
-  let(:scanner_2_stderr)                { 'Cannot scan full ratio.' }
-  let(:salus_error_1_class)             { 'EvaError' }
-  let(:salus_error_2_class)             { 'SalusRuntime' }
-  let(:salus_error_1_data)              { { 'message' => 'Cannot locate EVA02.', 'count' => 2 } }
-  let(:salus_error_2_data)              { { 'message' => 'Umbilical cable disconnected.' } }
-  let(:salus_runtime_error_data)        { { 'message' => 'Salus died.' } }
-  let(:custom_info)                     { 'test unit' }
-  let(:report) do
-    Salus::Report.new(project_name: project_name, custom_info: custom_info)
-  end
+  let(:report) { build_report }
+  let(:scan_reports) { (0...3).map { build_scan_report } }
 
-  # Load a given report with data.
-  def load_report(report)
-    report.configuration_source(config_source_1)
-    report.configuration_source(config_source_2)
-    report.configuration_directive(config_directive, config_directive_value)
-    report.scan_passed(scanner_1, scanner_1_passed)
-    report.scan_info(scanner_1, scanner_1_info_type_1, scanner_1_info_type_1_message_1)
-    report.scan_info(scanner_1, scanner_1_info_type_1, scanner_1_info_type_1_message_2)
-    report.scan_info(scanner_1, scanner_1_info_type_2, scanner_1_info_type_2_message_1)
-    report.scan_stdout(scanner_1, scanner_1_stdout)
-    report.scan_info(scanner_2, scanner_1_info_type_1, scanner_1_info_type_1_message_1)
-    report.scan_stderr(scanner_2, scanner_2_stderr)
-    report.salus_error(salus_error_1_class, salus_error_1_data)
-    report.salus_error(salus_error_2_class, salus_error_2_data)
-    report.salus_runtime_error(salus_runtime_error_data)
-    report
-  end
+  describe '#to_h and miscellaneous reporting methods' do
+    it 'emits the expected reporting data via the #to_h method' do
+      name = 'Neon Genesis Evangelion'
+      custom_info = { bitcoin_price: 100_000 }
+      config = { lemurs: 'contained', raptors: 'loose' }
 
-  let(:loaded_report) { load_report(report) }
+      report = Salus::Report.new(project_name: name, custom_info: custom_info, config: config)
 
-  # NOTE: #scan, #info, #error are tested by the construction of the report object above.
-
-  describe '#to_json' do
-    it 'should generate a JSON object with expected information' do
-      obj = JSON.parse(load_report(report).to_json)
-      expect(obj['project_name']).to eq(project_name)
-      expect(obj['version']).to eq(Salus::VERSION)
-      expect(obj['configuration']).to eq(
-        'sources' => [config_source_1, config_source_2],
-        config_directive => config_directive_value
-      )
-      expect(obj['scans']).to include(
-        scanner_1 => {
-          'passed' => true,
-          'info' => {
-            scanner_1_info_type_1 => [
-              scanner_1_info_type_1_message_1,
-              scanner_1_info_type_1_message_2
-            ],
-            scanner_1_info_type_2 => [
-              scanner_1_info_type_2_message_1
-            ]
-          },
-          'stdout' => scanner_1_stdout
-        }
-      )
-      expect(obj['scans']).to include(
-        scanner_2 => {
-          'info' => {
-            scanner_1_info_type_1 => [
-              scanner_1_info_type_1_message_1
-            ]
-          },
-          'stderr' => scanner_2_stderr
-        }
-      )
-
-      expect(obj['errors'][salus_error_1_class]).to include(salus_error_1_data)
-      expect(obj['errors'][salus_error_2_class]).to include(salus_error_2_data)
-      expect(obj['errors']['Salus']).to include(salus_runtime_error_data)
-
-      expect(obj['custom_info']).to eq(custom_info)
-    end
-  end
-
-  describe '#to_s' do
-    let(:standard_data) do
-      [
-        project_name,
-        scanner_1,
-        Salus::Report::SCAN_RESULT_WORD[scanner_1_passed],
-        scanner_2,
-        scanner_2_stderr,
-        salus_error_1_class,
-        salus_error_1_data.to_s
-      ]
-    end
-    let(:verbose_data) do
-      [
-        scanner_1_info_type_1,
-        scanner_1_info_type_1_message_1,
-        config_source_1,
-        config_source_2,
-        config_directive,
-        config_directive_value
-      ]
-    end
-
-    context 'verbose: false' do
-      it 'should generate text output without info et al.' do
-        standard_data.each { |str| expect(loaded_report.to_s(verbose: false)).to include(str) }
-        verbose_data.each { |str| expect(loaded_report.to_s(verbose: false)).not_to include(str) }
+      # The actual content here doesn't really matter -
+      # that functionality is speced out in the ScanReport unit tests
+      scan_reports = (1..5).map do |index|
+        scan_report = Salus::ScanReport.new("Scanner#{index}")
+        scan_report.info(:safe, 'maybe')
+        scan_report.error(message: 'something amiss')
+        scan_report.dependency(dependency_file: 'libxml2.so.2')
+        scan_report.pass
+        scan_report
       end
-    end
 
-    context 'verbose: true' do
-      it 'should generate text with expected information including info et al.' do
-        standard_data.each { |str| expect(loaded_report.to_s(verbose: true)).to include(str) }
-        verbose_data.each { |str| expect(loaded_report.to_s(verbose: true)).to include(str) }
+      scan_reports.each { |scan_report| report.add_scan_report(scan_report, required: false) }
+
+      (1..5).map { |index| report.error(message: 'some top-level error', data: index) }
+
+      hsh = report.to_h
+
+      expect(hsh.fetch(:project_name)).to eq(name)
+      expect(hsh.fetch(:custom_info)).to eq(custom_info)
+      expect(hsh.fetch(:config)).to eq(config)
+
+      hsh.fetch(:errors).each do |error|
+        expect(error[:message]).to eq('some top-level error')
+        expect((1..5)).to cover(error[:data])
       end
+
+      scans = hsh.fetch(:scans)
+
+      expectation =
+        scan_reports
+          .map { |scan_report, _required| [scan_report.scanner_name, scan_report.to_h] }
+          .to_h
+
+      expect(scans).to eq(expectation)
     end
 
-    it 'should wrap really long lines' do
-      report = Salus::Report.new(
-        project_name: 'test project',
-        custom_info: 'test unit'
-      )
+    it 'does not include project_name/custom_info/config if not given' do
+      report = Salus::Report.new
+      hsh = report.to_h
+      expect(hsh.key?(:project_name)).to eq(false)
+      expect(hsh.key?(:custom_info)).to eq(false)
+      expect(hsh.key?(:config)).to eq(false)
+    end
+  end
 
-      report.scan_stdout("TestScan", ("A" * 100) + ("B" * 100))
+  describe '#passed?' do
+    it 'returns true if and only if all required scans passed' do
+      passed_scan_reports = (0...5).map do
+        scan_report = Salus::ScanReport.new('DerpScanner')
+        scan_report.pass
+        scan_report
+      end
 
-      expect(report.to_s).not_to match(/AAAABBBB/) # Ensure there was a break at 100 chars in
+      failed_scan_reports = (0...5).map do
+        scan_report = Salus::ScanReport.new('HerpScanner')
+        scan_report.fail
+        scan_report
+      end
+
+      # No scans; passed
+      report = Salus::Report.new
+      expect(report.passed?).to eq(true)
+
+      # All scans required; all passed
+      report = Salus::Report.new
+      passed_scan_reports.each do |scan_report|
+        report.add_scan_report(scan_report, required: true)
+      end
+      expect(report.passed?).to eq(true)
+
+      # All scans not required; all passed
+      report = Salus::Report.new
+      passed_scan_reports.each do |scan_report|
+        report.add_scan_report(scan_report, required: false)
+      end
+      expect(report.passed?).to eq(true)
+
+      # All scans required; all failed
+      report = Salus::Report.new
+      failed_scan_reports.each do |scan_report|
+        report.add_scan_report(scan_report, required: true)
+      end
+      expect(report.passed?).to eq(false)
+
+      # All scans not required; all failed
+      report = Salus::Report.new
+      failed_scan_reports.each do |scan_report|
+        report.add_scan_report(scan_report, required: false)
+      end
+      expect(report.passed?).to eq(true)
+
+      # All scans required; several passed scans but one failed scan
+      report = Salus::Report.new
+      report.add_scan_report(failed_scan_reports[0], required: true)
+      passed_scan_reports.each do |scan_report|
+        report.add_scan_report(scan_report, required: true)
+      end
+      expect(report.passed?).to eq(false)
+
+      # Mix of required and un-required scans; all failed scans not required
+      report = Salus::Report.new
+      (passed_scan_reports + failed_scan_reports).each do |scan_report|
+        required = scan_report.passed? && rand < 0.5
+        report.add_scan_report(scan_report, required: required)
+      end
+      expect(report.passed?).to eq(true)
     end
   end
 
   describe '#export_report' do
-    context 'HTTP report URI given' do
-      let(:http_report_uri) { 'https://nerv.tk3/salus-report' }
-      let(:report_directive) do
-        {
-          'uri' => http_report_uri,
-          'format' => 'json'
-        }
-      end
-      let(:report) do
-        Salus::Report.new(
-          report_uris: [report_directive],
-          project_name: 'eva00',
-          custom_info: 'test unit'
-        )
+    def build_report(report_uri)
+      report = Salus::Report.new(
+        report_uris: [report_uri],
+        project_name: 'eva00',
+        custom_info: 'test unit'
+      )
+
+      3.times do
+        scan_report = Salus::ScanReport.new('DerpScanner')
+        scan_report.info(:asdf, 'qwerty')
+        scan_report.fail
+        report.add_scan_report(scan_report, required: true)
       end
 
+      5.times { report.error(message: 'derp') }
+
+      report
+    end
+
+    context 'HTTP report URI given' do
       it 'should make a call to send the report for http URI' do
-        stub_request(:post, http_report_uri)
-          .with(headers: { 'Content-Type' => 'application/json' }, body: loaded_report.to_json)
+        url = 'https://nerv.tk3/salus-report'
+        directive = { 'uri' => url, 'format' => 'json' }
+        report = build_report(directive)
+
+        stub_request(:post, url)
+          .with(headers: { 'Content-Type' => 'application/json' }, body: report.to_json)
           .to_return(status: 202)
 
-        expect { loaded_report.export_report }.not_to raise_error
+        expect { report.export_report }.not_to raise_error
 
         assert_requested(
           :post,
-          http_report_uri,
+          url,
           headers: { 'Content-Type' => 'application/json' },
-          body: loaded_report.to_json,
+          body: report.to_json,
           times: 1
         )
       end
 
       it 'should raise if there is an error with sending the report to a HTTP endpoint' do
-        stub_request(:post, http_report_uri)
+        url = 'https://nerv.tk3/salus-report'
+        directive = { 'uri' => url, 'format' => 'json' }
+        report = build_report(directive)
+
+        stub_request(:post, url)
           .with(headers: { 'Content-Type' => 'application/json' }, body: report.to_json)
           .to_return(status: 404)
+
         expect { report.export_report }.to raise_error(
           Salus::Report::ExportReportError,
           'POST of Salus report to https://nerv.tk3/salus-report had response status 404.'
@@ -186,51 +179,38 @@ describe Salus::Report do
     end
 
     context 'local file report URI given' do
-      let(:good_file_report_uri) { './spec/fixtures/report/salus_report.json' }
-      let(:good_file_report_directive) do
-        {
-          'uri' => good_file_report_uri,
-          'format' => 'json'
-        }
-      end
-      let(:bad_file_report_uri) { './spec/fixtures/non_existent_dir/salus_report.json' }
-      let(:bad_file_report_directive) do
-        {
-          'uri' => bad_file_report_uri,
-          'format' => 'json'
-        }
-      end
-
       it 'should save to the given directory for a local file uri' do
-        # Delete the fixtures file for cleanup - do at start incase last test run failed.
-        remove_file(good_file_report_uri)
+        path = './spec/fixtures/report/salus_report.json'
+        directive = { 'uri' => path, 'format' => 'json' }
+        report = build_report(directive)
 
-        report = Salus::Report.new(
-          report_uris: [good_file_report_directive],
-          project_name: 'eva00',
-          custom_info: 'test unit'
-        )
+        # Delete the fixtures file for cleanup - do at start incase last test run failed.
+        remove_file(path)
 
         # Save report
-        loaded_report = load_report(report)
-        loaded_report.export_report
+        report.export_report
 
         # Check save
-        expect(File.read(good_file_report_uri)).to eq(loaded_report.to_json)
+        expect(File.read(path)).to eq(report.to_json)
 
         # Delete the fixtures file for cleanup.
-        remove_file(good_file_report_uri)
+        remove_file(path)
       end
 
       it 'should raise if it tries to write a file report to a non-existent directory' do
+        path = './spec/fixtures/non_existent_dir/salus_report.json'
+        directive = { 'uri' => path, 'format' => 'json' }
+        report = report = build_report(directive)
+
         report = Salus::Report.new(
-          report_uris: [bad_file_report_directive],
+          report_uris: [directive],
           project_name: 'eva00',
           custom_info: 'test unit'
         )
+
         expect { report.export_report }.to raise_error(
           Salus::Report::ExportReportError,
-          "Cannot write file #{bad_file_report_uri} - " \
+          "Cannot write file #{path} - " \
           "Errno::ENOENT: No such file or directory @ rb_sysopen - "      \
           "./spec/fixtures/non_existent_dir/salus_report.json"
         )

--- a/spec/lib/salus/scanners/base_spec.rb
+++ b/spec/lib/salus/scanners/base_spec.rb
@@ -2,11 +2,7 @@ require_relative '../../../spec_helper.rb'
 
 describe Salus::Scanners::Base do
   let(:repository) { Salus::Repo.new('spec/fixtures/ruby_gem') }
-  let(:config) { { 'ignore' => [] } }
-  let(:report) { Salus::Report.new }
-  let(:scanner) do
-    Salus::Scanners::Base.new(repository: repository, report: report, config: config)
-  end
+  let(:scanner) { Salus::Scanners::Base.new(repository: repository, config: {}) }
 
   describe '#run' do
     it 'should raise an exception since this is an abstract function' do
@@ -43,61 +39,39 @@ describe Salus::Scanners::Base do
 
   describe '#report_success' do
     it 'should log to the report that the scan passed' do
-      expect { scanner.report_success }.to change {
-        json_report['scans']
-      }.from({}).to(
-        'Base' => {
-          'passed' => true
-        }
-      )
+      expect { scanner.report_success }.to change { scanner.report.passed? }
+        .from(false).to(true)
     end
   end
 
   describe '#report_failure' do
     it 'should log to the report that the scan failed' do
-      expect { scanner.report_failure }.to change {
-        json_report['scans']
-      }.from({}).to(
-        'Base' => {
-          'passed' => false
-        }
-      )
+      expect { scanner.report_failure }.to change { scanner.report.failed? }
+        .from(false).to(true)
     end
   end
 
   describe '#report_info' do
     it 'should store some info indexed by scanner and info type' do
-      expect { scanner.report_info('eva', 'AT Field active') }.to change {
-        json_report['scans']
-      }.from({}).to(
-        'Base' => {
-          'info' => { 'eva' => ['AT Field active'] }
-        }
-      )
+      expect { scanner.report_info(:eva, 'AT Field active') }
+        .to change { scanner.report.to_h.fetch(:info)[:eva] }
+        .from(nil).to('AT Field active')
     end
   end
 
   describe '#report_stdout' do
     it 'should store the stdout of the scanner' do
-      expect { scanner.report_stdout('Misato in command.') }.to change {
-        json_report['scans']
-      }.from({}).to(
-        'Base' => {
-          'stdout' => 'Misato in command.'
-        }
-      )
+      expect { scanner.report_stdout('Misato in command.') }
+        .to change { scanner.report.to_h.fetch(:info)[:stdout] }
+        .from(nil).to('Misato in command.')
     end
   end
 
   describe '#report_stderr' do
     it 'should store the stderr of the scanner' do
-      expect { scanner.report_stderr('SCANNER FAILED') }.to change {
-        json_report['scans']
-      }.from({}).to(
-        'Base' => {
-          'stderr' => 'SCANNER FAILED'
-        }
-      )
+      expect { scanner.report_stderr('SCANNER FAILED') }
+        .to change { scanner.report.to_h.fetch(:info)[:stderr] }
+        .from(nil).to('SCANNER FAILED')
     end
   end
 end

--- a/spec/lib/salus/scanners/brakeman_spec.rb
+++ b/spec/lib/salus/scanners/brakeman_spec.rb
@@ -1,45 +1,37 @@
 require_relative '../../../spec_helper.rb'
 
 describe Salus::Scanners::Brakeman do
-  let(:blank_config) { {} }
-  let(:report) { Salus::Report.new }
-  let(:scan_report) { json_report['scans']['Brakeman'] }
-  let(:brakeman_report) { scan_report['info']['brakeman_report'][0] }
-  let(:first_scan_warning) { brakeman_report['warnings'][0] }
-
   describe '#run' do
     context 'non-rails project' do
       it 'should record the STDERR of brakeman' do
-        scanner = Salus::Scanners::Brakeman.new(
-          repository: Salus::Repo.new('spec/fixtures/blank_repository'),
-          report: report,
-          config: blank_config
-        )
+        repo = Salus::Repo.new('spec/fixtures/blank_repository')
+        scanner = Salus::Scanners::Brakeman.new(repository: repo, config: {})
+
+        expect(scanner.should_run?).to eq(false)
+
         scanner.run
-        expect(scan_report['stderr']).to include('Please supply the path to a Rails application')
+
+        expect(scanner.report.passed?).to eq(false)
+
+        info = scanner.report.to_h.fetch(:info)
+        expect(info[:stderr]).to include('Please supply the path to a Rails application')
       end
     end
 
     context 'rails project with vulnerabilities' do
       it 'should record failure and record the STDOUT from brakeman' do
-        scanner = Salus::Scanners::Brakeman.new(
-          repository: Salus::Repo.new('spec/fixtures/brakeman/vulnerable_rails_app'),
-          report: report,
-          config: blank_config
-        )
+        repo = Salus::Repo.new('spec/fixtures/brakeman/vulnerable_rails_app')
+
+        scanner = Salus::Scanners::Brakeman.new(repository: repo, config: {})
         scanner.run
 
-        expect(scan_report['passed']).to eq(false)
+        expect(scanner.report.passed?).to eq(false)
 
-        expect(scan_report['stdout']).not_to eq(nil)
-        expect(scan_report['stdout']).not_to eq("")
+        info = scanner.report.to_h.fetch(:info)
 
-        expect(scan_report['info']['brakeman_report'].length).not_to equal(0)
-        expect(scan_report['info']['brakeman_report'][0]).not_to equal(0)
-        expect(scan_report['info']['brakeman_report'][0]['warnings'].length).not_to eq(0)
-        expect(scan_report['info']['brakeman_report'][0]['warnings'][0]).not_to eq(0)
-
-        expect(first_scan_warning['warning_type']).to eq('Dangerous Eval')
+        expect(info[:stdout]).not_to eq(nil)
+        expect(info[:stdout]).not_to eq("")
+        expect(info[:brakeman_report][:warnings][0][:warning_type]).to eq('Dangerous Eval')
       end
     end
   end
@@ -49,11 +41,8 @@ describe Salus::Scanners::Brakeman do
       it 'should return false' do
         repo = Salus::Repo.new('spec/fixtures/blank_repository')
         expect(repo.gemfile_present?).to eq(false)
-        scanner = Salus::Scanners::Brakeman.new(
-          repository: repo,
-          report: report,
-          config: blank_config
-        )
+
+        scanner = Salus::Scanners::Brakeman.new(repository: repo, config: {})
         expect(scanner.should_run?).to eq(false)
       end
     end
@@ -63,11 +52,8 @@ describe Salus::Scanners::Brakeman do
         repo = Salus::Repo.new('spec/fixtures/brakeman/ruby_app')
         expect(repo.gemfile_present?).to eq(true)
         expect(repo.gemfile).not_to match(/('|")rails('|")/)
-        scanner = Salus::Scanners::Brakeman.new(
-          repository: repo,
-          report: report,
-          config: blank_config
-        )
+
+        scanner = Salus::Scanners::Brakeman.new(repository: repo, config: {})
         expect(scanner.should_run?).to eq(false)
       end
     end
@@ -77,11 +63,8 @@ describe Salus::Scanners::Brakeman do
         repo = Salus::Repo.new('spec/fixtures/brakeman/safe_rails_app')
         expect(repo.gemfile_present?).to eq(true)
         expect(repo.gemfile).to match(/('|")rails('|")/)
-        scanner = Salus::Scanners::Brakeman.new(
-          repository: repo,
-          report: report,
-          config: blank_config
-        )
+
+        scanner = Salus::Scanners::Brakeman.new(repository: repo, config: {})
         expect(scanner.should_run?).to eq(true)
       end
     end

--- a/spec/lib/salus/scanners/bundle_audit_spec.rb
+++ b/spec/lib/salus/scanners/bundle_audit_spec.rb
@@ -1,140 +1,101 @@
 require_relative '../../../spec_helper.rb'
 
 describe Salus::Scanners::BundleAudit do
-  let(:blank_config) { { 'ignore' => [] } }
-  let(:report) { Salus::Report.new }
-  let(:scan_report) { json_report['scans']['BundleAudit'] }
-  let(:scan_errors) { json_report['errors']['BundleAudit'] }
-
   describe '#run' do
     it 'should check for updates to the CVE DB' do
-      scanner = Salus::Scanners::BundleAudit.new(
-        repository: Salus::Repo.new('spec/fixtures/bundle_audit/no_cves'),
-        report: report,
-        config: blank_config
-      )
+      repo = Salus::Repo.new('spec/fixtures/bundle_audit/no_cves')
+      scanner = Salus::Scanners::BundleAudit.new(repository: repo, config: {})
 
       # Mock out the system() call and ensure it was called
-      expect(Bundler::Audit::Database).to(
-        receive(:system).with(
-          "git", "pull", "--quiet", "origin", "master"
-        ).and_return(true)
-      )
+      expect(Bundler::Audit::Database)
+        .to receive(:system)
+        .with("git", "pull", "--quiet", "origin", "master")
+        .and_return(true)
 
       scanner.run
-    end
-
-    context 'broken Gemfile.lock' do
-      it 'should throw/rescue and report an error for an invalid directory' do
-        scanner = Salus::Scanners::BundleAudit.new(
-          repository: Salus::Repo.new('spec/fixtures/blank_repository'),
-          report: report,
-          config: blank_config
-        )
-        scanner.run
-        expect(scan_errors).to include(
-          'message' => "Errno::ENOENT - Invalid directory (directory doesn't exist)"
-        )
-      end
     end
 
     context 'CVEs in Gemfile.lock' do
       it 'should record failure and record the STDOUT from bundle-audit' do
         # TODO: create fake placeholder gems but such that you can actually bundle install them.
         # This will prevent new CVEs coming out from causing tests to fail.
-        scanner = Salus::Scanners::BundleAudit.new(
-          repository: Salus::Repo.new('spec/fixtures/bundle_audit/cves_found'),
-          report: report,
-          config: blank_config
-        )
+        repo = Salus::Repo.new('spec/fixtures/bundle_audit/cves_found')
+        scanner = Salus::Scanners::BundleAudit.new(repository: repo, config: {})
         scanner.run
 
-        bundle_audit_results = report.to_h[:scans]['BundleAudit']
-        actionview_result = bundle_audit_results['info']['unpatched_gem'][0]
+        expect(scanner.report.passed?).to eq(false)
 
-        expect(scan_report['passed']).to eq(false)
-        expect(actionview_result[:name]).to eq('actionview')
-        expect(actionview_result[:version]).to eq('4.1.15')
-        expect(actionview_result[:cve]).to eq('CVE-2016-6316')
-        expect(actionview_result[:cvss]).to eq(nil)
+        info = scanner.report.to_h.fetch(:info)
+        vuln = info[:vulnerabilities][0]
+
+        expect(vuln[:name]).to eq('actionview')
+        expect(vuln[:version]).to eq('4.1.15')
+        expect(vuln[:cve]).to eq('CVE-2016-6316')
+        expect(vuln[:cvss]).to eq(nil)
       end
     end
 
     context 'insecure sources in Gemfile' do
       it 'should record failure and report results' do
-        scanner = Salus::Scanners::BundleAudit.new(
-          repository: Salus::Repo.new('spec/fixtures/bundle_audit/insecure_source'),
-          report: report,
-          config: blank_config
-        )
+        repo = Salus::Repo.new('spec/fixtures/bundle_audit/insecure_source')
+        scanner = Salus::Scanners::BundleAudit.new(repository: repo, config: {})
         scanner.run
 
-        bundle_audit_results = report.to_h[:scans]['BundleAudit']
-        actionview_result = bundle_audit_results['info']['unpatched_gem'][0]
+        expect(scanner.report.passed?).to eq(false)
 
-        expect(bundle_audit_results['stdout']).not_to eq(nil)
-        expect(bundle_audit_results['stdout']).not_to eq('')
+        info = scanner.report.to_h.fetch(:info)
 
-        expect(scan_report['passed']).to eq(false)
-        expect(actionview_result[:name]).to eq('actionview')
-        expect(actionview_result[:version]).to eq('4.1.15')
-        expect(actionview_result[:cve]).to eq('CVE-2016-6316')
-        expect(actionview_result[:cvss]).to eq(nil)
+        expect(info[:vulnerabilities])
+          .to include(type: "InsecureSource", source: "http://rubygems.org/")
       end
     end
 
     context 'no CVEs in Gemfile.lock' do
-      it 'should record success' do
-        scanner = Salus::Scanners::BundleAudit.new(
-          repository: Salus::Repo.new('spec/fixtures/bundle_audit/no_cves'),
-          report: report,
-          config: blank_config
-        )
+      it 'should report success' do
+        repo = Salus::Repo.new('spec/fixtures/bundle_audit/no_cves')
+        scanner = Salus::Scanners::BundleAudit.new(repository: repo, config: {})
         scanner.run
-        expect(scan_report['passed']).to eq(true)
-        expect(scan_report['ignored_cve']).to be_nil
+
+        expect(scanner.report.passed?).to eq(true)
+
+        info = scanner.report.to_h.fetch(:info)
+        expect(info[:ignored_cves]).to eq([])
       end
     end
 
     context 'no CVEs in Gemfile.lock when ignoring CVEs' do
       it 'should record success and report on the ignored CVEs' do
+        repo = Salus::Repo.new('spec/fixtures/bundle_audit/passes_with_ignores')
         scanner = Salus::Scanners::BundleAudit.new(
-          repository: Salus::Repo.new('spec/fixtures/bundle_audit/passes_with_ignores'),
-          report: report,
+          repository: repo,
           config: { 'ignore' => %w[CVE-2012-3464 CVE-2015-3227] }
         )
+
         scanner.run
-        expect(scan_report['passed']).to eq(true)
-        expect(scan_report['info']['ignored_cves']).to eq(%w[CVE-2012-3464 CVE-2015-3227])
+
+        expect(scanner.report.passed?).to eq(true)
+
+        info = scanner.report.to_h.fetch(:info)
+        expect(info[:ignored_cves]).to eq(%w[CVE-2012-3464 CVE-2015-3227])
       end
     end
   end
 
   describe '#should_run?' do
-    context 'Gemfile.lock not present' do
-      it 'should return false' do
-        repo = Salus::Repo.new('spec/fixtures/blank_repository')
-        expect(repo.gemfile_lock_present?).to eq(false)
-        scanner = Salus::Scanners::BundleAudit.new(
-          repository: repo,
-          report: report,
-          config: blank_config
-        )
-        expect(scanner.should_run?).to eq(false)
-      end
+    it 'should return false if Gemfile.lock not present' do
+      repo = Salus::Repo.new('spec/fixtures/blank_repository')
+      expect(repo.gemfile_lock_present?).to eq(false)
+
+      scanner = Salus::Scanners::BundleAudit.new(repository: repo, config: {})
+      expect(scanner.should_run?).to eq(false)
     end
 
-    context 'Gemfile.lock is present' do
-      it 'should return true' do
-        repo = Salus::Repo.new('spec/fixtures/bundle_audit/no_cves')
-        expect(repo.gemfile_lock_present?).to eq(true)
-        scanner = Salus::Scanners::BundleAudit.new(
-          repository: repo,
-          report: report,
-          config: blank_config
-        )
-        expect(scanner.should_run?).to eq(true)
-      end
+    it 'should return true if Gemfile.lock is present' do
+      repo = Salus::Repo.new('spec/fixtures/bundle_audit/no_cves')
+      expect(repo.gemfile_lock_present?).to eq(true)
+
+      scanner = Salus::Scanners::BundleAudit.new(repository: repo, config: {})
+      expect(scanner.should_run?).to eq(true)
     end
   end
 end

--- a/spec/lib/salus/scanners/npm_audit_spec.rb
+++ b/spec/lib/salus/scanners/npm_audit_spec.rb
@@ -1,79 +1,78 @@
 require_relative '../../../spec_helper.rb'
 
 describe Salus::Scanners::NPMAudit do
-  let(:report) { Salus::Report.new }
-  let(:scan_report) { json_report['scans']['NPMAudit'] }
-  let(:scan_errors) { json_report['errors']['NPMAudit'] }
+  def load_config(fixture_dir)
+    YAML.load_file("#{fixture_dir}/salus.yaml")['scanner_configs']['NPMAudit']
+  end
 
   describe '#run' do
     context 'CVEs in package.json' do
       it 'should record failure and stderr from npm audit' do
-        scanner = Salus::Scanners::NPMAudit.new(
-          repository: Salus::Repo.new('spec/fixtures/npm_audit/failure'),
-          report: report,
-          config: {}
-        )
+        repo = Salus::Repo.new('spec/fixtures/npm_audit/failure')
+        scanner = Salus::Scanners::NPMAudit.new(repository: repo, config: {})
         scanner.run
 
-        expect(scan_report['passed']).to eq(false)
-        expect(scan_report['info'].keys).to eq(%w[package_lock_missing npm_audit_output])
-        expect(scan_report['info']['npm_audit_output'].length).to eq(1)
-        # Ensure 2 vulns were found
-        expect(scan_report['info']['npm_audit_output'][0]['advisories'].keys).to eq(%w[39 48])
+        expect(scanner.report.passed?).to eq(false)
+
+        info = scanner.report.to_h.fetch(:info)
+
+        expect(info.keys).to include(:npm_audit_output)
+        expect(info[:npm_audit_output][:advisories].keys.map(&:to_s))
+          .to contain_exactly('39', '48')
       end
     end
 
     context 'no CVEs in package.json' do
       it 'should record success' do
-        scanner = Salus::Scanners::NPMAudit.new(
-          repository: Salus::Repo.new('spec/fixtures/npm_audit/success'),
-          report: report,
-          config: {}
-        )
+        repo = Salus::Repo.new('spec/fixtures/npm_audit/success')
+        scanner = Salus::Scanners::NPMAudit.new(repository: repo, config: {})
         scanner.run
 
-        expect(scan_report['passed']).to eq(true)
-        expect(scan_report['info'].keys).to eq(['package_lock_missing'])
+        expect(scanner.report.passed?).to eq(true)
+
+        info = scanner.report.to_h.fetch(:info)
+        expect(info.keys).to contain_exactly(:package_lock_missing)
       end
     end
 
     context 'no CVEs in package.json when ignoring CVEs' do
       it 'should record success and report on the ignored CVEs' do
+        repo = Salus::Repo.new('spec/fixtures/npm_audit/success_with_exceptions')
         scanner = Salus::Scanners::NPMAudit.new(
-          repository: Salus::Repo.new('spec/fixtures/npm_audit/success_with_exceptions'),
-          report: report,
-          config: YAML.load_file(
-            "spec/fixtures/npm_audit/success_with_exceptions/salus.yaml"
-          )['scanner_configs']['NPMAudit'] # Mock what Salus does under the hood
+          repository: repo,
+          config: load_config('spec/fixtures/npm_audit/success_with_exceptions')
         )
         scanner.run
-        expect(scan_report['passed']).to eq(true)
-        expect(
-          scan_report['info'].keys.sort
-        ).to eq(%w[exceptions npm_audit_output package_lock_missing])
-        expect(scan_report['info']['exceptions'].length).to eq(2)
-        expect(scan_report['info']['exceptions'].map { |x| x['advisory_id'] }.sort).to eq(%w[39 48])
+
+        expect(scanner.report.passed?).to eq(true)
+
+        info = scanner.report.to_h.fetch(:info)
+        expect(info.keys).to include(:exceptions, :npm_audit_output)
+
+        exception_ids = info[:exceptions].map { |exception| exception['advisory_id'] }
+        expect(exception_ids).to contain_exactly('39', '48')
       end
     end
   end
 
   describe '#should_run?' do
-    context 'no relevant files present' do
-      it 'should return false' do
-        repo = Salus::Repo.new('spec/fixtures/blank_repository')
-        expect(repo.package_json_present?).to eq(false)
-        scanner = Salus::Scanners::NPMAudit.new(repository: repo, report: report, config: {})
-        expect(scanner.should_run?).to eq(false)
-      end
+    it 'should return false in the absence of package.json and friends' do
+      repo = Salus::Repo.new('spec/fixtures/blank_repository')
+
+      expect(repo.package_json_present?).to eq(false)
+      expect(repo.package_lock_json_present?).to eq(false)
+      expect(repo.yarn_lock_present?).to eq(false)
+
+      scanner = Salus::Scanners::NPMAudit.new(repository: repo, config: {})
+      expect(scanner.should_run?).to eq(false)
     end
 
-    context 'package.json is present' do
-      it 'should return true' do
-        repo = Salus::Repo.new('spec/fixtures/npm_audit/success')
-        expect(repo.package_json_present?).to eq(true)
-        scanner = Salus::Scanners::NPMAudit.new(repository: repo, report: report, config: {})
-        expect(scanner.should_run?).to eq(true)
-      end
+    it 'should return true if package.json is present' do
+      repo = Salus::Repo.new('spec/fixtures/npm_audit/success')
+      expect(repo.package_json_present?).to eq(true)
+
+      scanner = Salus::Scanners::NPMAudit.new(repository: repo, config: {})
+      expect(scanner.should_run?).to eq(true)
     end
   end
 end

--- a/spec/lib/salus/scanners/pattern_search_spec.rb
+++ b/spec/lib/salus/scanners/pattern_search_spec.rb
@@ -1,219 +1,225 @@
 require_relative '../../../spec_helper.rb'
 
 describe Salus::Scanners::PatternSearch do
-  let(:report) { Salus::Report.new }
-  let(:scan_report) { json_report['scans']['PatternSearch'] }
-
   describe '#run' do
     context 'no forbidden regex' do
       it 'should report matches' do
-        scanner = Salus::Scanners::PatternSearch.new(
-          repository: Salus::Repo.new('spec/fixtures/pattern_search'),
-          report: report,
-          config: { 'matches' => [{ 'regex' => 'Nerv', 'forbidden' => false }] }
-        )
+        repo = Salus::Repo.new('spec/fixtures/pattern_search')
+        config = { 'matches' => [{ 'regex' => 'Nerv', 'forbidden' => false }] }
+        scanner = Salus::Scanners::PatternSearch.new(repository: repo, config: config)
         scanner.run
-        expect(scan_report['info']['pattern_search_hit']).to include(
-          'regex' => 'Nerv',
-          'forbidden' => false,
-          'required' => false,
-          'msg' => '',
-          'hit' => 'lance.txt:3:Nerv housed the lance.'
+
+        expect(scanner.report.passed?).to eq(true)
+
+        info = scanner.report.to_h.fetch(:info)
+
+        expect(info[:hits]).to include(
+          regex: 'Nerv',
+          forbidden: false,
+          required: false,
+          msg: '',
+          hit: 'lance.txt:3:Nerv housed the lance.'
         )
-        expect(scan_report['info']['pattern_search_hit']).to include(
-          'regex' => 'Nerv',
-          'forbidden' => false,
-          'required' => false,
-          'msg' => '',
-          'hit' => 'seal.txt:3:Nerv is tasked with taking over when the UN fails.'
+
+        expect(info[:hits]).to include(
+          regex: 'Nerv',
+          forbidden: false,
+          required: false,
+          msg: '',
+          hit: 'seal.txt:3:Nerv is tasked with taking over when the UN fails.'
         )
-        expect(scan_report['passed']).to eq(true)
       end
 
       it 'should report matches with a message' do
-        scanner = Salus::Scanners::PatternSearch.new(
-          repository: Salus::Repo.new('spec/fixtures/pattern_search'),
-          report: report,
-          config: {
-            'matches' => [
-              {
-                'regex' => 'Nerv',
-                'message' => "Shaken, not stirred.",
-                'forbidden' => false
-              }
-            ]
-          }
-        )
+        repo = Salus::Repo.new('spec/fixtures/pattern_search')
+        config = {
+          'matches' => [
+            {
+              'regex' => 'Nerv',
+              'message' => "Shaken, not stirred.",
+              'forbidden' => false
+            }
+          ]
+        }
+
+        scanner = Salus::Scanners::PatternSearch.new(repository: repo, config: config)
         scanner.run
-        expect(scan_report['info']['pattern_search_hit']).to include(
-          'regex' => 'Nerv',
-          'forbidden' => false,
-          'required' => false,
-          'msg' => 'Shaken, not stirred.',
-          'hit' => 'lance.txt:3:Nerv housed the lance.'
+
+        expect(scanner.report.passed?).to eq(true)
+
+        info = scanner.report.to_h.fetch(:info)
+
+        expect(info[:hits]).to include(
+          regex: 'Nerv',
+          forbidden: false,
+          required: false,
+          msg: 'Shaken, not stirred.',
+          hit: 'lance.txt:3:Nerv housed the lance.'
         )
-        expect(scan_report['info']['pattern_search_hit']).to include(
-          'regex' => 'Nerv',
-          'forbidden' => false,
-          'required' => false,
-          'msg' => 'Shaken, not stirred.',
-          'hit' => 'seal.txt:3:Nerv is tasked with taking over when the UN fails.'
+
+        expect(info[:hits]).to include(
+          regex: 'Nerv',
+          forbidden: false,
+          required: false,
+          msg: 'Shaken, not stirred.',
+          hit: 'seal.txt:3:Nerv is tasked with taking over when the UN fails.'
         )
-        expect(scan_report['passed']).to eq(true)
       end
     end
 
     context 'some regex hits are forbidden' do
       it 'should report matches' do
-        scanner = Salus::Scanners::PatternSearch.new(
-          repository: Salus::Repo.new('spec/fixtures/pattern_search'),
-          report: report,
-          config: { 'matches' => [{ 'regex' => 'Nerv', 'forbidden' => true }] }
-        )
+        repo = Salus::Repo.new('spec/fixtures/pattern_search')
+        config = { 'matches' => [{ 'regex' => 'Nerv', 'forbidden' => true }] }
+        scanner = Salus::Scanners::PatternSearch.new(repository: repo, config: config)
         scanner.run
-        expect(scan_report['info']['pattern_search_hit']).to include(
-          'regex' => 'Nerv',
-          'forbidden' => true,
-          'required' => false,
-          'msg' => '',
-          'hit' => 'lance.txt:3:Nerv housed the lance.'
+
+        expect(scanner.report.passed?).to eq(false)
+
+        info = scanner.report.to_h.fetch(:info)
+
+        expect(info[:hits]).to include(
+          regex: 'Nerv',
+          forbidden: true,
+          required: false,
+          msg: '',
+          hit: 'lance.txt:3:Nerv housed the lance.'
         )
-        expect(scan_report['info']['pattern_search_hit']).to include(
-          'regex' => 'Nerv',
-          'forbidden' => true,
-          'required' => false,
-          'msg' => '',
-          'hit' => 'seal.txt:3:Nerv is tasked with taking over when the UN fails.'
+
+        expect(info[:hits]).to include(
+          regex: 'Nerv',
+          forbidden: true,
+          required: false,
+          msg: '',
+          hit: 'seal.txt:3:Nerv is tasked with taking over when the UN fails.'
         )
-        expect(scan_report['passed']).to eq(false)
       end
     end
 
     context 'some regex hits are required' do
       it 'should pass the scan if a required patterns are found' do
-        scanner = Salus::Scanners::PatternSearch.new(
-          repository: Salus::Repo.new('spec/fixtures/pattern_search'),
-          report: report,
-          config: {
-            'matches' => [
-              { 'regex' => 'Nerv', 'required' => true, 'message' => 'important string' }
-            ]
-          }
-        )
+        repo = Salus::Repo.new('spec/fixtures/pattern_search')
+        config = {
+          'matches' => [
+            { 'regex' => 'Nerv', 'required' => true, 'message' => 'important string' }
+          ]
+        }
 
+        scanner = Salus::Scanners::PatternSearch.new(repository: repo, config: config)
         scanner.run
 
-        expect(scan_report['info']['pattern_search_hit']).to include(
-          'regex' => 'Nerv',
-          'forbidden' => false,
-          'required' => true,
-          'msg' => 'important string',
-          'hit' => 'lance.txt:3:Nerv housed the lance.'
+        expect(scanner.report.passed?).to eq(true)
+
+        info = scanner.report.to_h.fetch(:info)
+
+        expect(info[:hits]).to include(
+          regex: 'Nerv',
+          forbidden: false,
+          required: true,
+          msg: 'important string',
+          hit: 'lance.txt:3:Nerv housed the lance.'
         )
-        expect(scan_report['passed']).to eq(true)
       end
 
-      it 'should pass the scan if a required patterns are found' do
-        scanner = Salus::Scanners::PatternSearch.new(
-          repository: Salus::Repo.new('spec/fixtures/pattern_search'),
-          report: report,
-          config: {
-            'matches' => [
-              { 'regex' => 'Tokyo3', 'required' => true, 'message' => 'current location' }
-            ]
-          }
-        )
+      it 'should failed the scan if a required pattern is not found' do
+        repo = Salus::Repo.new('spec/fixtures/pattern_search')
+        config = {
+          'matches' => [
+            { 'regex' => 'Tokyo3', 'required' => true, 'message' => 'current location' }
+          ]
+        }
 
+        scanner = Salus::Scanners::PatternSearch.new(repository: repo, config: config)
         scanner.run
 
-        expect(scan_report['info']['pattern_search_hit']).to include(
-          'Required pattern "Tokyo3" was not found - current location'
-        )
-        expect(scan_report['passed']).to eq(false)
+        expect(scanner.report.passed?).to eq(false)
+
+        errors = scanner.report.to_h.fetch(:errors)
+
+        expect(errors)
+          .to include(message: 'Required pattern "Tokyo3" was not found - current location')
       end
     end
 
     context 'global exclusions are given' do
       it 'should not search through excluded material' do
-        scanner = Salus::Scanners::PatternSearch.new(
-          repository: Salus::Repo.new('spec/fixtures/pattern_search'),
-          report: report,
-          config: {
-            'matches' => [
-              { 'regex' => 'UN' },
-              { 'regex' => 'lance', 'forbidden' => true }
-            ],
-            'exclude_extension' => ['txt']
-          }
-        )
+        repo = Salus::Repo.new('spec/fixtures/pattern_search')
+        config = {
+          'matches' => [
+            { regex: 'UN' },
+            { 'regex' => 'lance', 'forbidden' => true }
+          ],
+          'exclude_extension' => ['txt']
+        }
+
+        scanner = Salus::Scanners::PatternSearch.new(repository: repo, config: config)
         scanner.run
-        expect(scan_report['info']).to eq(nil)
-        expect(scan_report['passed']).to eq(true)
+
+        expect(scanner.report.passed?).to eq(true)
       end
     end
 
     context 'local exclusions are given' do
       it 'should not search through excluded material' do
-        scanner = Salus::Scanners::PatternSearch.new(
-          repository: Salus::Repo.new('spec/fixtures/pattern_search'),
-          report: report,
-          config: {
-            'matches' => [
-              { 'regex' => 'UN', 'exclude_extension' => ['txt'] },
-              { 'regex' => 'lance', 'forbidden' => true, 'exclude_extension' => ['txt'] }
-            ]
-          }
-        )
+        repo = Salus::Repo.new('spec/fixtures/pattern_search')
+        config = {
+          'matches' => [
+            { regex: 'UN', 'exclude_extension' => ['txt'] },
+            { 'regex' => 'lance', 'forbidden' => true, 'exclude_extension' => ['txt'] }
+          ]
+        }
+
+        scanner = Salus::Scanners::PatternSearch.new(repository: repo, config: config)
         scanner.run
-        expect(scan_report['info']).to eq(nil)
-        expect(scan_report['passed']).to eq(true)
+
+        expect(scanner.report.passed?).to eq(true)
       end
 
       it 'should not search through excluded extensions' do
-        scanner = Salus::Scanners::PatternSearch.new(
-          repository: Salus::Repo.new('spec/fixtures/pattern_search'),
-          report: report,
-          config: {
-            'matches' => [
-              { 'regex' => 'UN', 'exclude_extension' => %w[txt md] },
-              { 'regex' => 'lance', 'forbidden' => false }
-            ]
-          }
-        )
+        repo = Salus::Repo.new('spec/fixtures/pattern_search')
+
+        config = {
+          'matches' => [
+            { 'regex' => 'UN', 'exclude_extension' => %w[txt md] },
+            { 'regex' => 'lance', 'forbidden' => false }
+          ]
+        }
+
+        scanner = Salus::Scanners::PatternSearch.new(repository: repo, config: config)
         scanner.run
-        expect(scan_report['info']['pattern_search_hit']).to_not include(
-          'regex' => 'UN',
-          'forbidden' => false,
-          'msg' => '',
-          'hit' => 'seal.txt:3:Nerv is tasked with taking over when the UN fails.'
-        )
-        expect(scan_report['passed']).to eq(true)
+
+        expect(scanner.report.passed?).to eq(true)
+
+        info = scanner.report.to_h.fetch(:info)
+        expect(info[:hits].map { |hit| hit[:regex] }).to_not include('UN')
       end
     end
 
     context 'invalid regex or settings which causes error' do
       it 'should record the STDERR of bundle-audit' do
-        scanner = Salus::Scanners::PatternSearch.new(
-          repository: Salus::Repo.new('spec/fixtures/pattern_search'),
-          report: report,
-          config: { 'matches' => [{ 'regex' => '(', 'forbidden' => true }] }
-        )
+        repo = Salus::Repo.new('spec/fixtures/pattern_search')
+        config = { 'matches' => [{ 'regex' => '(', 'forbidden' => true }] }
+        scanner = Salus::Scanners::PatternSearch.new(repository: repo, config: config)
         scanner.run
-        expect(scan_report['stderr']).to include(
-          "Error: cannot parse pattern: error parsing regexp: missing closing ): `(?m)(`\n"
+
+        expect(scanner.report.passed?).to eq(false)
+
+        errors = scanner.report.to_h.fetch(:errors)
+
+        expect(errors).to include(
+          status: 1,
+          stderr:
+            "Error: cannot parse pattern: error parsing regexp: missing closing ): `(?m)(`\n",
+          message: "Call to sift failed"
         )
-        expect(scan_report['passed']).to eq(true) # we did not hit any forbidden errors.
       end
     end
   end
 
   describe '#should_run?' do
     it 'should return true' do
-      scanner = Salus::Scanners::PatternSearch.new(
-        repository: Salus::Repo.new('spec/fixtures/blank_repository'),
-        report: report,
-        config: {}
-      )
+      repo = Salus::Repo.new('spec/fixtures/blank_repository')
+      scanner = Salus::Scanners::PatternSearch.new(repository: repo, config: {})
       expect(scanner.should_run?).to eq(true)
     end
   end

--- a/spec/lib/salus/scanners/pattern_search_spec.rb
+++ b/spec/lib/salus/scanners/pattern_search_spec.rb
@@ -134,10 +134,10 @@ describe Salus::Scanners::PatternSearch do
 
         expect(scanner.report.passed?).to eq(false)
 
-        errors = scanner.report.to_h.fetch(:errors)
+        failure_messages = scanner.report.to_h.fetch(:info).fetch(:failure_messages)
 
-        expect(errors)
-          .to include(message: 'Required pattern "Tokyo3" was not found - current location')
+        expect(failure_messages)
+          .to include('Required pattern "Tokyo3" was not found - current location')
       end
     end
 

--- a/spec/lib/salus/scanners/report_go_dep_spec.rb
+++ b/spec/lib/salus/scanners/report_go_dep_spec.rb
@@ -1,83 +1,64 @@
 require_relative '../../../spec_helper.rb'
 
 describe Salus::Scanners::ReportGoDep do
-  let(:blank_config) { {} }
-  let(:report) { Salus::Report.new }
-  let(:scan_report) { json_report['scans']['ReportGoDep'] }
-
   describe '#run' do
-    context 'no Gopkg.lock present' do
-      it 'should throw an error since there is nothing to parse' do
-        scanner = Salus::Scanners::ReportGoDep.new(
-          repository: Salus::Repo.new('spec/fixtures/blank_repository'),
-          report: report,
-          config: blank_config
-        )
-        expect { scanner.run }.to raise_error(
-          Salus::Scanners::Base::InvalidScannerInvocationError,
-          'Cannot report on Go dependencies without a Gopkg.lock file.'
-        )
-      end
+    it 'should throw an error if no Gopkg.lock is present' do
+      repo = Salus::Repo.new('spec/fixtures/blank_repository')
+      scanner = Salus::Scanners::ReportGoDep.new(repository: repo, config: {})
+
+      expect { scanner.run }.to raise_error(
+        Salus::Scanners::Base::InvalidScannerInvocationError,
+        'Cannot report on Go dependencies without a Gopkg.lock file.'
+      )
     end
 
-    context 'Gopkg.lock present' do
-      it 'should report on all the dependencies in the Gopkg.lock file' do
-        scanner = Salus::Scanners::ReportGoDep.new(
-          repository: Salus::Repo.new('spec/fixtures/report_go_dep'),
-          report: report,
-          config: blank_config
-        )
-        scanner.run
-        expect(scan_report['info']['dependency']).to include(
-          'dependency_file' => 'Gopkg.lock',
-          'type' => 'go_dep_lock',
-          'name' => 'github.com/PagerDuty/go-pagerduty',
-          'reference' => 'fe74e407c23e030fa1523e7cbd972398fd85ec5d',
-          'version_tag' => nil
-        )
-        expect(scan_report['info']['dependency']).to include(
-          'dependency_file' => 'Gopkg.lock',
-          'type' => 'go_dep_lock',
-          'name' => 'github.com/Sirupsen/logrus',
-          'reference' => 'ba1b36c82c5e05c4f912a88eab0dcd91a171688f',
-          'version_tag' => 'v0.11.5'
-        )
-        expect(scan_report['info']['dependency']).to include(
-          'dependency_file' => 'Gopkg.lock',
-          'type' => 'go_dep_lock',
-          'name' => 'golang.org/x/sys',
-          'reference' => '9a7256cb28ed514b4e1e5f68959914c4c28a92e0',
-          'version_tag' => nil
-        )
-      end
+    it 'should report on all the dependencies in the Gopkg.lock file' do
+      repo = Salus::Repo.new('spec/fixtures/report_go_dep')
+      scanner = Salus::Scanners::ReportGoDep.new(repository: repo, config: {})
+
+      scanner.run
+
+      dependencies = scanner.report.to_h.fetch(:info).fetch(:dependencies)
+
+      expect(dependencies).to match_array([
+                                            {
+                                              dependency_file: 'Gopkg.lock',
+                                              type: 'go_dep_lock',
+                                              name: 'github.com/PagerDuty/go-pagerduty',
+                                              reference: 'fe74e407c23e030fa1523e7cbd972398fd85ec5d',
+                                              version_tag: nil
+                                            },
+                                            {
+                                              dependency_file: 'Gopkg.lock',
+                                              type: 'go_dep_lock',
+                                              name: 'github.com/Sirupsen/logrus',
+                                              reference: 'ba1b36c82c5e05c4f912a88eab0dcd91a171688f',
+                                              version_tag: 'v0.11.5'
+                                            },
+                                            {
+                                              dependency_file: 'Gopkg.lock',
+                                              type: 'go_dep_lock',
+                                              name: 'golang.org/x/sys',
+                                              reference: '9a7256cb28ed514b4e1e5f68959914c4c28a92e0',
+                                              version_tag: nil
+                                            }
+                                          ])
     end
   end
 
   describe '#should_run?' do
-    context 'no Gopkg.lock present' do
-      it 'should return false' do
-        repo = Salus::Repo.new('spec/fixtures/blank_repository')
-        expect(repo.dep_lock_present?).to eq(false)
-        scanner = Salus::Scanners::ReportGoDep.new(
-          repository: repo,
-          report: report,
-          config: blank_config
-        )
-        expect(scanner.should_run?).to eq(false)
-      end
+    it 'should return false if Gopkg.lock is absent' do
+      repo = Salus::Repo.new('spec/fixtures/blank_repository')
+      expect(repo.dep_lock_present?).to eq(false)
+      scanner = Salus::Scanners::ReportGoDep.new(repository: repo, config: {})
+      expect(scanner.should_run?).to eq(false)
     end
 
-    context 'Gopkg.lock is present' do
-      it 'should return true' do
-        repo = Salus::Repo.new('spec/fixtures/report_go_dep')
-        expect(repo.dep_lock_present?).to eq(true)
-        scanner = Salus::Scanners::ReportGoDep.new(
-          repository: repo,
-          report: report,
-          config: blank_config
-        )
-        expect(scanner.should_run?).to eq(true)
-      end
+    it 'should return true if Gopkg.lock is present' do
+      repo = Salus::Repo.new('spec/fixtures/report_go_dep')
+      expect(repo.dep_lock_present?).to eq(true)
+      scanner = Salus::Scanners::ReportGoDep.new(repository: repo, config: {})
+      expect(scanner.should_run?).to eq(true)
     end
   end
 end

--- a/spec/lib/salus/scanners/report_go_dep_spec.rb
+++ b/spec/lib/salus/scanners/report_go_dep_spec.rb
@@ -20,29 +20,31 @@ describe Salus::Scanners::ReportGoDep do
 
       dependencies = scanner.report.to_h.fetch(:info).fetch(:dependencies)
 
-      expect(dependencies).to match_array([
-                                            {
-                                              dependency_file: 'Gopkg.lock',
-                                              type: 'go_dep_lock',
-                                              name: 'github.com/PagerDuty/go-pagerduty',
-                                              reference: 'fe74e407c23e030fa1523e7cbd972398fd85ec5d',
-                                              version_tag: nil
-                                            },
-                                            {
-                                              dependency_file: 'Gopkg.lock',
-                                              type: 'go_dep_lock',
-                                              name: 'github.com/Sirupsen/logrus',
-                                              reference: 'ba1b36c82c5e05c4f912a88eab0dcd91a171688f',
-                                              version_tag: 'v0.11.5'
-                                            },
-                                            {
-                                              dependency_file: 'Gopkg.lock',
-                                              type: 'go_dep_lock',
-                                              name: 'golang.org/x/sys',
-                                              reference: '9a7256cb28ed514b4e1e5f68959914c4c28a92e0',
-                                              version_tag: nil
-                                            }
-                                          ])
+      expect(dependencies).to match_array(
+        [
+          {
+            dependency_file: 'Gopkg.lock',
+            type: 'go_dep_lock',
+            name: 'github.com/PagerDuty/go-pagerduty',
+            reference: 'fe74e407c23e030fa1523e7cbd972398fd85ec5d',
+            version_tag: nil
+          },
+          {
+            dependency_file: 'Gopkg.lock',
+            type: 'go_dep_lock',
+            name: 'github.com/Sirupsen/logrus',
+            reference: 'ba1b36c82c5e05c4f912a88eab0dcd91a171688f',
+            version_tag: 'v0.11.5'
+          },
+          {
+            dependency_file: 'Gopkg.lock',
+            type: 'go_dep_lock',
+            name: 'golang.org/x/sys',
+            reference: '9a7256cb28ed514b4e1e5f68959914c4c28a92e0',
+            version_tag: nil
+          }
+        ]
+      )
     end
   end
 

--- a/spec/lib/salus/scanners/report_node_modules_spec.rb
+++ b/spec/lib/salus/scanners/report_node_modules_spec.rb
@@ -1,167 +1,160 @@
 require_relative '../../../spec_helper.rb'
 
 describe Salus::Scanners::ReportNodeModules do
-  let(:blank_config) { {} }
-  let(:report) { Salus::Report.new }
-  let(:scan_report) { json_report['scans']['ReportNodeModules'] }
-
   describe '#run' do
-    context 'no relevant node package files present' do
-      it 'should throw an error since there is nothing to parse' do
-        scanner = Salus::Scanners::ReportNodeModules.new(
-          repository: Salus::Repo.new('spec/fixtures/blank_repository'),
-          report: report,
-          config: blank_config
-        )
-        expect { scanner.run }.to raise_error(
-          Salus::Scanners::Base::InvalidScannerInvocationError,
-          'Cannot report on Node modules without package.json, '\
-            'package-lock.json or yarn.lock files.'
-        )
-      end
+    it 'should throw an error if package.json and friends are absent' do
+      repo = Salus::Repo.new('spec/fixtures/blank_repository')
+      scanner = Salus::Scanners::ReportNodeModules.new(repository: repo, config: {})
+
+      expect { scanner.run }.to raise_error(
+        Salus::Scanners::Base::InvalidScannerInvocationError,
+        'Cannot report on Node modules without package.json, '\
+          'package-lock.json or yarn.lock files.'
+      )
     end
 
-    context 'package.json present only' do
-      it 'should report on all the dependencies in the package.json file' do
-        scanner = Salus::Scanners::ReportNodeModules.new(
-          repository: Salus::Repo.new('spec/fixtures/report_node_modules/package_json_only'),
-          report: report,
-          config: blank_config
-        )
-        scanner.run
-        expect(scan_report['info']['dependency']).to include(
-          'dependency_file' => 'package.json', 'type' => 'node_version', 'version' => '>= 6.9'
-        )
-        expect(scan_report['info']['dependency']).to include(
-          'dependency_file' => 'package.json', 'type' => 'npm_version', 'version' => '>= 4.0.0'
-        )
-        expect(scan_report['info']['dependency']).to include(
-          'dependency_file' => 'package.json',
-          'type' => 'node_module',
-          'name' => 'control-system',
-          'version' => '1.2.3',
-          'source' => 'https://npm.hq.nerv.net'
-        )
-        expect(scan_report['info']['dependency']).to include(
-          'dependency_file' => 'package.json',
-          'type' => 'node_module',
-          'name' => 'prediction',
-          'version' => '0.0.1',
-          'source' => 'https://npm.magi.nerv.net'
-        )
-        expect(scan_report['info']['dependency']).to include(
-          'dependency_file' => 'package.json',
-          'type' => 'node_module',
-          'name' => 'classnames',
-          'version' => '^2.2.5',
-          'source' => '<package manager default>'
-        )
-        expect(scan_report['info']['dependency']).to include(
-          'dependency_file' => 'package.json',
-          'type' => 'node_module',
-          'name' => 'mobx',
-          'version' => '^3.2.1',
-          'source' => '<package manager default>'
-        )
-      end
+    it 'should report all the deps in package.json file in the absence of a lockfile' do
+      repo = Salus::Repo.new('spec/fixtures/report_node_modules/package_json_only')
+      scanner = Salus::Scanners::ReportNodeModules.new(repository: repo, config: {})
+      scanner.run
+
+      info = scanner.report.to_h.fetch(:info)
+
+      expect(info[:package_json_node_version]).to eq('>= 6.9')
+      expect(info[:package_json_npm_version]).to eq('>= 4.0.0')
+
+      expect(info[:dependencies]).to match_array(
+        [
+          {
+            dependency_file: 'package.json',
+            type: 'node_module',
+            name: 'control-system',
+            version: '1.2.3',
+            source: 'https://npm.hq.nerv.net'
+          },
+          {
+            dependency_file: 'package.json',
+            type: 'node_module',
+            name: 'prediction',
+            version: '0.0.1',
+            source: 'https://npm.magi.nerv.net'
+          },
+          {
+            dependency_file: 'package.json',
+            type: 'node_module',
+            name: 'classnames',
+            version: '^2.2.5',
+            source: '<package manager default>'
+          },
+          {
+            dependency_file: 'package.json',
+            type: 'node_module',
+            name: 'mobx',
+            version: '^3.2.1',
+            source: '<package manager default>'
+          }
+        ]
+      )
     end
 
-    context 'package.json and package-lock.json present' do
-      it 'should report on all the dependencies in the package-lock.json and package.json file' do
-        scanner = Salus::Scanners::ReportNodeModules.new(
-          repository: Salus::Repo.new('spec/fixtures/report_node_modules/package_lock_json'),
-          report: report,
-          config: blank_config
-        )
-        scanner.run
-        expect(scan_report['info']['dependency']).to include(
-          'dependency_file' => 'package-lock.json',
-          'type' => 'package_lock_version',
-          'version' => '1'
-        )
-        expect(scan_report['info']['dependency']).to include(
-          'dependency_file' => 'package-lock.json',
-          'type' => 'node_module',
-          'name' => '@nerv-hq/control-system',
-          'version' => '1.2.3',
-          'source' => 'https://npm.hq.nerv.net/control-system/v1.2.3/'\
-            'tarball#sha1-ux/eKKZxz2ojD4icjhvReee++74='
-        )
-        expect(scan_report['info']['dependency']).to include(
-          'dependency_file' => 'package-lock.json',
-          'type' => 'node_module',
-          'name' => '@magi-core/prediction',
-          'version' => '0.0.1',
-          'source' => 'https://npm.magi.nerv.net/prediction/v0.0.1/'\
-            'tarball#sha1-ux/EyKzTRzvejDFis90vRLj8++74='
-        )
-        expect(scan_report['info']['dependency']).to include(
-          'dependency_file' => 'package-lock.json',
-          'type' => 'node_module',
-          'name' => 'classnames',
-          'version' => '2.2.5',
-          'source' => 'https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz'\
-            '#sha1-+zgB1FNGdknvNgPH1hoCvRKb3m0='
-        )
-        expect(scan_report['info']['dependency']).to include(
-          'dependency_file' => 'package-lock.json',
-          'type' => 'node_module',
-          'name' => 'mobx',
-          'version' => '3.2.1',
-          'source' => 'https://registry.npmjs.org/mobx/-/mobx-3.2.1.tgz'\
-            '#sha1-aureASDMP3i6pXGVAxYwoK6PE88='
-        )
-      end
+    it 'should report all deps from package-lock.json, if present' do
+      repo = Salus::Repo.new('spec/fixtures/report_node_modules/package_lock_json')
+      scanner = Salus::Scanners::ReportNodeModules.new(repository: repo, config: {})
+      scanner.run
+
+      info = scanner.report.to_h.fetch(:info)
+
+      expect(info[:package_lock_version]).to eq('1')
+
+      expect(info[:dependencies]).to match_array(
+        [
+          {
+            dependency_file: 'package-lock.json',
+            type: 'node_module',
+            name: '@nerv-hq/control-system',
+            version: '1.2.3',
+            source: 'https://npm.hq.nerv.net/control-system/v1.2.3/'\
+              'tarball#sha1-ux/eKKZxz2ojD4icjhvReee++74='
+          },
+          {
+            dependency_file: 'package-lock.json',
+            type: 'node_module',
+            name: '@magi-core/prediction',
+            version: '0.0.1',
+            source: 'https://npm.magi.nerv.net/prediction/v0.0.1/'\
+              'tarball#sha1-ux/EyKzTRzvejDFis90vRLj8++74='
+          },
+          {
+            dependency_file: 'package-lock.json',
+            type: 'node_module',
+            name: 'classnames',
+            version: '2.2.5',
+            source: 'https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz'\
+              '#sha1-+zgB1FNGdknvNgPH1hoCvRKb3m0='
+          },
+          {
+            dependency_file: 'package-lock.json',
+            type: 'node_module',
+            name: 'mobx',
+            version: '3.2.1',
+            source: 'https://registry.npmjs.org/mobx/-/mobx-3.2.1.tgz'\
+              '#sha1-aureASDMP3i6pXGVAxYwoK6PE88='
+          }
+        ]
+      )
     end
 
-    context 'package.json and yarn.lock present' do
-      it 'should report on all the dependencies in the yarn.lock and package.json file' do
-        scanner = Salus::Scanners::ReportNodeModules.new(
-          repository: Salus::Repo.new('spec/fixtures/report_node_modules/yarn_lock'),
-          report: report,
-          config: blank_config
-        )
-        scanner.run
-        expect(scan_report['info']['dependency']).to include(
-          'dependency_file' => 'yarn.lock',
-          'type' => 'node_module',
-          'name' => '@nerv-hq/control-system',
-          'version' => '1.2.3',
-          'source' => 'https://npm.hq.nerv.net/control-system/v1.2.3/'\
-            'tarball#fb3801d453467639ef560fc7a61a02bd129bde6d'
-        )
-        expect(scan_report['info']['dependency']).to include(
-          'dependency_file' => 'yarn.lock',
-          'type' => 'node_module',
-          'name' => '@magi-core/prediction',
-          'version' => '0.0.1',
-          'source' => 'https://npm.magi.nerv.net/prediction/v0.0.1/'\
-            'tarball#fb3801d453467639ef5602c7a51a02fd129bbbbd'
-        )
-        expect(scan_report['info']['dependency']).to include(
-          'dependency_file' => 'yarn.lock',
-          'type' => 'node_module',
-          'name' => 'classnames',
-          'version' => '2.2.5',
-          'source' => 'https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz'\
-            '#fb3801d453467649ef3603c7d61a02bd129bde6d'
-        )
-        expect(scan_report['info']['dependency']).to include(
-          'dependency_file' => 'yarn.lock',
-          'type' => 'node_module',
-          'name' => 'mobx',
-          'version' => '3.2.1',
-          'source' => 'https://registry.yarnpkg.com/mobx/-/mobx-3.2.1.tgz'\
-            '#6aeade0120cc3f78baa57195031630a0ae8f13cf'
-        )
-        expect(scan_report['info']['dependency']).to include(
-          'dependency_file' => 'yarn.lock',
-          'type' => 'node_module',
-          'name' => 'eslint-plugin-internal',
-          'version' => '0.0.0',
-          'source' => 'file:./lib/lint-rules'
-        )
-      end
+    it 'should report all deps from yarn.lock, if present' do
+      repo = Salus::Repo.new('spec/fixtures/report_node_modules/yarn_lock')
+      scanner = Salus::Scanners::ReportNodeModules.new(repository: repo, config: {})
+
+      scanner.run
+
+      info = scanner.report.to_h.fetch(:info)
+
+      expect(info[:dependencies]).to match_array(
+        [
+          {
+            dependency_file: 'yarn.lock',
+            type: 'node_module',
+            name: '@nerv-hq/control-system',
+            version: '1.2.3',
+            source: 'https://npm.hq.nerv.net/control-system/v1.2.3/'\
+              'tarball#fb3801d453467639ef560fc7a61a02bd129bde6d'
+          },
+          {
+            dependency_file: 'yarn.lock',
+            type: 'node_module',
+            name: '@magi-core/prediction',
+            version: '0.0.1',
+            source: 'https://npm.magi.nerv.net/prediction/v0.0.1/'\
+              'tarball#fb3801d453467639ef5602c7a51a02fd129bbbbd'
+          },
+          {
+            dependency_file: 'yarn.lock',
+            type: 'node_module',
+            name: 'classnames',
+            version: '2.2.5',
+            source: 'https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz'\
+              '#fb3801d453467649ef3603c7d61a02bd129bde6d'
+          },
+          {
+            dependency_file: 'yarn.lock',
+            type: 'node_module',
+            name: 'mobx',
+            version: '3.2.1',
+            source: 'https://registry.yarnpkg.com/mobx/-/mobx-3.2.1.tgz'\
+              '#6aeade0120cc3f78baa57195031630a0ae8f13cf'
+          },
+          {
+            dependency_file: 'yarn.lock',
+            type: 'node_module',
+            name: 'eslint-plugin-internal',
+            version: '0.0.0',
+            source: 'file:./lib/lint-rules'
+          }
+        ]
+      )
     end
   end
 
@@ -172,11 +165,7 @@ describe Salus::Scanners::ReportNodeModules do
         expect(repo.package_json_present?).to eq(false)
         expect(repo.package_lock_json_present?).to eq(false)
         expect(repo.yarn_lock_present?).to eq(false)
-        scanner = Salus::Scanners::ReportNodeModules.new(
-          repository: repo,
-          report: report,
-          config: blank_config
-        )
+        scanner = Salus::Scanners::ReportNodeModules.new(repository: repo, config: {})
         expect(scanner.should_run?).to eq(false)
       end
     end
@@ -187,11 +176,7 @@ describe Salus::Scanners::ReportNodeModules do
         expect(repo.package_json_present?).to eq(true)
         expect(repo.package_lock_json_present?).to eq(false)
         expect(repo.yarn_lock_present?).to eq(false)
-        scanner = Salus::Scanners::ReportNodeModules.new(
-          repository: repo,
-          report: report,
-          config: blank_config
-        )
+        scanner = Salus::Scanners::ReportNodeModules.new(repository: repo, config: {})
         expect(scanner.should_run?).to eq(true)
       end
     end
@@ -202,11 +187,7 @@ describe Salus::Scanners::ReportNodeModules do
         expect(repo.package_json_present?).to eq(true)
         expect(repo.package_lock_json_present?).to eq(true)
         expect(repo.yarn_lock_present?).to eq(false)
-        scanner = Salus::Scanners::ReportNodeModules.new(
-          repository: repo,
-          report: report,
-          config: blank_config
-        )
+        scanner = Salus::Scanners::ReportNodeModules.new(repository: repo, config: {})
         expect(scanner.should_run?).to eq(true)
       end
     end
@@ -217,11 +198,7 @@ describe Salus::Scanners::ReportNodeModules do
         expect(repo.package_json_present?).to eq(true)
         expect(repo.package_lock_json_present?).to eq(false)
         expect(repo.yarn_lock_present?).to eq(true)
-        scanner = Salus::Scanners::ReportNodeModules.new(
-          repository: repo,
-          report: report,
-          config: blank_config
-        )
+        scanner = Salus::Scanners::ReportNodeModules.new(repository: repo, config: {})
         expect(scanner.should_run?).to eq(true)
       end
     end

--- a/spec/lib/salus/scanners/report_python_modules_spec.rb
+++ b/spec/lib/salus/scanners/report_python_modules_spec.rb
@@ -1,43 +1,49 @@
 require_relative '../../../spec_helper.rb'
 
 describe Salus::Scanners::ReportPythonModules do
-  let(:blank_config) { {} }
-  let(:report) { Salus::Report.new }
-  let(:scan_report) { json_report['scans']['ReportPythonModules'] }
-  let(:dependencies) { scan_report['info']['dependency'] }
-
   describe '#should_run?' do
-    context 'no requirements file present' do
-      it 'should return false' do
-        repo = Salus::Repo.new('spec/fixtures/blank_repository')
-        scanner = Salus::Scanners::ReportPythonModules.new(
-          repository: repo,
-          report: report,
-          config: blank_config
-        )
-        expect(scanner.should_run?).to eq(false)
-      end
+    it 'should return false in the absence of requirements.txt' do
+      repo = Salus::Repo.new('spec/fixtures/blank_repository')
+      scanner = Salus::Scanners::ReportPythonModules.new(repository: repo, config: {})
+      expect(scanner.should_run?).to eq(false)
+    end
+
+    it 'should return true if requirements.txt is present' do
+      repo = Salus::Repo.new('spec/fixtures/python/requirements_unpinned')
+      scanner = Salus::Scanners::ReportPythonModules.new(repository: repo, config: {})
+      expect(scanner.should_run?).to eq(true)
     end
   end
-  describe '#run' do
-    context 'basic requirements.txt' do
-      it 'should report requirements' do
-        repo = Salus::Repo.new('spec/fixtures/python/requirements_unpinned')
-        scanner = Salus::Scanners::ReportPythonModules.new(
-          repository: repo,
-          report: report,
-          config: blank_config
-        )
-        expect(scanner.should_run?).to eq(true)
 
-        scanner.run
-        expect(scan_report).not_to eq(nil), "ERROR: #{JSON.pretty_generate(json_report)}"
+  it 'should report modules from requirements.txt' do
+    repo = Salus::Repo.new('spec/fixtures/python/requirements_unpinned')
+    scanner = Salus::Scanners::ReportPythonModules.new(repository: repo, config: {})
 
-        deps = dependencies.map { |dep| [dep['name'], dep['version']] }
-        expect(deps).to include(%w[requests >=2.5])
-        expect(deps).to include(%w[six >=1.9])
-        expect(deps).to include(%w[pycryptodome >=3.4.11])
-      end
-    end
+    scanner.run
+
+    dependencies = scanner.report.to_h.fetch(:info).fetch(:dependencies)
+
+    expect(dependencies).to match_array(
+      [
+        {
+          dependency_file: 'requirements.txt',
+          name: 'requests',
+          version: '>=2.5',
+          type: 'python_requirement'
+        },
+        {
+          dependency_file: 'requirements.txt',
+          name: 'six',
+          version: '>=1.9',
+          type: 'python_requirement'
+        },
+        {
+          dependency_file: 'requirements.txt',
+          name: 'pycryptodome',
+          version: '>=3.4.11',
+          type: 'python_requirement'
+        }
+      ]
+    )
   end
 end

--- a/spec/lib/salus/scanners/report_ruby_gems_spec.rb
+++ b/spec/lib/salus/scanners/report_ruby_gems_spec.rb
@@ -1,133 +1,86 @@
 require_relative '../../../spec_helper.rb'
 
 describe Salus::Scanners::ReportRubyGems do
-  let(:blank_config) { {} }
-  let(:report) { Salus::Report.new }
-  let(:scan_report) { json_report['scans']['ReportRubyGems'] }
-
   describe '#run' do
-    context 'no Gemfile or Gemfile.lock present' do
-      it 'should throw an error since there is nothing to parse' do
-        scanner = Salus::Scanners::ReportRubyGems.new(
-          repository: Salus::Repo.new('spec/fixtures/blank_repository'),
-          report: report,
-          config: blank_config
-        )
-        expect { scanner.run }.to raise_error(
-          Salus::Scanners::Base::InvalidScannerInvocationError,
-          'Cannot report on Ruby gems without a Gemfile or Gemfile.lock'
-        )
-      end
+    it 'should throw an error in the absence of Gemfile/Gemfile.lock' do
+      repo = Salus::Repo.new('spec/fixtures/blank_repository')
+      scanner = Salus::Scanners::ReportRubyGems.new(repository: repo, config: {})
+
+      expect { scanner.run }.to raise_error(
+        Salus::Scanners::Base::InvalidScannerInvocationError,
+        'Cannot report on Ruby gems without a Gemfile or Gemfile.lock'
+      )
     end
 
-    context 'Gemfile present only' do
-      it 'should report on all the dependencies in the Gemfile' do
-        scanner = Salus::Scanners::ReportRubyGems.new(
-          repository: Salus::Repo.new('spec/fixtures/report_ruby_gems/gemfile_only'),
-          report: report,
-          config: blank_config
-        )
-        scanner.run
-        expect(scan_report['info']['dependency']).to include(
-          'dependency_file' => 'Gemfile', 'type' => 'ruby', 'version' => '2.3.0'
-        )
-        expect(scan_report['info']['dependency']).to include(
-          'dependency_file' => 'Gemfile',
-          'type' => 'gem',
-          'name' => 'kibana_url',
-          'version' => '~> 1.0',
-          'source' => 'https://rubygems.org/'
-        )
-        expect(scan_report['info']['dependency']).to include(
-          'dependency_file' => 'Gemfile',
-          'type' => 'gem',
-          'name' => 'rails',
-          'version' => '>= 0',
-          'source' => 'https://rubygems.org/'
-        )
-        expect(scan_report['info']['dependency']).to include(
-          'dependency_file' => 'Gemfile',
-          'type' => 'gem',
-          'name' => 'master_lock',
-          'version' => '>= 0',
-          'source' => 'git@github.com:coinbase/master_lock.git (at master)'
-        )
-      end
+    it 'should report all the deps in the Gemfile if Gemfile.lock is absent' do
+      repo = Salus::Repo.new('spec/fixtures/report_ruby_gems/gemfile_only')
+      scanner = Salus::Scanners::ReportRubyGems.new(repository: repo, config: {})
+      scanner.run
+
+      info = scanner.report.to_h.fetch(:info)
+
+      expect(info[:ruby_version]).to eq('2.3.0')
+
+      expect(info[:dependencies]).to match_array(
+        [
+          {
+            dependency_file: 'Gemfile',
+            type: 'gem',
+            name: 'kibana_url',
+            version: '~> 1.0',
+            source: 'https://rubygems.org/'
+          },
+          {
+            dependency_file: 'Gemfile',
+            type: 'gem',
+            name: 'rails',
+            version: '>= 0',
+            source: 'https://rubygems.org/'
+          },
+          {
+            dependency_file: 'Gemfile',
+            type: 'gem',
+            name: 'master_lock',
+            version: '>= 0',
+            source: 'git@github.com:coinbase/master_lock.git (at master)'
+          }
+        ]
+      )
     end
 
-    context 'Gemfile present without ruby version' do
-      it 'should report on all the dependencies in the Gemfile' do
-        scanner = Salus::Scanners::ReportRubyGems.new(
-          repository: Salus::Repo.new(
-            'spec/fixtures/report_ruby_gems/gemfile_without_ruby_version'
-          ),
-          report: report,
-          config: blank_config
-        )
-        scanner.run
-        expect(scan_report['info']['dependency']).not_to include(
-          'dependency_file' => 'Gemfile', 'type' => 'ruby', 'version' => '2.3.0'
-        )
-        expect(scan_report['info']['dependency']).to include(
-          'dependency_file' => 'Gemfile',
-          'type' => 'gem',
-          'name' => 'kibana_url',
-          'version' => '~> 1.0',
-          'source' => 'https://rubygems.org/'
-        )
-        expect(scan_report['info']['dependency']).to include(
-          'dependency_file' => 'Gemfile',
-          'type' => 'gem',
-          'name' => 'rails',
-          'version' => '>= 0',
-          'source' => 'https://rubygems.org/'
-        )
-        expect(scan_report['info']['dependency']).to include(
-          'dependency_file' => 'Gemfile',
-          'type' => 'gem',
-          'name' => 'master_lock',
-          'version' => '>= 0',
-          'source' => 'git@github.com:coinbase/master_lock.git (at master)'
-        )
-      end
-    end
+    it 'should report all deps in Gemfile.lock' do
+      repo = Salus::Repo.new('spec/fixtures/report_ruby_gems/lockfile')
+      scanner = Salus::Scanners::ReportRubyGems.new(repository: repo, config: {})
+      scanner.run
 
-    context 'Gemfile and Gemfile.lock present' do
-      it 'should report on all the dependencies in the Gemfile.lock file' do
-        scanner = Salus::Scanners::ReportRubyGems.new(
-          repository: Salus::Repo.new('spec/fixtures/report_ruby_gems/lockfile'),
-          report: report,
-          config: blank_config
-        )
-        scanner.run
-        expect(scan_report['info']['dependency']).to include(
-          'dependency_file' => 'Gemfile', 'type' => 'ruby', 'version' => 'ruby 2.3.0p0'
-        )
-        expect(scan_report['info']['dependency']).to include(
-          'dependency_file' => 'Gemfile', 'type' => 'bundler', 'version' => '1.15.1'
-        )
-        expect(scan_report['info']['dependency']).to include(
-          'dependency_file' => 'Gemfile.lock',
-          'type' => 'gem',
-          'name' => 'actioncable',
-          'version' => '5.1.2',
-          'source' => match(%r{rubygems repository https:\/\/rubygems.org\/})
-        )
-        expect(scan_report['info']['dependency']).to include(
-          'dependency_file' => 'Gemfile.lock',
-          'type' => 'gem',
-          'name' => 'kibana_url',
-          'version' => '1.0.1',
-          'source' => match(%r{rubygems repository https:\/\/rubygems.org\/})
-        )
-        expect(scan_report['info']['dependency']).to include(
-          'dependency_file' => 'Gemfile.lock',
-          'type' => 'gem',
-          'name' => 'master_lock',
-          'version' => '0.9.1',
-          'source' => 'git@github.com:coinbase/master_lock.git (at master@9dfd28d)'
-        )
-      end
+      info = scanner.report.to_h.fetch(:info)
+
+      expect(info[:ruby_version]).to eq('ruby 2.3.0p0')
+      expect(info[:bundler_version]).to eq('1.15.1')
+
+      expected = [
+        {
+          dependency_file: 'Gemfile.lock',
+          type: 'gem',
+          name: 'actioncable',
+          version: '5.1.2',
+          source: match(%r{rubygems repository https:\/\/rubygems.org\/})
+        },
+        {
+          dependency_file: 'Gemfile.lock',
+          type: 'gem',
+          name: 'kibana_url',
+          version: '1.0.1',
+          source: match(%r{rubygems repository https:\/\/rubygems.org\/})
+        },
+        dependency_file: 'Gemfile.lock',
+        type: 'gem',
+        name: 'master_lock',
+        version: '0.9.1',
+        source: 'git@github.com:coinbase/master_lock.git (at master@9dfd28d)'
+      ]
+
+      expect(info[:dependencies]).to include(*expected)
     end
   end
 
@@ -137,11 +90,7 @@ describe Salus::Scanners::ReportRubyGems do
         repo = Salus::Repo.new('spec/fixtures/blank_repository')
         expect(repo.gemfile_present?).to eq(false)
         expect(repo.gemfile_lock_present?).to eq(false)
-        scanner = Salus::Scanners::ReportRubyGems.new(
-          repository: repo,
-          report: report,
-          config: blank_config
-        )
+        scanner = Salus::Scanners::ReportRubyGems.new(repository: repo, config: {})
         expect(scanner.should_run?).to eq(false)
       end
     end
@@ -151,11 +100,7 @@ describe Salus::Scanners::ReportRubyGems do
         repo = Salus::Repo.new('spec/fixtures/report_ruby_gems/gemfile_only')
         expect(repo.gemfile_present?).to eq(true)
         expect(repo.gemfile_lock_present?).to eq(false)
-        scanner = Salus::Scanners::ReportRubyGems.new(
-          repository: repo,
-          report: report,
-          config: blank_config
-        )
+        scanner = Salus::Scanners::ReportRubyGems.new(repository: repo, config: {})
         expect(scanner.should_run?).to eq(true)
       end
     end
@@ -164,11 +109,7 @@ describe Salus::Scanners::ReportRubyGems do
       it 'should return true' do
         repo = Salus::Repo.new('spec/fixtures/report_ruby_gems/lockfile')
         expect(repo.gemfile_lock_present?).to eq(true)
-        scanner = Salus::Scanners::ReportRubyGems.new(
-          repository: repo,
-          report: report,
-          config: blank_config
-        )
+        scanner = Salus::Scanners::ReportRubyGems.new(repository: repo, config: {})
         expect(scanner.should_run?).to eq(true)
       end
     end

--- a/spec/lib/salus_spec.rb
+++ b/spec/lib/salus_spec.rb
@@ -13,7 +13,7 @@ describe Salus::CLI do
       it 'runs without error' do
         # there is a Salus::Processor::DEFAULT_PATH folder here for testing
         Dir.chdir('spec/fixtures/salus/success') do
-          expect(Salus.scan).to eq(Salus::EXIT_SUCCESS)
+          expect(Salus.scan(quiet: true)).to eq(Salus::EXIT_SUCCESS)
         end
       end
     end
@@ -22,7 +22,7 @@ describe Salus::CLI do
       it 'runs and exits failure since the overall scan failed' do
         Dir.chdir('spec/fixtures/salus/failure') do
           # This should hit the local config file which enforces a failing pattern search.
-          expect(Salus.scan).to eq(Salus::EXIT_FAILURE)
+          expect(Salus.scan(quiet: true)).to eq(Salus::EXIT_FAILURE)
         end
       end
     end
@@ -31,43 +31,17 @@ describe Salus::CLI do
       it 'runs and exits failure since the overall scan failed' do
         Dir.chdir('spec/fixtures/salus/success') do
           expect(
-            Salus.scan(config: 'file:///failure_salus.yaml')
+            Salus.scan(config: 'file:///failure_salus.yaml', quiet: true)
           ).to eq(Salus::EXIT_FAILURE)
         end
       end
     end
 
     context 'with configuration envars' do
-      it 'runs and exits failure since the overall scan failer' do
+      it 'runs and exits failure since the overall scan failed' do
         Dir.chdir('spec/fixtures/salus/success') do
           ENV['SALUS_CONFIGURATION'] = 'file:///failure_salus.yaml'
-          expect(Salus.scan).to eq(Salus::EXIT_FAILURE)
-        end
-      end
-    end
-
-    context 'with configuration envars' do
-      it 'runs and exits failure since the overall scan failer' do
-        Dir.chdir('spec/fixtures/salus/success') do
-          expect { Salus.scan(quiet: false) }.to output.to_stdout
-          expect { Salus.scan(quiet: true) }.not_to output.to_stdout
-        end
-      end
-    end
-
-    context 'with configuration envars' do
-      it 'runs and exits failure since the overall scan failed' do
-        Dir.chdir('spec/fixtures/salus/verbose') do
-          # This is in the info column of ReportRubyGems scanner row.
-          info_regex = /INFO - dependency/
-
-          ENV['SALUS_CONFIGURATION'] = 'file:///salus.yaml'
-
-          # Check default which is verbose: false.
-          expect { Salus.scan }.not_to output(info_regex).to_stdout
-
-          # Check that verbose: true gives use info output.
-          expect { Salus.scan(verbose: true) }.to output(info_regex).to_stdout
+          expect(Salus.scan(quiet: true)).to eq(Salus::EXIT_FAILURE)
         end
       end
     end

--- a/spec/support.rb
+++ b/spec/support.rb
@@ -1,8 +1,3 @@
-# Useful for testing scanner objects.
-def json_report
-  JSON.parse(report.to_json)
-end
-
 def remove_file(file_path)
   File.delete(file_path) if File.exist?(file_path)
 end


### PR DESCRIPTION
Rather than stick everything in a big top-level hash that lives in Report, let's use a ScanReport class to record the results of a single scan. I think this gives us a better separation of concerns overall (a scanner exists independent of the entire suite) and should make it a bit easier to improve the logging story going forward.

A Report collects ScanReports (via `#add_scan_report`); `Report#to_s` calls `ScanReport#to_s` (likewise for `to_h`). `to_h` is (basically) backwards-compatible with the old version.

Some other miscellaneous changes:
- Before, calling `report_error` from a scanner would append the error to the global Salus error hash - it was associated with the scanner only by name, and not in any sort of structural way. Now, ScanReports have their own error hash and `report_error` routes errors there
- In the case that a scanner raises (and fails to handle) an exception, that error is appended both to the ScanReport's error hash and to the global error hash (because it's probably a bug)
- Before, per-scan info data were necessarily arrays, and calling `info` multiple times from a scanner with the same key would append to the same array. Now they're just scalars (`info(key, value) => @info[key] = value`)

Most of this diff is specs 😁 