### PR TITLE
semgrep: add config option to support external config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,10 +69,10 @@ RUN go get github.com/securego/gosec/cmd/gosec@915e9ee \
   && mv /root/go/bin/gosec /usr/bin/
 
 ### semgrep tool install https://semgrep.dev
-ENV SEMGREP_VERSION 0.7.0
+ENV SEMGREP_VERSION 0.9.0
 ENV SEMGREP_TARBALL_FILE semgrep-v$SEMGREP_VERSION-ubuntu-16.04.tgz
 ENV SEMGREP_DOWNLOAD_URL https://github.com/returntocorp/semgrep/releases/download/v$SEMGREP_VERSION/$SEMGREP_TARBALL_FILE
-ENV SEMGREP_DOWNLOAD_SHA256 8e47d0d9ef6a7ee324723018b7ef374a026b7a4f385d0060d5e04424ad130027
+ENV SEMGREP_DOWNLOAD_SHA256 aae50f8dd494af24bb59cfceaf0780767fd0b8df2fc669b8812b6061fa06baca
 
 RUN curl -fsSL "$SEMGREP_DOWNLOAD_URL" -o semgrep.tar.gz \
   && echo "$SEMGREP_DOWNLOAD_SHA256 semgrep.tar.gz" | sha256sum -c - \

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,10 +69,10 @@ RUN go get github.com/securego/gosec/cmd/gosec@915e9ee \
   && mv /root/go/bin/gosec /usr/bin/
 
 ### semgrep tool install https://semgrep.dev
-ENV SEMGREP_VERSION 0.9.0
+ENV SEMGREP_VERSION 0.10.1
 ENV SEMGREP_TARBALL_FILE semgrep-v$SEMGREP_VERSION-ubuntu-16.04.tgz
 ENV SEMGREP_DOWNLOAD_URL https://github.com/returntocorp/semgrep/releases/download/v$SEMGREP_VERSION/$SEMGREP_TARBALL_FILE
-ENV SEMGREP_DOWNLOAD_SHA256 aae50f8dd494af24bb59cfceaf0780767fd0b8df2fc669b8812b6061fa06baca
+ENV SEMGREP_DOWNLOAD_SHA256 7d07d223e88d52a2e8886e748726e1c8488d8d81ced34b80b128c362d9b57a0a
 
 RUN curl -fsSL "$SEMGREP_DOWNLOAD_URL" -o semgrep.tar.gz \
   && echo "$SEMGREP_DOWNLOAD_SHA256 semgrep.tar.gz" | sha256sum -c - \

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ coinbase/salus pulls the docker image
 
 ## Supported Scanners
 
