### PR TITLE
Gosec fix

### DIFF
--- a/lib/salus/scanners/gosec.rb
+++ b/lib/salus/scanners/gosec.rb
@@ -13,7 +13,7 @@ module Salus::Scanners
       shell_return = Dir.chdir(@repository.path_to_repo) do
         # sometimes the go.sum needs to be forced updated to be able to correctly build packages.
         # forcing go get seems to do the trick
-        run_shell("go get")
+        run_shell("go get ./...")
         cmd = "gosec #{config_options}-fmt=json ./..."
         run_shell(cmd)
       end

--- a/lib/salus/scanners/gosec.rb
+++ b/lib/salus/scanners/gosec.rb
@@ -13,7 +13,15 @@ module Salus::Scanners
       shell_return = Dir.chdir(@repository.path_to_repo) do
         # sometimes the go.sum needs to be forced updated to be able to correctly build packages.
         # forcing go get seems to do the trick
-        run_shell("go get ./...")
+        if File.size?('go.mod')
+          go_get_ret = run_shell("go get ./...")
+          if go_get_ret.status != 0
+            go_get_err = "Unable to start gosec because go get ./... failed. #{go_get_ret.stderr}"
+            report_error(go_get_err, status: go_get_ret.status)
+            report_stderr(go_get_err)
+            return report_failure
+          end
+        end
         cmd = "gosec #{config_options}-fmt=json ./..."
         run_shell(cmd)
       end

--- a/spec/fixtures/gosec/bad_gomod_app/go.mod
+++ b/spec/fixtures/gosec/bad_gomod_app/go.mod
@@ -1,0 +1,7 @@
+module test/hello
+
+require (
+	test123.test456.test789/test2 v0.123456
+)
+
+go 1.13

--- a/spec/fixtures/gosec/bad_gomod_app/hello.go
+++ b/spec/fixtures/gosec/bad_gomod_app/hello.go
@@ -1,0 +1,5 @@
+package hello
+
+func Hello() string {
+	return "Hello!"
+}

--- a/spec/fixtures/gosec/bad_gomod_app/hello_test.go
+++ b/spec/fixtures/gosec/bad_gomod_app/hello_test.go
@@ -1,0 +1,10 @@
+package hello
+
+import "testing"
+
+func TestHello(t *testing.T) {
+    want := "Hello!"
+    if got := Hello(); got != want {
+        t.Errorf("Hello() = %q, want %q", got, want)
+    }
+}

--- a/spec/lib/salus/scanners/gosec_spec.rb
+++ b/spec/lib/salus/scanners/gosec_spec.rb
@@ -6,6 +6,17 @@ describe Salus::Scanners::Gosec do
 
     before { scanner.run }
 
+    context 'go get ./... fails' do
+      let(:repo) { Salus::Repo.new('spec/fixtures/gosec/bad_gomod_app') }
+
+      it 'should display go get error and not run gosec' do
+        expect(scanner.should_run?).to eq(true)
+        expect(scanner.report.passed?).to eq(false)
+        err_msg = scanner.report.to_h.fetch(:errors).first[:message]
+        expect(err_msg).to include('Unable to start gosec because go get ./... failed.')
+      end
+    end
+
     context 'non-go project' do
       let(:repo) { Salus::Repo.new('spec/fixtures/blank_repository') }
 


### PR DESCRIPTION
* Update `go get` to `go get ./...`. This fixes weird gosec errors on some repos.
* If `go get ./...` succeeds, then run `gosec`.  If it `go get ./...` fails, then report the error and do not run `gosec`.