### PR TITLE
Add scheme to Bugsnag endpoints

### DIFF
--- a/lib/salus/bugsnag.rb
+++ b/lib/salus/bugsnag.rb
@@ -8,6 +8,11 @@ if ENV['BUGSNAG_API_KEY']
     notify_endpoint = ENV.fetch('BUGSNAG_ENDPOINT', 'https://notify.bugsnag.com')
     session_endpoint = nil # there are no sessions to track here
 
+    # Bugsnag requires a valid scheme, so add one if it's missing
+    if !notify_endpoint.start_with?('http://', 'https://')
+      notify_endpoint = 'https://' + notify_endpoint
+    end
+
     config.set_endpoints(notify_endpoint, session_endpoint)
     config.api_key = ENV['BUGSNAG_API_KEY']
     config.release_stage = 'production'


### PR DESCRIPTION
Small fix to add `https` if it is missing from the bugsnag endpoint. Note that if the URL happens to be bad for some reason, Bugsnag will issue an error and exit 1 the first time `notify` is called. The message looks like:

```
** [Bugsnag] 2020-05-13 20:01:10 +0000: Notifying https://fake.example.com of RuntimeError
** [Bugsnag] 2020-05-13 20:01:11 +0000: Notification to https://fake.example.com failed, #<SocketError: Failed to open TCP connection to fake.example.com:443 (getaddrinfo: Name or service not known)>
** [Bugsnag] 2020-05-13 20:02:20 +0000: <stack trace>
```