+- [Bandit](docs/scanners/bandit.md) - Execution of [Bandit](https://pypi.org/project/bandit/), looks for common security issues in Python code.
 - [BundleAudit](docs/scanners/bundle_audit.md) - Execution of [bundle-audit](https://github.com/rubysec/bundler-audit), looks for CVEs in ruby gem dependencies.
 - [Brakeman](docs/scanners/brakeman.md) - Execution of [Brakeman](https://brakemanscanner.org/), looks for vulnerable code in Rails projects.
 - [npm audit](docs/scanners/npm_audit.md) - Execution of [`npm audit`](https://docs.npmjs.com/getting-started/running-a-security-audit) which looks for CVEs in node module dependencies.

--- a/docs/scanners/semgrep.md
+++ b/docs/scanners/semgrep.md
@@ -8,6 +8,8 @@ If a found pattern is forbidden this scanner will fail and the `message` will be
 
 There is also a `exclude_directory` option for excluding directories -- the glob pattern will match anywhere in the file path parts so for example `exclude_drectory: [node_modules]` will ignore both `./node_modules`, `lib/node_modules`, and `demo/demo2/node_modules`. Passing in full paths such as `exclude_drectory: [lib/node_modules]` is not supported.
 
+There is also support for external config files / registry keys under a `config` key. Any value entered here will directly be passed to `semgrep` and override `pattern`, `language`, and `message`.
+
 ## Configuration
 
 ```yaml
@@ -29,5 +31,7 @@ scanner_configs:
       - pattern: $LOG_ENDPOINT = os.getenv("LOGGER_ENDPOINT", ...)
         message: All files need to get the dynamic logger. Please don't hardcode this.
         language: python
+        required: true
+      - config: .semgrep.yml
         required: true
 ```

--- a/lib/salus/scanners/semgrep.rb
+++ b/lib/salus/scanners/semgrep.rb
@@ -60,7 +60,7 @@ module Salus::Scanners
               *(pattern_exclude_directory_flags || global_exclude_directory_flags),
               base_path
             ].compact
-            user_message = "config \"#{config}\""
+            user_message = "patterns in config \"#{config}\""
           else
             pattern = match['pattern']
             command = [

--- a/lib/salus/scanners/semgrep.rb
+++ b/lib/salus/scanners/semgrep.rb
@@ -24,6 +24,7 @@ module Salus::Scanners
   class Semgrep < Base
     def run
       global_exclude_directory_flags = flag_list('--exclude-dir', @config['exclude_directory'])
+      @config['strict'] ||= false
 
       # For each pattern, keep a running history of failures, errors, and hits
       # These will be reported on at the end.
@@ -45,15 +46,18 @@ module Salus::Scanners
           # Set defaults.
           match["forbidden"] ||= false
           match["required"] ||= false
+          match["strict"] ||= false
           match["message"] ||= ""
 
           has_external_config = !match['config'].nil?
+
+          strict_flag = @config['strict'] || match["strict"] ? '--strict' : nil
 
           if has_external_config
             config = match['config']
             command = [
               "semgrep",
-              "--strict",
+              strict_flag,
               "--json",
               "--config",
               File.join(base_path, config),
@@ -65,7 +69,7 @@ module Salus::Scanners
             pattern = match['pattern']
             command = [
               "semgrep",
-              "--strict",
+              strict_flag,
               "--json",
               "--pattern",
               pattern,

--- a/lib/salus/scanners/semgrep.rb
+++ b/lib/salus/scanners/semgrep.rb
@@ -24,7 +24,6 @@ module Salus::Scanners
   class Semgrep < Base
     def run
       global_exclude_directory_flags = flag_list('--exclude-dir', @config['exclude_directory'])
-      @config['strict'] ||= false
 
       # For each pattern, keep a running history of failures, errors, and hits
       # These will be reported on at the end.

--- a/lib/salus/scanners/semgrep.rb
+++ b/lib/salus/scanners/semgrep.rb
@@ -25,22 +25,19 @@ module Salus::Scanners
     def run
       global_exclude_directory_flags = flag_list('--exclude-dir', @config['exclude_directory'])
 
-      # For each pattern, keep a running history of failures, errors, and hits
+      # For each pattern, keep a running history of failures, errors, warnings, and hits
       # These will be reported on at the end.
       failure_messages = []
+      warning_messages = []
       errors = []
+      warnings = []
       all_hits = []
 
       Dir.chdir(@repository.path_to_repo) do
         base_path = Dir.pwd
         @config["matches"]&.each do |match|
           # semgrep has the following behavior:
-          #   always returns with status code 0 if able to parse
-          #   ouputs a json object with a 'results' key
-
-          pattern_exclude_directory_flags = flag_list(
-            '--exclude-dir', match['exclude_directory']
-          )
+          #   ouputs a json object with a 'results' and 'errors' key
 
           # Set defaults.
           match["forbidden"] ||= false
@@ -48,37 +45,16 @@ module Salus::Scanners
           match["strict"] ||= false
           match["message"] ||= ""
 
-          has_external_config = !match['config'].nil?
+          pattern_exclude_directory_flags = flag_list(
+            '--exclude-dir', match['exclude_directory']
+          )
 
-          strict_flag = @config['strict'] || match["strict"] ? '--strict' : nil
-
-          if has_external_config
-            config = match['config']
-            command = [
-              "semgrep",
-              strict_flag,
-              "--json",
-              "--config",
-              File.join(base_path, config),
-              *(pattern_exclude_directory_flags || global_exclude_directory_flags),
-              base_path
-            ].compact
-            user_message = "patterns in config \"#{config}\""
-          else
-            pattern = match['pattern']
-            command = [
-              "semgrep",
-              strict_flag,
-              "--json",
-              "--pattern",
-              pattern,
-              "--lang",
-              match['language'],
-              *(pattern_exclude_directory_flags || global_exclude_directory_flags),
-              base_path
-            ].compact
-            user_message = "pattern \"#{pattern}\""
-          end
+          command, user_message = build_command_and_message(
+            match,
+            @config['strict'] || match["strict"],
+            base_path,
+            pattern_exclude_directory_flags || global_exclude_directory_flags
+          )
 
           # run semgrep
           shell_return = run_shell(command)
@@ -87,6 +63,15 @@ module Salus::Scanners
             # parse the output
             data = JSON.parse(shell_return.stdout)
             hits = data["results"]
+            semgrep_non_fatal_errors = data["errors"]
+            semgrep_non_fatal_errors&.map do |nfe|
+              nfe_str = error_to_string(nfe)
+              warning_messages << nfe_str
+              warnings << {
+                message: nfe_str,
+                details: error_to_object(nfe)
+              }
+            end
 
             if hits.empty?
               # If there were no hits, but the pattern was required add an error message.
@@ -96,25 +81,19 @@ module Salus::Scanners
               end
             else
               hits.each do |hit|
-                msg = if has_external_config
-                        hit['extra']['message']
-                      else
-                        match['message']
-                      end
+                msg = message_from_hit(hit, match)
                 if match["forbidden"]
                   failure_messages << "Forbidden #{user_message} was found " \
                   "- #{msg}\n" \
-                  "\t#{hit['path'].sub(base_path + '/', '')}:#{hit['start']['line']}:" \
-                  "#{hit['extra']['lines']}"
+                  "\t#{hit_to_string(hit, base_path)}"
                 end
                 all_hits << {
-                  pattern: pattern,
-                  config: config,
+                  pattern: match['pattern'],
+                  config: match['config'],
                   forbidden: match["forbidden"],
                   required: match["required"],
                   msg: msg,
-                  hit: "#{hit['path'].sub(base_path + '/', '')}:#{hit['start']['line']}:" \
-                  "#{hit['extra']['lines']}".rstrip
+                  hit: hit_to_string(hit, base_path)
                 }
               end
             end
@@ -128,14 +107,14 @@ module Salus::Scanners
             begin
               # parse the output
               output_data = JSON.parse(shell_return.stdout)
-              error_details = lines_from_errors(output_data["errors"])
+              error_str = messages_str_from_errors(output_data["errors"])
               # only take the first line of stderror because the other lines
               # are verbose debugging info generated based on a temp file
               # so the filename is random and fails the test.
               errors << {
                 status: shell_return.status,
                 stderr: shell_return.stderr.split("\n").first \
-                + "\n\n" + error_details
+                + "\n\n" + error_str
               }
             rescue JSON::ParserError
               # only take the first line of stderror because the other lines
@@ -159,6 +138,8 @@ module Salus::Scanners
 
         report_info(:hits, all_hits)
         errors.each { |error| report_error("Call to semgrep failed", error) }
+        report_warn(:semgrep_non_fatal, warnings) unless warnings.empty?
+        warning_messages.each { |message| log(message) }
 
         if failure_messages.empty?
           report_success
@@ -173,6 +154,51 @@ module Salus::Scanners
       true # we will always run this on the provided folder
     end
 
+    def build_command_and_message(match, strict, base_path, exclude_directories_flags)
+      has_external_config = !match['config'].nil?
+      strict_flag = strict ? '--strict' : nil
+
+      if has_external_config
+        config = match['config']
+        command = [
+          "semgrep",
+          strict_flag,
+          "--json",
+          "--config",
+          File.join(base_path, config),
+          *exclude_directories_flags,
+          base_path
+        ].compact
+        user_message = "patterns in config \"#{config}\""
+      else
+        pattern = match['pattern']
+        command = [
+          "semgrep",
+          strict_flag,
+          "--json",
+          "--pattern",
+          pattern,
+          "--lang",
+          match['language'],
+          *exclude_directories_flags,
+          base_path
+        ].compact
+        user_message = "pattern \"#{pattern}\""
+      end
+
+      [command, user_message]
+    end
+
+    def message_from_hit(hit, match)
+      has_external_config = !match['config'].nil?
+      msg = if has_external_config
+              hit['extra']['message']
+            else
+              match['message']
+            end
+      msg
+    end
+
     # returns nil if list is nil
     def flag_list(flag, list)
       list&.map do |value|
@@ -180,16 +206,36 @@ module Salus::Scanners
       end
     end
 
-    def lines_from_errors(list_of_errors)
-      list_of_errors&.map do |error|
-        data = error.fetch('data', {})
-        path = data.fetch('path', 'no path')
-        start = data.fetch('start', {})
-        start_line = start.fetch('line', 'no line number')
-        extra = data.fetch('extra', {})
-        message = extra.fetch('message', 'no message')
-        "#{message}\n" \
-        "\t#{path}:#{start_line}"
+    def hit_to_string(hit, base_path)
+      "#{hit['path'].sub(base_path + '/', '')}:#{hit['start']['line']}:" \
+        "#{hit['extra']['lines']}".rstrip
+    end
+
+    def error_to_object(err)
+      data = err.fetch('data', {})
+      path = data.fetch('path', 'no path')
+      start = data.fetch('start', {})
+      end_obj = data.fetch('end', {})
+      extra = data.fetch('extra', {})
+      message = extra.fetch('message', 'no message')
+      line = extra.fetch('line', '')
+      {
+        path: path,
+        start: start,
+        end: end_obj,
+        message: message,
+        line: line
+      }
+    end
+
+    def error_to_string(err)
+      err_obj = error_to_object(err)
+      "#{err_obj[:message]}\n\t#{err_obj[:path]}:#{err_obj[:start].fetch('line', '')}"
+    end
+
+    def messages_str_from_errors(list_of_errors)
+      list_of_errors&.map do |err|
+        error_to_string(err)
       end&.join("\n")
     end
   end

--- a/spec/fixtures/semgrep/semgrep-config-required.yml
+++ b/spec/fixtures/semgrep/semgrep-config-required.yml
@@ -1,0 +1,7 @@
+rules:
+    - id: semgrep-eq-42
+      patterns:
+        - pattern: $X == 42
+      message: 42 must be in all files
+      languages: [python]
+      severity: WARNING

--- a/spec/fixtures/semgrep/semgrep-config.yml
+++ b/spec/fixtures/semgrep/semgrep-config.yml
@@ -1,0 +1,7 @@
+rules:
+    - id: semgrep-eqeq-test
+      patterns:
+        - pattern: $X == $X
+      message: $X == $X is always true
+      languages: [python]
+      severity: WARNING

--- a/spec/lib/salus/scanners/semgrep_spec.rb
+++ b/spec/lib/salus/scanners/semgrep_spec.rb
@@ -625,7 +625,8 @@ describe Salus::Scanners::Semgrep do
         errors = scanner.report.to_h.fetch(:errors)
         expect(errors).to include(
           status: 3, # semgrep exit code documentation
-          stderr: "run with --strict and 1 errors occurred during semgrep run; exiting",
+          stderr: "run with --strict and 1 errors occurred during semgrep run; exiting" \
+            "\n\nSyntax error\n\t/home/spec/fixtures/semgrep/invalid/unparsable_py.py:3",
           message: "Call to semgrep failed"
         )
       end
@@ -650,7 +651,8 @@ describe Salus::Scanners::Semgrep do
         errors = scanner.report.to_h.fetch(:errors)
         expect(errors).to include(
           status: 3, # semgrep exit code documentation
-          stderr: "run with --strict and 1 errors occurred during semgrep run; exiting",
+          stderr: "run with --strict and 1 errors occurred during semgrep run; exiting" \
+            "\n\nSyntax error\n\t/home/spec/fixtures/semgrep/invalid/unparsable_js.js:3",
           message: "Call to semgrep failed"
         )
       end

--- a/spec/lib/salus/scanners/semgrep_spec.rb
+++ b/spec/lib/salus/scanners/semgrep_spec.rb
@@ -23,6 +23,7 @@ describe Salus::Scanners::Semgrep do
         info = scanner.report.to_h.fetch(:info)
 
         expect(info[:hits]).to include(
+          config: nil,
           pattern: "$X == $X",
           forbidden: false,
           required: false,
@@ -31,6 +32,7 @@ describe Salus::Scanners::Semgrep do
         )
 
         expect(info[:hits]).to include(
+          config: nil,
           pattern: "$X == $X",
           forbidden: false,
           required: false,
@@ -39,12 +41,61 @@ describe Salus::Scanners::Semgrep do
         )
 
         expect(info[:hits]).to include(
+          config: nil,
           pattern: "$X == $X",
           forbidden: false,
           required: false,
           msg: "",
           hit: "vendor/trivial2.py:10:    if user.id == user.id:"
         )
+      end
+
+      context "external config" do
+        it "should report matches" do
+          repo = Salus::Repo.new("spec/fixtures/semgrep")
+          config = {
+            "matches" => [
+              {
+                "config" => "semgrep-config.yml",
+                "forbidden" => false,
+                "exclude_directory" => ['invalid']
+              }
+            ]
+          }
+          scanner = Salus::Scanners::Semgrep.new(repository: repo, config: config)
+          scanner.run
+
+          expect(scanner.report.passed?).to eq(true)
+
+          info = scanner.report.to_h.fetch(:info)
+
+          expect(info[:hits]).to include(
+            config: "semgrep-config.yml",
+            pattern: nil,
+            forbidden: false,
+            required: false,
+            msg: "3 == 3 is always true",
+            hit: "trivial.py:3:if 3 == 3:"
+          )
+
+          expect(info[:hits]).to include(
+            config: "semgrep-config.yml",
+            pattern: nil,
+            forbidden: false,
+            required: false,
+            msg: "user.id == user.id is always true",
+            hit: "examples/trivial2.py:10:    if user.id == user.id:"
+          )
+
+          expect(info[:hits]).to include(
+            config: "semgrep-config.yml",
+            pattern: nil,
+            forbidden: false,
+            required: false,
+            msg: "user.id == user.id is always true",
+            hit: "vendor/trivial2.py:10:    if user.id == user.id:"
+          )
+        end
       end
 
       it "should report matches with a message" do
@@ -69,6 +120,7 @@ describe Salus::Scanners::Semgrep do
         info = scanner.report.to_h.fetch(:info)
 
         expect(info[:hits]).to include(
+          config: nil,
           pattern: "$X == $X",
           forbidden: false,
           required: false,
@@ -77,6 +129,7 @@ describe Salus::Scanners::Semgrep do
         )
 
         expect(info[:hits]).to include(
+          config: nil,
           pattern: "$X == $X",
           forbidden: false,
           required: false,
@@ -85,6 +138,7 @@ describe Salus::Scanners::Semgrep do
         )
 
         expect(info[:hits]).to include(
+          config: nil,
           pattern: "$X == $X",
           forbidden: false,
           required: false,
@@ -115,6 +169,7 @@ describe Salus::Scanners::Semgrep do
         info = scanner.report.to_h.fetch(:info)
 
         expect(info[:hits]).to include(
+          config: nil,
           pattern: "$X == $X",
           forbidden: true,
           required: false,
@@ -123,6 +178,7 @@ describe Salus::Scanners::Semgrep do
         )
 
         expect(info[:hits]).to include(
+          config: nil,
           pattern: "$X == $X",
           forbidden: true,
           required: false,
@@ -131,6 +187,7 @@ describe Salus::Scanners::Semgrep do
         )
 
         expect(info[:hits]).to include(
+          config: nil,
           pattern: "$X == $X",
           forbidden: true,
           required: false,
@@ -163,6 +220,7 @@ describe Salus::Scanners::Semgrep do
         info = scanner.report.to_h.fetch(:info)
 
         expect(info[:hits]).to include(
+          config: nil,
           pattern: "$X == $X",
           forbidden: false,
           required: true,
@@ -171,6 +229,7 @@ describe Salus::Scanners::Semgrep do
         )
 
         expect(info[:hits]).to include(
+          config: nil,
           pattern: "$X == $X",
           forbidden: false,
           required: true,
@@ -179,6 +238,7 @@ describe Salus::Scanners::Semgrep do
         )
 
         expect(info[:hits]).to include(
+          config: nil,
           pattern: "$X == $X",
           forbidden: false,
           required: true,
@@ -236,6 +296,7 @@ describe Salus::Scanners::Semgrep do
         info = scanner.report.to_h.fetch(:info)
 
         expect(info[:hits]).to include(
+          config: nil,
           pattern: "$X == $X",
           forbidden: true,
           required: false,
@@ -244,6 +305,7 @@ describe Salus::Scanners::Semgrep do
         )
 
         expect(info[:hits]).to include(
+          config: nil,
           pattern: "$X == $X",
           forbidden: true,
           required: false,
@@ -252,6 +314,7 @@ describe Salus::Scanners::Semgrep do
         )
 
         expect(info[:hits]).not_to include(
+          config: nil,
           pattern: "$X == $X",
           forbidden: true,
           required: false,
@@ -284,6 +347,7 @@ describe Salus::Scanners::Semgrep do
         info = scanner.report.to_h.fetch(:info)
 
         expect(info[:hits]).to include(
+          config: nil,
           pattern: "$X == $X",
           forbidden: true,
           required: false,
@@ -292,6 +356,7 @@ describe Salus::Scanners::Semgrep do
         )
 
         expect(info[:hits]).not_to include(
+          config: nil,
           pattern: "$X == $X",
           forbidden: true,
           required: false,
@@ -300,6 +365,7 @@ describe Salus::Scanners::Semgrep do
         )
 
         expect(info[:hits]).not_to include(
+          config: nil,
           pattern: "$X == $X",
           forbidden: true,
           required: false,
@@ -332,6 +398,7 @@ describe Salus::Scanners::Semgrep do
         info = scanner.report.to_h.fetch(:info)
 
         expect(info[:hits]).to include(
+          config: nil,
           pattern: "$X == $X",
           forbidden: true,
           required: false,
@@ -340,6 +407,7 @@ describe Salus::Scanners::Semgrep do
         )
 
         expect(info[:hits]).to include(
+          config: nil,
           pattern: "$X == $X",
           forbidden: true,
           required: false,
@@ -348,6 +416,7 @@ describe Salus::Scanners::Semgrep do
         )
 
         expect(info[:hits]).not_to include(
+          config: nil,
           pattern: "$X == $X",
           forbidden: true,
           required: false,
@@ -380,6 +449,7 @@ describe Salus::Scanners::Semgrep do
         info = scanner.report.to_h.fetch(:info)
 
         expect(info[:hits]).to include(
+          config: nil,
           pattern: "$X == $X",
           forbidden: true,
           required: false,
@@ -388,6 +458,7 @@ describe Salus::Scanners::Semgrep do
         )
 
         expect(info[:hits]).not_to include(
+          config: nil,
           pattern: "$X == $X",
           forbidden: true,
           required: false,
@@ -396,6 +467,7 @@ describe Salus::Scanners::Semgrep do
         )
 
         expect(info[:hits]).not_to include(
+          config: nil,
           pattern: "$X == $X",
           forbidden: true,
           required: false,

--- a/spec/lib/salus/scanners/semgrep_spec.rb
+++ b/spec/lib/salus/scanners/semgrep_spec.rb
@@ -10,8 +10,7 @@ describe Salus::Scanners::Semgrep do
             {
               "pattern" => "$X == $X",
               "language" => "python",
-              "forbidden" => false,
-              "exclude_directory" => ['invalid']
+              "forbidden" => false
             }
           ]
         }
@@ -57,8 +56,7 @@ describe Salus::Scanners::Semgrep do
             "matches" => [
               {
                 "config" => "semgrep-config.yml",
-                "forbidden" => false,
-                "exclude_directory" => ['invalid']
+                "forbidden" => false
               }
             ]
           }
@@ -103,8 +101,7 @@ describe Salus::Scanners::Semgrep do
             "matches" => [
               {
                 "config" => "semgrep-config.yml",
-                "forbidden" => true,
-                "exclude_directory" => ['invalid']
+                "forbidden" => true
               }
             ]
           }
@@ -149,8 +146,7 @@ describe Salus::Scanners::Semgrep do
             "matches" => [
               {
                 "config" => "semgrep-config.yml",
-                "required" => true,
-                "exclude_directory" => ['invalid']
+                "required" => true
               }
             ]
           }
@@ -195,8 +191,7 @@ describe Salus::Scanners::Semgrep do
             "matches" => [
               {
                 "config" => "semgrep-config-required.yml",
-                "required" => true,
-                "exclude_directory" => ['invalid']
+                "required" => true
               }
             ]
           }
@@ -220,8 +215,7 @@ describe Salus::Scanners::Semgrep do
               "pattern" => "$X == $X",
               "language" => "python",
               "message" => "Useless equality test.",
-              "forbidden" => false,
-              "exclude_directory" => ['invalid']
+              "forbidden" => false
             }
           ]
         }
@@ -270,8 +264,7 @@ describe Salus::Scanners::Semgrep do
             {
               "pattern" => "$X == $X",
               "language" => "python",
-              "forbidden" => true,
-              "exclude_directory" => ['invalid']
+              "forbidden" => true
             }
           ]
         }
@@ -320,8 +313,7 @@ describe Salus::Scanners::Semgrep do
               "pattern" => "$X == $X",
               "language" => "python",
               "message" => "Useless equality test.",
-              "required" => true,
-              "exclude_directory" => ['invalid']
+              "required" => true
             }
           ]
         }
