### PR TITLE
Salus v2.7.2: Brakeman upgrade

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 ruby '2.4.6'
 
 gem 'activesupport', '~> 5.2', '>= 5.2.1'
-gem 'brakeman', '~> 4.4'
+gem 'brakeman', '~> 4.7'
 gem 'bugsnag', '~> 4.0'
 gem 'bundler', '~> 2'
 gem 'bundler-audit', '~> 0.6.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     ast (2.4.0)
     blankslate (2.1.2.4)
-    brakeman (4.5.0)
+    brakeman (4.7.2)
     bugsnag (4.2.1)
     bundler-audit (0.6.1)
       bundler (>= 1.2.0, < 3)
@@ -102,7 +102,7 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport (~> 5.2, >= 5.2.1)
-  brakeman (~> 4.4)
+  brakeman (~> 4.7)
   bugsnag (~> 4.0)
   bundler (~> 2)
   bundler-audit (~> 0.6.1)
@@ -123,4 +123,4 @@ RUBY VERSION
    ruby 2.4.6p354
 
 BUNDLED WITH
-   2.0.1
+   2.0.2

--- a/docs/scanners/npm_audit.md
+++ b/docs/scanners/npm_audit.md
@@ -2,4 +2,4 @@
 
 Finds CVEs in Node modules included as dependencies in a project that is packaged by NPM.
 
-See the [NodeAudit](/docs/node_audit.md) doc for configuration options.
+See the [NodeAudit](node_audit.md) doc for configuration options.

--- a/lib/salus.rb
+++ b/lib/salus.rb
@@ -19,7 +19,7 @@ require 'salus/config'
 require 'salus/processor'
 
 module Salus
-  VERSION = '2.7.1'.freeze
+  VERSION = '2.7.2'.freeze
   DEFAULT_REPO_PATH = './repo'.freeze # This is inside the docker container at /home/repo.
 
   SafeYAML::OPTIONS[:default_mode] = :safe

--- a/spec/fixtures/integration/expected_report.json
+++ b/spec/fixtures/integration/expected_report.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.7.1",
+  "version": "2.7.2",
   "passed": true,
   "running_time": 0.0,
   "scans": {

--- a/spec/fixtures/processor/local_uri/expected_report.json
+++ b/spec/fixtures/processor/local_uri/expected_report.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.7.1",
+  "version": "2.7.2",
   "passed": true,
   "running_time": 0.0,
   "scans": {

--- a/spec/fixtures/processor/remote_uri/expected_report.json
+++ b/spec/fixtures/processor/remote_uri/expected_report.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.7.1",
+  "version": "2.7.2",
   "passed": true,
   "running_time": 0.0,
   "scans": {


### PR DESCRIPTION
- Upgrade brakeman from 4.5.0 to 4.7.2
- Fix broken link in npm documentation