### PR TITLE
Add get upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ruby:2.4.5@sha256:dd40c9f70dd028d0df8c7f7fa636daf2fc7ac1f4919562b68c60691b99714e05
 MAINTAINER security@coinbase.com
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get upgrade -y --no-install-recommends && apt-get install -y --no-install-recommends \
     g++ \
     gcc \
     libc6-dev \

--- a/lib/salus.rb
+++ b/lib/salus.rb
@@ -19,7 +19,7 @@ require 'salus/config'
 require 'salus/processor'
 
 module Salus
-  VERSION = '2.3.1'.freeze
+  VERSION = '2.3.2'.freeze
   DEFAULT_REPO_PATH = './repo'.freeze # This is inside the docker container at /home/repo.
 
   SafeYAML::OPTIONS[:default_mode] = :safe

--- a/spec/fixtures/processor/local_uri/expected_report.json
+++ b/spec/fixtures/processor/local_uri/expected_report.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.3.1",
+  "version": "2.3.2",
   "passed": true,
   "running_time": 0.0,
   "scans": {

--- a/spec/fixtures/processor/remote_uri/expected_report.json
+++ b/spec/fixtures/processor/remote_uri/expected_report.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.3.1",
+  "version": "2.3.2",
   "passed": true,
   "running_time": 0.0,
   "scans": {


### PR DESCRIPTION
adding `apt-get upgrade` to rebuild image to [apt 1.4.9](https://metadata.ftp-master.debian.org/changelogs//main/a/apt/apt_1.4.9_changelog) which includes the patch for CVE‌-2019-3462. 

Here is the diff: 

```
$ diff \
> <(docker run --entrypoint="" coinbase/salus:2.3.1@sha256:0ec9deac2d06a61e361392322176c41c1f27d05aa0a81f23d2696c597460297f dpkg -l | awk '{print $2 , $3 "\n"}') \
> <(docker run --entrypoint="" salus-local dpkg -l | awk '{print $2 , $3 "\n"}')
13c13
< apt 1.4.8
---
> apt 1.4.9
21c21
< base-files 9.9+deb9u6
---
> base-files 9.9+deb9u7
147c147
< libapt-pkg5.0:amd64 1.4.8
---
> libapt-pkg5.0:amd64 1.4.9
611c611
< libsystemd0:amd64 232-25+deb9u6
---
> libsystemd0:amd64 232-25+deb9u8
635c635
< libudev1:amd64 232-25+deb9u6
---
> libudev1:amd64 232-25+deb9u8
823c823
< tzdata 2018g-0+deb9u1
---
> tzdata 2018i-0+deb9u1
```