@@ -369,8 +361,7 @@ describe Salus::Scanners::Semgrep do
               "pattern" => "$X == 42",
               "language" => "python",
               "message" => "Should be 42",
-              "required" => true,
-              "exclude_directory" => ['invalid']
+              "required" => true
             }
           ]
         }
@@ -399,7 +390,7 @@ describe Salus::Scanners::Semgrep do
               "forbidden" => true
             }
           ],
-          'exclude_directory' => %w[examples invalid]
+          'exclude_directory' => %w[examples]
         }
 
         scanner = Salus::Scanners::Semgrep.new(repository: repo, config: config)
@@ -450,7 +441,7 @@ describe Salus::Scanners::Semgrep do
               "forbidden" => true
             }
           ],
-          'exclude_directory' => %w[examples vendor invalid]
+          'exclude_directory' => %w[examples vendor]
         }
 
         scanner = Salus::Scanners::Semgrep.new(repository: repo, config: config)
@@ -499,7 +490,7 @@ describe Salus::Scanners::Semgrep do
               "language" => "python",
               "message" => "Useless equality test.",
               "forbidden" => true,
-              'exclude_directory' => %w[examples invalid]
+              'exclude_directory' => %w[examples]
             }
           ]
         }
@@ -550,7 +541,7 @@ describe Salus::Scanners::Semgrep do
               "language" => "python",
               "message" => "Useless equality test.",
               "forbidden" => true,
