### PR TITLE
version bump to 2.10.3

### DIFF
--- a/lib/salus.rb
+++ b/lib/salus.rb
@@ -8,7 +8,7 @@ require 'salus/config'
 require 'salus/processor'
 
 module Salus
-  VERSION = '2.10.2'.freeze
+  VERSION = '2.10.3'.freeze
   DEFAULT_REPO_PATH = './repo'.freeze # This is inside the docker container at /home/repo.
 
   SafeYAML::OPTIONS[:default_mode] = :safe

--- a/spec/fixtures/integration/expected_report.json
+++ b/spec/fixtures/integration/expected_report.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.10.2",
+  "version": "2.10.3",
   "passed": true,
   "running_time": 0.0,
   "scans": {

--- a/spec/fixtures/processor/local_uri/expected_report.json
+++ b/spec/fixtures/processor/local_uri/expected_report.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.10.2",
+  "version": "2.10.3",
   "passed": true,
   "running_time": 0.0,
   "scans": {

--- a/spec/fixtures/processor/remote_uri/expected_report.json
+++ b/spec/fixtures/processor/remote_uri/expected_report.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.10.2",
+  "version": "2.10.3",
   "passed": true,
   "running_time": 0.0,
   "scans": {


### PR DESCRIPTION
Release Notes:

* Upgrade semgrep to 0.10.0
* Add support for advanced semgrep patterns
* Warn (not fail) on semgrep parser-related errors.  
* Update semgrep documentation with more details
* Clarify README
* Fix gosec documentation on `exclude-dir`
