### PR TITLE
Scanners with raise do not fail builds

### DIFF
--- a/lib/salus/scanners/base.rb
+++ b/lib/salus/scanners/base.rb
@@ -51,9 +51,22 @@ module Salus::Scanners
           backtrace: exception.backtrace.take(5)
         }
 
-        @report.error(error_data)
-        @report.fail
+        # There is a philosophical decision to be made here.
+        # When a scanner throws an exception, do we fail it or not?
+        # If a required scanner raised, the entire Salus run fail, and if that
+        # was in a CI pipeline, then the project tests/build would also fail.
+        #
+        # This should probably be a configurable setting but for now, we will default
+        # to passing the scanner so that we do not disrupt build pipelines when a scanner
+        # fails (which could be because of a scanner bug, a CVE registry going down etc).
+        #
+        # Instead, the consumer of the Salus report should be monitoring for errors and
+        # addressing them when they come up. If this was configurable it would allow the user
+        # of Salus to choose if a scanner which raised should be considered failed or not.
+        @report.pass
 
+        # Record the error so that the Salus report captures the issue.
+        @report.error(error_data)
         salus_report.error(error_data)
 
         raise if reraise

--- a/spec/lib/salus/scanners/base_spec.rb
+++ b/spec/lib/salus/scanners/base_spec.rb
@@ -4,6 +4,31 @@ describe Salus::Scanners::Base do
   let(:repository) { Salus::Repo.new('spec/fixtures/ruby_gem') }
   let(:scanner) { Salus::Scanners::Base.new(repository: repository, config: {}) }
 
+  describe 'run!' do
+    it 'should catch exceptions from scanners and record the error' do
+      salus_report = Salus::Report.new
+      scanner = Salus::Scanners::BundleAudit.new(repository: repository, config: {})
+      allow(scanner).to receive(:run).and_raise(RuntimeError, 'bundle audit failed')
+
+      expect do
+        scanner.run!(
+          salus_report: salus_report,
+          required: true,
+          reraise: false
+        )
+      end.not_to raise_error
+      expect(salus_report.passed?).to eq(true)
+
+      salus_errors = salus_report.to_h[:errors]
+      scanner_errors = salus_report.to_h[:scans]['BundleAudit'][:errors]
+      expect(salus_errors).to eq(scanner_errors)
+      expect(salus_errors.first).to include(
+        message: 'Unhandled exception running BundleAudit: RuntimeError: bundle audit failed',
+        error_class: RuntimeError
+      )
+    end
+  end
+
   describe '#run' do
     it 'should raise an exception since this is an abstract function' do
       expect { scanner.run }.to raise_error(NoMethodError)


### PR DESCRIPTION
Scanners can fail for many reasons. There might be a bug in the scanner
or, a registry that it might rely on, such as a CVE database, might be
down. This would result in the scanner raising, and if the scanner is
required, Salus would then also fail.

This means that build pipelines might be heavily disrupted by external
dependencies which is not good. Furthermore, as we add more and more
scanners, the probability of this rises.

The status quo is that if a scanner raises, it counts as the scanner not
passing (as if it found an issue). Instead, we will count the scanner as
passed but still record the error. The build will pass overall and the
consumer of a Salus report can track the error.

This is probably a good setting to make configurable to the user and so
a future PR should allow for this to be toggled from Salus config files.

We add a test for this functionality which also adds a test for the
recording of errors to the Salus/Scan reports when a scanner raises.