-              'exclude_directory' => %w[examples vendor invalid]
+              'exclude_directory' => %w[examples vendor]
             }
           ]
         }
@@ -624,7 +615,8 @@ describe Salus::Scanners::Semgrep do
             {
               "pattern" => "$X",
               "language" => "python",
-              "forbidden" => false
+              "forbidden" => false,
+              "strict" => true
             }
           ]
         }
@@ -651,7 +643,8 @@ describe Salus::Scanners::Semgrep do
               "language" => "js",
               "forbidden" => false
             }
-          ]
+          ],
+          "strict" => true
         }
         scanner = Salus::Scanners::Semgrep.new(repository: repo, config: config)
         scanner.run

--- a/spec/lib/salus/scanners/semgrep_spec.rb
+++ b/spec/lib/salus/scanners/semgrep_spec.rb
@@ -599,9 +599,8 @@ describe Salus::Scanners::Semgrep do
 
         errors = scanner.report.to_h.fetch(:errors)
         expect(errors).to include(
-          status: 4, # semgrep exit code documentation
-          stderr: "invalid pattern \"$\": "\
-                  "Parse_info.Lexical_error(\"unrecognized symbol: $\", _)",
+          status: 2, # semgrep exit code documentation
+          stderr: "non-zero return code while invoking semgrep-core:",
           message: "Call to semgrep failed"
         )
       end
@@ -626,8 +625,7 @@ describe Salus::Scanners::Semgrep do
         errors = scanner.report.to_h.fetch(:errors)
         expect(errors).to include(
           status: 3, # semgrep exit code documentation
-          stderr: "semgrep: /home/spec/fixtures/semgrep/"\
-          "invalid/unparsable_py.py: ParseError",
+          stderr: "run with --strict and 1 errors occurred during semgrep run; exiting",
           message: "Call to semgrep failed"
         )
       end
@@ -652,7 +650,7 @@ describe Salus::Scanners::Semgrep do
         errors = scanner.report.to_h.fetch(:errors)
         expect(errors).to include(
           status: 3, # semgrep exit code documentation
-          stderr: "parse error ",
+          stderr: "run with --strict and 1 errors occurred during semgrep run; exiting",
           message: "Call to semgrep failed"
         )
       end


### PR DESCRIPTION
- Add in `config` option for semgrep to support external config in either a file or url
- bump version of semgrep to 0.10.1
- make `strict` mode configurable