### PR TITLE
Hash support for custom_info

### DIFF
--- a/docs/salus_reports.md
+++ b/docs/salus_reports.md
@@ -20,7 +20,7 @@ The report, structurally, is a Hash of the following form:
 {
   "version": <String, semantic version of this report format>,
   "project_name": <String, comes from Salus configuration, typically used for identifying the codebase for this report>,
-  "custom_info": <String, comes from Salus configuration, used to pipe additional data from Salus runner to report consumer>,
+  "custom_info": <String or hash, comes from Salus configuration, used to pipe additional data from Salus runner to report consumer>,
   "configuration": <Hash, exact configuration used while Salus executed>,
   "scans": {
     <String, scanner name>: <Boolean, true for pass, false for fail>

--- a/lib/salus/config.rb
+++ b/lib/salus/config.rb
@@ -54,7 +54,7 @@ module Salus
       @enforced_scanners = all_none_some(SCANNERS.keys, final_config['enforced_scanners'])
       @scanner_configs   = final_config['scanner_configs'] || {}
       @project_name      = final_config['project_name']&.to_s
-      @custom_info       = final_config['custom_info']&.to_s
+      @custom_info       = final_config['custom_info']
       @report_uris       = final_config['reports'] || []
 
       apply_default_scanner_config!

--- a/spec/fixtures/config/custom_info_h.yaml
+++ b/spec/fixtures/config/custom_info_h.yaml
@@ -1,0 +1,13 @@
+---
+enforced_scanners:
+  - BundleAudit
+  - Brakeman
+
+scanner_configs:
+  BundleAudit:
+    ignore:
+      - CVE-AAAA-BBBB
+      - CVE-XXXX-YYYY
+
+custom_info:
+  branch: "master"

--- a/spec/fixtures/config/custom_info_s.yaml
+++ b/spec/fixtures/config/custom_info_s.yaml
@@ -1,0 +1,12 @@
+---
+enforced_scanners:
+  - BundleAudit
+  - Brakeman
+
+scanner_configs:
+  BundleAudit:
+    ignore:
+      - CVE-AAAA-BBBB
+      - CVE-XXXX-YYYY
+
+custom_info: "master"

--- a/spec/lib/salus/config_spec.rb
+++ b/spec/lib/salus/config_spec.rb
@@ -4,6 +4,8 @@ describe Salus::Config do
   let(:config_file_1)            { File.read('spec/fixtures/config/salus.yaml') }
   let(:config_file_2)            { File.read('spec/fixtures/config/salus_extra.yaml') }
   let(:envar_config_file)        { File.read('spec/fixtures/config/envar_config.yaml') }
+  let(:custom_info_hash_config_file) { File.read('spec/fixtures/config/custom_info_h.yaml') }
+  let(:custom_info_string_config_file) { File.read('spec/fixtures/config/custom_info_s.yaml') }
   let(:expected_report_uris) do
     [
       {
@@ -66,6 +68,18 @@ describe Salus::Config do
           ]
         )
       end
+    end
+
+    it 'should accept custom_info hashes' do
+      config = Salus::Config.new([custom_info_hash_config_file])
+      expect(config.custom_info).to be_a(Hash)
+      expect(config.custom_info).to include("branch")
+    end
+
+    it 'should accept custom_info strings' do
+      config = Salus::Config.new([custom_info_string_config_file])
+      expect(config.custom_info).to be_a(String)
+      expect(config.custom_info).to eq('master')
     end
 
     it 'should deep merge config files' do


### PR DESCRIPTION
Enable custom_info to support hashes. This helps to add context to a scan.

There is a reference for this capability in the Report spec: 

https://github.com/coinbase/salus/blob/master/spec/lib/salus/report_spec.rb#L10