### PR TITLE
version bump to 2.7.3

### DIFF
--- a/lib/salus.rb
+++ b/lib/salus.rb
@@ -19,7 +19,7 @@ require 'salus/config'
 require 'salus/processor'
 
 module Salus
-  VERSION = '2.7.2'.freeze
+  VERSION = '2.7.3'.freeze
   DEFAULT_REPO_PATH = './repo'.freeze # This is inside the docker container at /home/repo.
 
   SafeYAML::OPTIONS[:default_mode] = :safe

--- a/spec/fixtures/integration/expected_report.json
+++ b/spec/fixtures/integration/expected_report.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.7.2",
+  "version": "2.7.3",
   "passed": true,
   "running_time": 0.0,
   "scans": {

--- a/spec/fixtures/processor/local_uri/expected_report.json
+++ b/spec/fixtures/processor/local_uri/expected_report.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.7.2",
+  "version": "2.7.3",
   "passed": true,
   "running_time": 0.0,
   "scans": {

--- a/spec/fixtures/processor/remote_uri/expected_report.json
+++ b/spec/fixtures/processor/remote_uri/expected_report.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.7.2",
+  "version": "2.7.3",
   "passed": true,
   "running_time": 0.0,
   "scans": {


### PR DESCRIPTION
Release Notes: 
#98 [bugfix] fix `NoMethodError` in `ReportNodeModules` reporting
#99 [bugfix] lock bundler at 2.0.2 due to bug in 2.1.2, add rubocop rule for unimportant LiteralInInterpolation rule, fix unrelated rubocop issue