### PR TITLE
Use Logs for Dev, Info for Reports

### DIFF
--- a/docs/custom_salus.md
+++ b/docs/custom_salus.md
@@ -13,7 +13,8 @@ __Available Methods:__
 - `#run_shell(command, env: {}, stdin_data: '')` - used to run shell commands in the container, useful for executing a scanner.
 - `#report_success` - adds to the report the fact that this scan was successful (found no vulnerabilities).
 - `#report_failure` - adds to the report the fact that this scan was unsuccessful (found a vulnerability).
-- `#report_info(type, message)` - adds data to the report that is useful to track.
+- `#log`- adds data to the report and is shown in normal (not verbose) mode. This method should be used to show the developer information that they can act on to fix any security issues found from the scan.
+- `#report_info(type, message)` - adds data to the report and is only shown to the developer in verbose mode. This method is primarily used for information that will be parsed by a Salus report consumer.
 - `#report_stdout(stdout)` - adds the STDOUT of the scanner to the report.
 - `#report_stderr(stderr)` - adds the STDERR of the scanner to the report.
 - `#report_error(error_data)` - adds an error encountered while scanning to the report.

--- a/docs/scanners/pattern_search.md
+++ b/docs/scanners/pattern_search.md
@@ -21,6 +21,6 @@ scanner_configs:
         message: All repos must contain a documented threat model.
         required: true
         exclude_extension:
