### PR TITLE
Patternmatch config option for including extension

### DIFF
--- a/docs/scanners/pattern_search.md
+++ b/docs/scanners/pattern_search.md
@@ -2,6 +2,8 @@
 
 This scanner can flag anti-patterns found in a codebase or require that certain strings be present. This might be useful for preventing the use of dangerous methods like `eval()` in Ruby (which might allow for RCE) or `dangerouslySetInnerHTML` in React (which might allow for XSS). By default, all found patterns are added to the info section of the report. If a found pattern is forbidden, this scanner will fail and the `message` will be show to the developer in the report to give additional context on why this was an issue. A `required` pattern must be found in order for the scan to pass.
 
+The scanner also allows options `exclude_extension` and `include_extension` for excluding and including file extensions, respectively. These options can be set globally and per-match. While these options can be combined, exclusions take precedence when extensions conflict (are both included and excluded) in declarations.
+
 The tool [sift](https://sift-tool.org), written in Go, is used to perform the pattern matching.
 
 ## Configuration

--- a/docs/scanners/pattern_search.md
+++ b/docs/scanners/pattern_search.md
@@ -15,8 +15,11 @@ scanner_configs:
         forbidden: true
         exclude_directory:
           - node_modules
-        exclude_extension:
-          - md
+        include_extension:
+          - js
+          - erb
+          - html
+          - htm
       - regex: "# Threat Model"
         message: All repos must contain a documented threat model.
         required: true

--- a/lib/salus/scanners/pattern_search.rb
+++ b/lib/salus/scanners/pattern_search.rb
@@ -38,7 +38,8 @@ module Salus::Scanners
           match_exclude_directory_flags = flag_list(
             '--exclude-dirs', match['exclude_directory']
           )
-          match_exclude_extension_flags = extension_flag('--exclude-ext', match['exclude_extension'])
+          match_exclude_extension_flags = extension_flag('--exclude-ext', \
+                                                         match['exclude_extension'])
           match_include_extension_flags = extension_flag('--ext', match['include_extension'])
 
           command_string = [
@@ -114,9 +115,9 @@ module Salus::Scanners
     private
 
     def extension_flag(flag, file_extensions)
-      if file_extensions.nil? or flag.nil?
+      if file_extensions.nil? || flag.nil?
         nil
-      elsif file_extensions.empty? or flag.empty?
+      elsif file_extensions.empty? || flag.empty?
         ""
       else
         flag << '='

--- a/lib/salus/scanners/pattern_search.rb
+++ b/lib/salus/scanners/pattern_search.rb
@@ -5,7 +5,9 @@ require 'salus/scanners/base'
 # Config file can provide:
 #   - exclude_directories: Array of directories (GLOB) in the repo to exclude from the search.
 #   - exclude_extensions: Array of file extensions to exclude from the search.
-#   The above can also be provided per-match, and will override the global values.
+#   - include_extensions: Array of file extensions to scan exclusively.
+#   The above can also be provided per-match, and will override the global values. Exclusions
+#   take precedence over inclusions if they conflict.
 #   - matches: Array[Hash]
 #       regex:       <regex>   (required)      regex to match against.
 #       forbidden:   <boolean> (default false) if true, a hit on this regex will fail the test.

--- a/lib/salus/scanners/pattern_search.rb
+++ b/lib/salus/scanners/pattern_search.rb
@@ -16,7 +16,8 @@ module Salus::Scanners
   class PatternSearch < Base
     def run
       global_exclude_directory_flags = flag_list('--exclude-dirs', @config['exclude_directory'])
-      global_exclude_extension_flags = extension_flag(@config['exclude_extension'])
+      global_exclude_extension_flags = extension_flag('--exclude-ext', @config['exclude_extension'])
+      global_include_extension_flags = extension_flag('--ext', @config['include_extension'])
 
       # For each pattern, keep a running history of failures, errors, and hits
       # These will be reported on at the end.
@@ -35,12 +36,14 @@ module Salus::Scanners
           match_exclude_directory_flags = flag_list(
             '--exclude-dirs', match['exclude_directory']
           )
-          match_exclude_extension_flags = extension_flag(match['exclude_extension'])
+          match_exclude_extension_flags = extension_flag('--exclude-ext', match['exclude_extension'])
+          match_include_extension_flags = extension_flag('--ext', match['include_extension'])
 
           command_string = [
             "sift -n -e \"#{match['regex']}\" .",
             match_exclude_directory_flags || global_exclude_directory_flags,
-            match_exclude_extension_flags || global_exclude_extension_flags
+            match_exclude_extension_flags || global_exclude_extension_flags,
+            match_include_extension_flags || global_include_extension_flags
           ].compact.join(' ')
           shell_return = run_shell(command_string)
 
@@ -108,13 +111,13 @@ module Salus::Scanners
 
     private
 
-    def extension_flag(file_extensions)
-      if file_extensions.nil?
+    def extension_flag(flag, file_extensions)
+      if file_extensions.nil? or flag.nil?
         nil
-      elsif file_extensions.empty?
+      elsif file_extensions.empty? or flag.empty?
         ""
       else
-        flag = '--exclude-ext='
+        flag << '='
         flag << file_extensions.join(',')
       end
     end

--- a/spec/fixtures/pattern_search/fancy.md
+++ b/spec/fixtures/pattern_search/fancy.md
@@ -1,0 +1,3 @@
+# Fancy
+
+This is _fancy_ **formatted**.

--- a/spec/lib/salus/scanners/pattern_search_spec.rb
+++ b/spec/lib/salus/scanners/pattern_search_spec.rb
@@ -202,7 +202,7 @@ describe Salus::Scanners::PatternSearch do
           'matches' => [
             { regex: 'UN' },
             { 'regex' => 'lance', 'forbidden' => true },
-            { regex: 'fancy'}
+            { regex: 'fancy' }
           ],
           'include_extension' => ['md']
         }
@@ -255,7 +255,8 @@ describe Salus::Scanners::PatternSearch do
         config = {
           'matches' => [
             { 'regex' => 'fancy', 'include_extension' => ['md']  },
-            { 'regex' => 'lance', 'forbidden' => true, 'exclude_extension' => ['txt'], 'include_extension' => ['md'] }
+            { 'regex' => 'lance', 'forbidden' => true, 'exclude_extension' => ['txt'], \
+              'include_extension' => ['md'] }
           ]
         }
 
@@ -272,8 +273,9 @@ describe Salus::Scanners::PatternSearch do
         repo = Salus::Repo.new('spec/fixtures/pattern_search')
         config = {
           'matches' => [
-            { 'regex' => 'fancy', 'include_extension' => ['md'], 'exclude_extension' => ['md']  },
-            { 'regex' => 'lance', 'forbidden' => true, 'exclude_extension' => ['txt'], 'include_extension' => ['md'] }
+            { 'regex' => 'fancy', 'include_extension' => ['md'], 'exclude_extension' => ['md'] },
+            { 'regex' => 'lance', 'forbidden' => true, 'exclude_extension' => ['txt'], \
+              'include_extension' => ['md'] }
           ]
         }
 
@@ -289,7 +291,7 @@ describe Salus::Scanners::PatternSearch do
         repo = Salus::Repo.new('spec/fixtures/pattern_search')
         config = {
           'matches' => [
-            { 'regex' => 'fancy', 'include_extension' => ['md']  },
+            { 'regex' => 'fancy', 'include_extension' => ['md'] },
             { 'regex' => 'lance', 'forbidden' => true, 'include_extension' => ['md'] }
           ],
           'exclude_extension' => %w[txt md]


### PR DESCRIPTION
The pattern_search (sift) scanner has an option to exclude file extensions from matches, useful for targeting specific files for which you don't want potential false positive matches. This option maps to sift's --exclude-ext command line flag. Similarly, sift has an option to only scan specified extensions, but this option is not exposed via the Salus config. This means one has to manually blacklist all undesired extensions.

This PR exposes an include_extension salus config option for the pattern_match scanner. In cases where we know exactly which extensions we want to target, this allows us to better target matches.

This is a dupe of PR #55 but has the rubocop fixes.

cc: @raphdev I will close the original PR because I fixed the rubocop errors.