### PR TITLE
Allow for custom failure messages for each scanner

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -87,7 +87,7 @@ scanner_configs:
       - CVE-XXXX-YYYY # irrelevant CVE which does not have a patch yet
 ```
 
-Special configuration that exist for particular scanners is defined in the [scanners directory](/scanners).
+Special configuration that exist for particular scanners is defined in the [scanners directory](/docs/scanners).
 
 ## Envar Interpolation
 

--- a/docs/scanners/base.md
+++ b/docs/scanners/base.md
@@ -1,3 +1,22 @@
 # `Salus::Scanners::Base`
 
 The parent class of all scanners. Contains methods useful for executing scanners and reporting results.
+
+## Config global to all scanners
+
+##### Custom Failure Messages
+
+You can define a custom message to be shown to the developer when the given scanner fails. This is useful for pointing developers to internal security resources or teams that can help address the failure.
+
+Example with `BundleAudit` configuration:
+
+```yaml
+scanner_configs:
+  BundleAudit:
+    failure_message: |
+      A CVE was found in one of your gems. Please try to upgrade the offending gem.
+        $ bundle update <gem name>
+
+      If this does not resolve the error, seek advice from the security team.
+      Slack channel: #security
+```

--- a/lib/salus/scan_report.rb
+++ b/lib/salus/scan_report.rb
@@ -7,13 +7,14 @@ module Salus
 
     attr_reader :scanner_name, :running_time
 
-    def initialize(scanner_name)
+    def initialize(scanner_name, custom_failure_message: nil)
       @scanner_name = scanner_name
       @passed = nil
       @running_time = nil
       @logs = nil
       @info = {}
       @errors = []
+      @custom_failure_message = custom_failure_message
     end
 
     def record
@@ -99,6 +100,11 @@ module Salus
       if !@errors.empty?
         stringified_errors = indent(wrapify(JSON.pretty_generate(@errors), indented_wrap))
         output += "\n\n ~~ Errors:\n\n#{stringified_errors}".chomp
+      end
+
+      if !@custom_failure_message.blank? && !passed?
+        failure_message = indent(wrapify(@custom_failure_message, indented_wrap))
+        output += "\n\n#{failure_message}".chomp
       end
 
       output

--- a/lib/salus/scanners/base.rb
+++ b/lib/salus/scanners/base.rb
@@ -12,8 +12,11 @@ module Salus::Scanners
 
     def initialize(repository:, config:)
       @repository = repository
-      @report = Salus::ScanReport.new(name)
       @config = config
+      @report = Salus::ScanReport.new(
+        name,
+        custom_failure_message: @config['failure_message']
+      )
     end
 
     def name

--- a/spec/lib/salus/scan_report_spec.rb
+++ b/spec/lib/salus/scan_report_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe Salus::ScanReport do
+  describe '#to_s' do
+    let(:scanner_name) { 'T3 Check' }
+    let(:failure_message) { 'Please use MAGI to fix' }
+    let(:report) { Salus::ScanReport.new(scanner_name, custom_failure_message: failure_message) }
+    let(:log_string) { 'Checking underground bunkers.' }
+    let(:info_type) { 'LockStatus' }
+    let(:info_value) { 'Locked' }
+    let(:error_hash) { { 'Error' => 'Could not check all sectors' } }
+    let(:string_report) { report.to_s(verbose: false, wrap: 100, use_colors: false) }
+
+    before do
+      report.fail
+      report.log(log_string)
+      report.info(info_type, info_value)
+      report.error(error_hash)
+    end
+
+    context 'not verbose' do
+      it 'includes all relevant improtant in string form' do
+        expect(string_report).to include('FAILED')
+        expect(string_report).to include(log_string)
+        expect(string_report).to include(error_hash['Error'])
+        expect(string_report).to include(failure_message)
+        expect(string_report).not_to include(info_value)
+      end
+    end
+
+    context 'not verbose' do
+      let(:string_report) { report.to_s(verbose: true, wrap: 100, use_colors: false) }
+
+      it 'includes all relevant improtant in string form' do
+        expect(string_report).to include(info_value)
+      end
+    end
+  end
+end


### PR DESCRIPTION
When certain scanners fail, it can be useful to give developers some
custom advice and resources to help them self-service their fix.

To facilitate this in a general way, we implement a method of rendering
a failure message that comes from Salus configuration.