-          - .rb
-          - .js
+          - rb
+          - js
 ```

--- a/lib/salus/scan_report.rb
+++ b/lib/salus/scan_report.rb
@@ -92,7 +92,7 @@ module Salus
         output += "\n\n ~~ Scanner Logs:\n\n#{logs.chomp}"
       end
 
-      if !@info.empty? && (verbose || !passed?)
+      if !@info.empty? && verbose
         stringified_info = indent(wrapify(JSON.pretty_generate(@info), indented_wrap))
         output += "\n\n ~~ Metadata:\n\n#{stringified_info}".chomp
       end

--- a/lib/salus/scanners/brakeman.rb
+++ b/lib/salus/scanners/brakeman.rb
@@ -27,7 +27,7 @@ module Salus::Scanners
         if shell_return.status == 3
           report_failure
           report_stdout(shell_return.stdout)
-          report_info(:brakeman_report, JSON.parse(shell_return.stdout, symbolize_names: true))
+          log(shell_return.stdout)
         else
           report_error(
             "brakeman exited with an unexpected exit status",

--- a/lib/salus/scanners/bundle_audit.rb
+++ b/lib/salus/scanners/bundle_audit.rb
@@ -19,7 +19,14 @@ module Salus::Scanners
       scanner = Bundler::Audit::Scanner.new(@repository.path_to_repo)
 
       vulns = []
-      scanner.scan(ignore: ignore) { |result| vulns.push(serialize_vuln(result)) }
+      scanner.scan(ignore: ignore) do |result|
+        hash = serialize_vuln(result)
+        vulns.push(hash)
+
+        # TODO: we should tabulate these vulnerabilities in the same way
+        # that we tabulate CVEs for Node packages - see NodeAudit scanner.
+        log(JSON.pretty_generate(hash))
+      end
 
       report_info(:ignored_cves, ignore)
       report_info(:vulnerabilities, vulns)

--- a/lib/salus/scanners/npm_audit.rb
+++ b/lib/salus/scanners/npm_audit.rb
@@ -30,7 +30,7 @@ module Salus::Scanners
         raise message
       end
 
-      report_info(:npm_audit_output, json)
+      report_stdout(json)
 
       json.fetch(:advisories).values
     end

--- a/lib/salus/scanners/pattern_search.rb
+++ b/lib/salus/scanners/pattern_search.rb
@@ -93,9 +93,13 @@ module Salus::Scanners
 
       report_info(:hits, all_hits)
       errors.each { |error| report_error('Call to sift failed', error) }
-      report_info(:failure_messages, failure_messages)
 
-      failure_messages.empty? ? report_success : report_failure
+      if failure_messages.empty?
+        report_success
+      else
+        report_failure
+        failure_messages.each { |message| log(message) }
+      end
     end
 
     def should_run?

--- a/lib/salus/scanners/yarn_audit.rb
+++ b/lib/salus/scanners/yarn_audit.rb
@@ -31,7 +31,7 @@ module Salus::Scanners
         raise error_lines.join("\n")
       end
 
-      report_info(:yarn_audit_output, command_output.stdout)
+      report_stdout(command_output.stdout)
 
       command_output.stdout.split("\n")[0..-2].map do |raw_advisory|
         advisory_hash = JSON.parse(raw_advisory, symbolize_names: true)

--- a/spec/fixtures/docker/expected_report.json
+++ b/spec/fixtures/docker/expected_report.json
@@ -16,9 +16,6 @@
             "msg": "",
             "hit": "README.md:1:# placeholder"
           }
-        ],
-        "failure_messages": [
-
         ]
       },
       "errors": [

--- a/spec/fixtures/processor/local_uri/expected_report.json
+++ b/spec/fixtures/processor/local_uri/expected_report.json
@@ -10,9 +10,6 @@
       "info": {
         "hits": [
 
-        ],
-        "failure_messages": [
-
         ]
       },
       "errors": [

--- a/spec/fixtures/processor/remote_uri/expected_report.json
+++ b/spec/fixtures/processor/remote_uri/expected_report.json
@@ -10,9 +10,6 @@
       "info": {
         "hits": [
 
-        ],
-        "failure_messages": [
-
         ]
       },
       "errors": [

--- a/spec/lib/salus/scan_report_spec.rb
+++ b/spec/lib/salus/scan_report_spec.rb
@@ -33,9 +33,9 @@ describe Salus::ScanReport do
         report.error(error_hash)
         expect(string_report).to include('FAILED')
         expect(string_report).to include(log_string)
-        expect(string_report).to include(info_value)
         expect(string_report).to include(error_hash['Error'])
         expect(string_report).to include(failure_message)
+        expect(string_report).not_to include(info_value)
       end
     end
 

--- a/spec/lib/salus/scanners/brakeman_spec.rb
+++ b/spec/lib/salus/scanners/brakeman_spec.rb
@@ -28,10 +28,11 @@ describe Salus::Scanners::Brakeman do
         expect(scanner.report.passed?).to eq(false)
 
         info = scanner.report.to_h.fetch(:info)
+        logs = scanner.report.to_h.fetch(:logs)
 
-        expect(info[:stdout]).not_to eq(nil)
-        expect(info[:stdout]).not_to eq("")
-        expect(info[:brakeman_report][:warnings][0][:warning_type]).to eq('Dangerous Eval')
+        expect(info[:stdout]).not_to be_nil
+        expect(info[:stdout]).not_to be_empty
+        expect(logs).to include('Dangerous Eval')
       end
     end
   end

--- a/spec/lib/salus/scanners/node_audit_spec.rb
+++ b/spec/lib/salus/scanners/node_audit_spec.rb
@@ -23,7 +23,7 @@ describe Salus::Scanners::NodeAudit do
 
           expect(scanner.report.passed?).to eq(false)
           info = scanner.report.to_h.fetch(:info)
-          expect(info.key?("#{klass_snake_str}_output".to_sym)).to eq(true)
+          expect(info.key?(:stdout)).to eq(true)
           expect(info).to include(
             prod_advisories: %w[39 48],
             dev_advisories: [],
@@ -44,7 +44,7 @@ describe Salus::Scanners::NodeAudit do
           expect(scanner.report.passed?).to eq(true)
 
           info = scanner.report.to_h.fetch(:info)
-          expect(info.key?("#{klass_snake_str}_output".to_sym)).to eq(true)
+          expect(info.key?(:stdout)).to eq(true)
           expect(info).to include(
             prod_advisories: [],
             dev_advisories: [],
@@ -66,7 +66,7 @@ describe Salus::Scanners::NodeAudit do
 
           expect(scanner.report.passed?).to eq(true)
           info = scanner.report.to_h.fetch(:info)
-          expect(info.key?("#{klass_snake_str}_output".to_sym)).to eq(true)
+          expect(info.key?(:stdout)).to eq(true)
           expect(info).to include(
             prod_advisories: %w[39 48],
             dev_advisories: [],

--- a/spec/lib/salus/scanners/pattern_search_spec.rb
+++ b/spec/lib/salus/scanners/pattern_search_spec.rb
@@ -134,8 +134,7 @@ describe Salus::Scanners::PatternSearch do
 
         expect(scanner.report.passed?).to eq(false)
 
-        failure_messages = scanner.report.to_h.fetch(:info).fetch(:failure_messages)
-
+        failure_messages = scanner.report.to_h.fetch(:logs)
         expect(failure_messages)
           .to include('Required pattern "Tokyo3" was not found - current location')
       end


### PR DESCRIPTION
Previously, for a failed scanner, info data was presented to the
developer. This often has raw STDOUT from a scanner and other
information which makes the output that the developer needs to parse
very large and unreadable.

Instead we will use `log()` for all dev friendly output and it will be
output whenever a scanner fails. `info()` will be reserved for Salus
report consumers and verbose mode.