### PR TITLE
Deep Merge of Salus Config

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,7 +22,7 @@ A third method of providing configuration URIs is via the environment variable `
 
 ### Cascading Configurations
 
-When using a global configuration provided over HTTP, you might still want to modify Salus for special cases relevant only to the repository being scanned. To do this, you can append multiple configuration files by listing the configuration URIs in order of ascending precedence. Each top level directive will be overwritten by the directive present in later files. A space (`" "`) is used to delimit each URI.
+When using a global configuration provided over HTTP, you might still want to modify Salus for special cases relevant only to the repository being scanned. To do this, you can append multiple configuration files by listing the configuration URIs in order of ascending precedence. The hash represented by the YAML is deep merged with the next one. This means that keys are preserved but values are overwritten unless the value is also a Hash, in which case the algorithm recurses. A space (`" "`) is used to delimit each URI.
 
 ```sh
 docker run             \

--- a/lib/salus/config.rb
+++ b/lib/salus/config.rb
@@ -39,7 +39,7 @@ module Salus
       # The later files in the array take superiority by overwriting configuration already
       # defined in the earlier files in the array (DEFAULT_CONFIG is the first such file/object).
       final_config = DEFAULT_CONFIG.dup
-      configuration_files.each { |file| final_config.merge!(YAML.safe_load(file)) }
+      configuration_files.each { |file| final_config.deep_merge!(YAML.safe_load(file)) }
 
       # Check if any of the values are actually pointing to envars.
       final_config = fetch_envars(final_config)

--- a/spec/fixtures/config/salus.yaml
+++ b/spec/fixtures/config/salus.yaml
@@ -2,3 +2,9 @@
 enforced_scanners:
   - BundleAudit
   - Brakeman
+
+scanner_configs:
+  BundleAudit:
+    ignore:
+      - CVE-AAAA-BBBB
+      - CVE-XXXX-YYYY

--- a/spec/fixtures/config/salus_extra.yaml
+++ b/spec/fixtures/config/salus_extra.yaml
@@ -2,3 +2,7 @@
 enforced_scanners:
   - BundleAudit
   - ExtraScanner
+
+scanner_configs:
+  BundleAudit:
+    failure_message: 'Please upgrade the failing dependency.'

--- a/spec/lib/salus/config_spec.rb
+++ b/spec/lib/salus/config_spec.rb
@@ -67,6 +67,14 @@ describe Salus::Config do
         )
       end
     end
+
+    it 'should deep merge config files' do
+      config = Salus::Config.new([config_file_1, config_file_2])
+      expect(config.scanner_configs['BundleAudit']).to eq(
+        'ignore' => ['CVE-AAAA-BBBB', 'CVE-XXXX-YYYY'],
+        'failure_message' => 'Please upgrade the failing dependency.'
+      )
+    end
   end
 
   describe '#scanner_active?' do


### PR DESCRIPTION
It's more useful to deep merge configuration files when they are
concatenated so that local configuration of a scanner (or other
directives) does not overwrite all global configuration about a
particular directive.

This is particularly important for an upcoming PR on custom failure
messages per scanner.