### PR TITLE
Upgrade Yarn 1.12.1 --> 1.12.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ ENV LC_ALL C.UTF-8
 # Using node version 8.12.0 since it's the latest LTS.
 ENV NODE_VERSION 8.12.0
 ENV NPM_VERSION 6.4.1
-ENV YARN_VERSION 1.12.1
+ENV YARN_VERSION 1.12.3
 ENV NPM_CONFIG_LOGLEVEL info
 
 # Downloaded from https://nodejs.org/en/download/

--- a/lib/salus.rb
+++ b/lib/salus.rb
@@ -19,7 +19,7 @@ require 'salus/config'
 require 'salus/processor'
 
 module Salus
-  VERSION = '2.0.0'.freeze
+  VERSION = '2.1.0'.freeze
   DEFAULT_REPO_PATH = './repo'.freeze # This is inside the docker container at /home/repo.
 
   SafeYAML::OPTIONS[:default_mode] = :safe

--- a/spec/fixtures/docker/expected_report.json
+++ b/spec/fixtures/docker/expected_report.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.0",
+  "version": "2.1.0",
   "passed": true,
   "running_time": 0.0,
   "scans": {

--- a/spec/fixtures/processor/local_uri/expected_report.json
+++ b/spec/fixtures/processor/local_uri/expected_report.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.0",
+  "version": "2.1.0",
   "passed": true,
   "running_time": 0.0,
   "scans": {

--- a/spec/fixtures/processor/remote_uri/expected_report.json
+++ b/spec/fixtures/processor/remote_uri/expected_report.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.0",
+  "version": "2.1.0",
   "passed": true,
   "running_time": 0.0,
   "scans": {

--- a/spec/lib/salus/processor_spec.rb
+++ b/spec/lib/salus/processor_spec.rb
@@ -91,7 +91,7 @@ describe Salus::Processor do
 
       expect(report_hsh[:project_name]).to eq('EVA-01')
       expect(report_hsh[:custom_info]).to eq('Purple unit')
-      expect(report_hsh[:version]).to eq('2.0.0')
+      expect(report_hsh[:version]).to eq('2.1.0')
       expect(report_hsh[:passed]).to eq(false)
       expect(report_hsh[:errors]).to eq([])
 


### PR DESCRIPTION
This finally includes the patch for [Yarn issue 6607](https://github.com/yarnpkg/yarn/issues/6607) which was breaking lots of scans (including the current Salus scan on this PR).