### PR TITLE
Ensure NodeAudit config applied to descendants

### DIFF
--- a/lib/salus/config.rb
+++ b/lib/salus/config.rb
@@ -82,9 +82,14 @@ module Salus
       # We will remap any NPMAudit and YarnAudit scanner connfigs to NodeAudit.
       return if %w[NodeAudit NPMAudit YarnAudit].map { |k| @scanner_configs.key?(k) }.none?
 
+      # Make a fully merged config hash for NodeAudit.
       @scanner_configs['NodeAudit'] ||= {}
       @scanner_configs['NodeAudit'].deep_merge!(@scanner_configs['NPMAudit'] || {})
       @scanner_configs['NodeAudit'].deep_merge!(@scanner_configs['YarnAudit'] || {})
+
+      # Copy over the config to the relevant scanners to ensure they all inherit it.
+      @scanner_configs['NPMAudit'] = @scanner_configs['NodeAudit']
+      @scanner_configs['YarnAudit'] = @scanner_configs['NodeAudit']
     end
 
     def fetch_envars(config_hash)

--- a/spec/lib/salus/config_spec.rb
+++ b/spec/lib/salus/config_spec.rb
@@ -81,12 +81,16 @@ describe Salus::Config do
       npm_audit_config = File.read('spec/fixtures/config/npm_audit_config.yaml')
       config = Salus::Config.new([node_audit_config, npm_audit_config])
 
-      expect(config.scanner_configs['NodeAudit']).to eq(
+      expected_config = {
         'foo' => 'bar',    # from NodeAudit config
         'exceptions' => [  # from NPMAudit config
           { 'advisory_id' => '12', 'changed_by' => 'appsec team', 'notes' => 'barfoo' }
         ]
-      )
+      }
+
+      expect(config.scanner_configs['NodeAudit']).to eq(expected_config)
+      expect(config.scanner_configs['NPMAudit']).to eq(expected_config)
+      expect(config.scanner_configs['YarnAudit']).to eq(expected_config)
     end
   end
 


### PR DESCRIPTION
In a previous PR we merged all NodeAudit related configs together, but
we did not then apply this config to all the related scanners. This
meant that subclasses of NodeAudit did not necessarily have the
configuration they should have. Simple change to ensure this happens.