### PR TITLE
Show INFO for failed scanners

### DIFF
--- a/lib/salus/scan_report.rb
+++ b/lib/salus/scan_report.rb
@@ -92,7 +92,7 @@ module Salus
         output += "\n\n ~~ Scanner Logs:\n\n#{logs.chomp}"
       end
 
-      if !@info.empty? && verbose
+      if !@info.empty? && (verbose || !passed?)
         stringified_info = indent(wrapify(JSON.pretty_generate(@info), indented_wrap))
         output += "\n\n ~~ Metadata:\n\n#{stringified_info}".chomp
       end

--- a/spec/lib/salus/scan_report_spec.rb
+++ b/spec/lib/salus/scan_report_spec.rb
@@ -10,21 +10,41 @@ describe Salus::ScanReport do
     let(:info_value) { 'Locked' }
     let(:error_hash) { { 'Error' => 'Could not check all sectors' } }
     let(:string_report) { report.to_s(verbose: false, wrap: 100, use_colors: false) }
+    let(:verbose_string_report) { report.to_s(verbose: true, wrap: 100, use_colors: false) }
 
     before do
-      report.fail
+      report.pass
       report.log(log_string)
       report.info(info_type, info_value)
-      report.error(error_hash)
     end
 
-    context 'not verbose' do
+    context 'not verbose and passed' do
       it 'includes all relevant improtant in string form' do
+        expect(string_report).to include('PASSED')
+        expect(string_report).not_to include(log_string)
+        expect(string_report).not_to include(failure_message)
+        expect(string_report).not_to include(info_value)
+      end
+    end
+
+    context 'not verbose and failed' do
+      it 'includes all relevant improtant in string form' do
+        report.fail
+        report.error(error_hash)
         expect(string_report).to include('FAILED')
         expect(string_report).to include(log_string)
+        expect(string_report).to include(info_value)
         expect(string_report).to include(error_hash['Error'])
         expect(string_report).to include(failure_message)
-        expect(string_report).not_to include(info_value)
+      end
+    end
+
+    context 'verbose and passed' do
+      it 'includes all relevant improtant in string form' do
+        expect(verbose_string_report).to include('PASSED')
+        expect(verbose_string_report).to include(log_string)
+        expect(verbose_string_report).to include(info_value)
+        expect(verbose_string_report).not_to include(failure_message)
       end
     end
 


### PR DESCRIPTION
If a scanner does not pass, show the captured info because this will have useful error messages to help the developer fix the issue.