### PR TITLE
Upgrade Bugsnag Integration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,7 +25,7 @@ Style/StringLiterals:
 Metrics/BlockLength:
   Enabled: false
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 100
 
 Metrics/MethodLength:
@@ -79,5 +79,5 @@ Layout/HashAlignment:
 Lint/ToJSON:
   Enabled: false
 
-LiteralInInterpolation:
+Lint/LiteralInInterpolation:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ ruby '2.7.0'
 
 gem 'activesupport', '~> 5.2', '>= 5.2.1'
 gem 'brakeman', '~> 4.7'
-gem 'bugsnag', '~> 4.0'
+gem 'bugsnag', '~> 6.13.1'
 # TODO: Lock `bundler` until:
 #  https://github.com/rubysec/bundler-audit/issues/235 and
 #  https://github.com/bundler/bundler/issues/7511 are resolved.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,8 @@ GEM
     ast (2.4.0)
     blankslate (2.1.2.4)
     brakeman (4.7.2)
-    bugsnag (4.2.1)
+    bugsnag (6.13.1)
+      concurrent-ruby (~> 1.0)
     bundler-audit (0.6.1)
       bundler (>= 1.2.0, < 3)
       thor (~> 0.18)
@@ -103,7 +104,7 @@ PLATFORMS
 DEPENDENCIES
   activesupport (~> 5.2, >= 5.2.1)
   brakeman (~> 4.7)
-  bugsnag (~> 4.0)
+  bugsnag (~> 6.13.1)
   bundler (= 2.0.2)
   bundler-audit (~> 0.6.1)
   faraday (~> 0.9)

--- a/integrations/bugsnag/README.md
+++ b/integrations/bugsnag/README.md
@@ -10,9 +10,9 @@ docker run --rm -t -e BUGSNAG_API_KEY=<YOUR_API_KEY> -v $(pwd):/home/repo coinba
 ```
 
 ### Error Reporting Endpoint
-By default, it will send error reports to `notify.bugsnag.com`. This can be changed by defining the env var, `BUGSNAG_ENDPOINT` with your custom reporting URL.
+By default, it will send error reports to `https://notify.bugsnag.com`. This can be changed by defining the env var, `BUGSNAG_ENDPOINT` with your custom reporting URL.
 
 For example if you are running Salus as a docker container, you can do the following:
 ```
-docker run --rm -t -e BUGSNAG_API_KEY=<YOUR_API_KEY> -e BUGSNAG_ENDPOINT=<YOUR_CUSTOM_BUGSNAG_ENDPOINT> -v $(pwd):/home/repo coinbase/salus
+docker run --rm -t -e BUGSNAG_API_KEY=<YOUR_API_KEY> -e BUGSNAG_ENDPOINT=<https://YOUR_CUSTOM_BUGSNAG_ENDPOINT> -v $(pwd):/home/repo coinbase/salus
 ```

--- a/lib/salus.rb
+++ b/lib/salus.rb
@@ -1,4 +1,3 @@
-require 'bugsnag'
 require 'active_support'
 require 'active_support/core_ext'
 require 'salus/bugsnag'
@@ -9,8 +8,6 @@ require 'salus/config'
 require 'salus/processor'
 
 module Salus
-  include Salus::SalusBugsnag
-
   VERSION = '2.8.4'.freeze
   DEFAULT_REPO_PATH = './repo'.freeze # This is inside the docker container at /home/repo.
 
@@ -21,18 +18,8 @@ module Salus
 
   URI_DELIMITER = ' '.freeze # space
 
-  if ENV['BUGSNAG_API_KEY']
-    Bugsnag.configure do |config|
-      config.endpoint = ENV.fetch('BUGSNAG_ENDPOINT', 'notify.bugsnag.com')
-      config.api_key = ENV['BUGSNAG_API_KEY']
-    end
-
-    # Hook at_exit to send off the fatal exception if it occurred
-    at_exit { bugsnag_notify($ERROR_INFO) if $ERROR_INFO }
-  end
-
   class << self
-    include Salus::SalusBugsnag
+    include SalusBugsnag
 
     def scan(
       config: nil,

--- a/lib/salus/bugsnag.rb
+++ b/lib/salus/bugsnag.rb
@@ -5,9 +5,13 @@ require 'English'
 # including both handled and unhandled execptions
 if ENV['BUGSNAG_API_KEY']
   Bugsnag.configure do |config|
-    config.endpoint = ENV.fetch('BUGSNAG_ENDPOINT', 'notify.bugsnag.com')
+    notify_endpoint = ENV.fetch('BUGSNAG_ENDPOINT', 'https://notify.bugsnag.com')
+    session_endpoint = nil # there are no sessions to track here
+
+    config.set_endpoints(notify_endpoint, session_endpoint)
     config.api_key = ENV['BUGSNAG_API_KEY']
     config.release_stage = 'production'
+    config.auto_capture_sessions = false
   end
 
   # Hook at_exit to send off the fatal exception if it occurred

--- a/lib/salus/bugsnag.rb
+++ b/lib/salus/bugsnag.rb
@@ -1,3 +1,19 @@
+require 'bugsnag'
+require 'English'
+
+# If present, configure Bugsnag globally to capture all errors
+# including both handled and unhandled execptions
+if ENV['BUGSNAG_API_KEY']
+  Bugsnag.configure do |config|
+    config.endpoint = ENV.fetch('BUGSNAG_ENDPOINT', 'notify.bugsnag.com')
+    config.api_key = ENV['BUGSNAG_API_KEY']
+    config.release_stage = 'production'
+  end
+
+  # Hook at_exit to send off the fatal exception if it occurred
+  at_exit { Bugsnag.notify($ERROR_INFO) if $ERROR_INFO }
+end
+
 module Salus
   module SalusBugsnag
     def bugsnag_notify(msg)

--- a/lib/salus/scanners/base.rb
+++ b/lib/salus/scanners/base.rb
@@ -1,6 +1,7 @@
 require 'open3'
 require 'salus/scan_report'
 require 'salus/shell_result'
+require 'salus/bugsnag'
 require 'shellwords'
 
 module Salus::Scanners


### PR DESCRIPTION
1. Move configuration so that Bugsnag is notified properly
2. Upgrade the Bugsnag gem from `4.0.0` to `6.13.1` to resolve warnings. However, current deployments using Bugsnag would need to be slightly updated with change. I could add some code to detect endpoints with or without `https` and add it proactively, so let me know if this is a concern. 

OLD way of adding Bugsnag ENV vars:
```
docker run --rm -t 
  -e BUGSNAG_API_KEY=myverysecretkey 
  -e BUGSNAG_ENDPOINT=notify.customdomain.net 
  -v $(pwd):/home/repo coinbase/salus
```

NEW way of adding ENV vars (note the `https://`):
```
docker run --rm -t 
  -e BUGSNAG_API_KEY=myversecretkey 
  -e BUGSNAG_ENDPOINT=https://notify.customdomain.net
  -v $(pwd):/home/repo coinbase/salus
```
