### PR TITLE
[chore] remove spurious check on return value from yarn audit scanner

### DIFF
--- a/lib/salus/scanners/yarn_audit.rb
+++ b/lib/salus/scanners/yarn_audit.rb
@@ -21,16 +21,6 @@ module Salus::Scanners
       # We must also pluck out only the standard advisory hashes.
       command_output = run_shell(AUDIT_COMMAND)
 
-      if command_output.status == 1
-        error_lines = []
-        error_lines << "#{AUDIT_COMMAND} failed."
-        error_lines << "Exit status: #{command_output.status}"
-        error_lines << "STDOUT: #{command_output.stdout}"
-        error_lines << "STDERR: #{command_output.stderr}"
-
-        raise error_lines.join("\n")
-      end
-
       report_stdout(command_output.stdout)
 
       command_output.stdout.split("\n")[0..-2].map do |raw_advisory|


### PR DESCRIPTION
See title. This check never did what was intended; the exit code of yarn audit can be several different values for a successful run (https://github.com/yarnpkg/yarn/blob/master/src/cli/commands/audit.js#L141-L146) none of which are semantically meaningful for our purposes.