### PR TITLE
Gosec fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Example CircleCI `config.yml`:
 version: 2.1
 
 orbs:
-  salus: federacy/salus@2.6.1
+  salus: federacy/salus@2.6.2
 
 workflows:
   main:

--- a/integrations/circleci/README.md
+++ b/integrations/circleci/README.md
@@ -24,7 +24,7 @@ Note: active_scanners and enforced_scanners must be yaml formatted for Salus con
 version: 2.1
 
 orbs:
-  salus: federacy/salus@2.6.1
+  salus: federacy/salus@2.6.2
 
 workflows:
   main:
@@ -38,7 +38,7 @@ workflows:
 version: 2.1
 
 orbs:
-  salus: federacy/salus@2.6.1
+  salus: federacy/salus@2.6.2
 
 workflows:
   main:
@@ -53,7 +53,7 @@ workflows:
 version: 2.1
 
 orbs:
-  salus: federacy/salus@2.6.1
+  salus: federacy/salus@2.6.2
 
 workflows:
   main:
@@ -68,7 +68,7 @@ workflows:
 ```
 version: 2.1
 orbs:
-  salus: federacy/salus@2.6.1
+  salus: federacy/salus@2.6.2
 executors:
   salus_2_4_2:
     docker:

--- a/integrations/circleci/orb.yml
+++ b/integrations/circleci/orb.yml
@@ -82,7 +82,7 @@ examples:
     usage:
       version: 2.1
       orbs:
-        salus: federacy/salus@2.6.1
+        salus: federacy/salus@2.6.2
       workflows:
         salus_scan:
           jobs: 
@@ -92,7 +92,7 @@ examples:
     usage:
       version: 2.1
       orbs:
-        salus: federacy/salus@2.6.1
+        salus: federacy/salus@2.6.2
       workflows:
         salus_scan:
           jobs: 
@@ -103,7 +103,7 @@ examples:
     usage:
       version: 2.1
       orbs:
-        salus: federacy/salus@2.6.1
+        salus: federacy/salus@2.6.2
       workflows:
         salus_scan:
           jobs: 
@@ -114,7 +114,7 @@ examples:
     usage:
       version: 2.1
       orbs:
-        salus: federacy/salus@2.6.1
+        salus: federacy/salus@2.6.2
       executors:
         salus_2_4_2:
           docker:

--- a/lib/salus.rb
+++ b/lib/salus.rb
@@ -19,7 +19,7 @@ require 'salus/config'
 require 'salus/processor'
 
 module Salus
-  VERSION = '2.6.1'.freeze
+  VERSION = '2.6.2'.freeze
   DEFAULT_REPO_PATH = './repo'.freeze # This is inside the docker container at /home/repo.
 
   SafeYAML::OPTIONS[:default_mode] = :safe

--- a/lib/salus/scanners/gosec.rb
+++ b/lib/salus/scanners/gosec.rb
@@ -60,7 +60,7 @@ module Salus::Scanners
     end
 
     def go_file?
-      !Dir.glob("#{@repository.path_to_repo}/*.go").first.nil?
+      !Dir.glob("#{@repository.path_to_repo}/**/*.go").first.nil?
     end
   end
 end

--- a/spec/fixtures/integration/expected_report.json
+++ b/spec/fixtures/integration/expected_report.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.6.1",
+  "version": "2.6.2",
   "passed": true,
   "running_time": 0.0,
   "scans": {

--- a/spec/fixtures/processor/local_uri/expected_report.json
+++ b/spec/fixtures/processor/local_uri/expected_report.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.6.1",
+  "version": "2.6.2",
   "passed": true,
   "running_time": 0.0,
   "scans": {

--- a/spec/fixtures/processor/remote_uri/expected_report.json
+++ b/spec/fixtures/processor/remote_uri/expected_report.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.6.1",
+  "version": "2.6.2",
   "passed": true,
   "running_time": 0.0,
   "scans": {

--- a/spec/fixtures/python/requirements_pinned/requirements.txt
+++ b/spec/fixtures/python/requirements_pinned/requirements.txt
@@ -15,7 +15,7 @@ kombu==4.1.0
 MarkupSafe==1.0
 numpy==1.14.0
 pandas==0.22.0
-python-dateutil==2.6.2
+python-dateutil==2.6.1
 pytz==2017.3
 requests==2.18.4
 requests-cache==0.4.13

--- a/spec/fixtures/python/requirements_pinned/requirements.txt
+++ b/spec/fixtures/python/requirements_pinned/requirements.txt
@@ -15,7 +15,7 @@ kombu==4.1.0
 MarkupSafe==1.0
 numpy==1.14.0
 pandas==0.22.0
-python-dateutil==2.6.1
+python-dateutil==2.6.2
 pytz==2017.3
 requests==2.18.4
 requests-cache==0.4.13


### PR DESCRIPTION
Instead of us trying to guess how a go project is constructed, Salus now looks for any go files in the provided directory and subdirectories and runs gosec from the provided folder if a go file is found anywhere inside.

This lets gosec do a better job of pulling in dependencies located in adjacent folders.