### PR TITLE
Add information about missing configs to report

### DIFF
--- a/docs/salus_reports.md
+++ b/docs/salus_reports.md
@@ -167,8 +167,11 @@ Long arrays have been shortened for brevity.
 :version: 1.0.0
 :custom_info: ''
 :configuration:
-  sources:
-  - file:///salus.yaml
+  :sources:
+    :configured:
+    - file:///salus.yaml
+    :valid:
+    - file:///salus.yaml
   active_scanners:
   - Brakeman
   - BundleAudit
@@ -298,9 +301,14 @@ Long arrays have been shortened for brevity.
   "version": "1.0.0",
   "custom_info": "",
   "configuration": {
-    "sources": [
-      "file:///salus.yaml"
-    ],
+    "sources": {
+      "configured": [
+        "file:///salus.yaml"
+      ],
+      "valid": [
+        "file:///salus.yaml"
+      ]
+    },
     "active_scanners": [
       "Brakeman",
       "BundleAudit",
@@ -381,8 +389,11 @@ __YAML form verbose__
 :version: 1.0.0
 :custom_info: ''
 :configuration:
-  sources:
-  - file:///salus.yaml
+  :sources:
+    :configured:
+    - file:///salus.yaml
+    :valid:
+    - file:///salus.yaml
   active_scanners:
   - Brakeman
   - BundleAudit
@@ -439,9 +450,14 @@ __JSON form verbose__
   "version": "1.0.0",
   "custom_info": "",
   "configuration": {
-    "sources": [
-      "file:///salus.yaml"
-    ],
+    "sources": {
+      "configured": [
+        "file:///salus.yaml"
+      ],
+      "valid": [
+        "file:///salus.yaml"
+      ]
+    },
     "active_scanners": [
       "Brakeman",
       "BundleAudit",

--- a/lib/salus/config.rb
+++ b/lib/salus/config.rb
@@ -26,6 +26,8 @@ module Salus
       .to_h
       .freeze
 
+    # This is the base configuration file, and we merge all other configuration
+    # provided into this file to create one final configuration.
     DEFAULT_CONFIG = YAML.load_file(
       File.join(File.dirname(__FILE__), '../../salus-default.yaml'),
       safe: true

--- a/lib/salus/report.rb
+++ b/lib/salus/report.rb
@@ -87,7 +87,6 @@ module Salus
       # Adjust the wrap by 2 because we're wrapping indented paragraphs
       indented_wrap = (wrap.nil? ? nil : wrap - INDENT_SIZE)
 
-      # Only add config if verbose mode is on.
       if verbose
         # Dump config in particular as YAML rather than JSON, because salus
         # config files are YAML. Also, stringify the keys before serializing,
@@ -95,8 +94,13 @@ module Salus
         # annoying
         stringified_config = YAML.dump(@config.deep_stringify_keys, indentation: INDENT_SIZE)
         output += "\n\n==== Salus Configuration\n\n"
-        output += indent(wrapify(stringified_config, indented_wrap))
+      else
+        # Include some info on which configuration files were used
+        stringified_config = @config[:sources][:valid].join("\n")
+        output += "\n\n==== Salus Configuration Files Used:\n\n"
       end
+
+      output += indent(wrapify(stringified_config, indented_wrap))
 
       if !@errors.empty?
         stringified_errors = JSON.pretty_generate(@errors)

--- a/spec/fixtures/integration/expected_report.json
+++ b/spec/fixtures/integration/expected_report.json
@@ -56,7 +56,7 @@
       },
       "Brakeman": {
         "pass_on_raise": false
-      },        
+      },
       "BundleAudit": {
         "pass_on_raise": false
       },
@@ -97,8 +97,13 @@
         "format": "json"
       }
     ],
-    "sources": [
-      "file:///salus.yaml"
-    ]
+    "sources": {
+      "configured": [
+        "file:///salus.yaml"
+      ],
+      "valid": [
+        "file:///salus.yaml"
+      ]
+    }
   }
 }

--- a/spec/fixtures/processor/local_uri/expected_report.json
+++ b/spec/fixtures/processor/local_uri/expected_report.json
@@ -125,8 +125,13 @@
         "format": "json"
       }
     ],
-    "sources": [
-      "file:///salus.yaml"
-    ]
+    "sources": {
+      "configured": [
+        "file:///salus.yaml"
+      ],
+      "valid": [
+        "file:///salus.yaml"
+      ]
+    }
   }
 }

--- a/spec/fixtures/processor/remote_uri/expected_report.json
+++ b/spec/fixtures/processor/remote_uri/expected_report.json
@@ -125,8 +125,13 @@
         "format": "json"
       }
     ],
-    "sources": [
-      "file:///salus.yaml"
-    ]
+    "sources": {
+      "configured": [
+        "file:///salus.yaml"
+      ],
+      "valid": [
+        "file:///salus.yaml"
+      ]
+    }
   }
 }


### PR DESCRIPTION
- Updated the processor to distinguish between configs that were valid and used, and configs that were not. 
- Updated some comments to make it more clear about the difference between the implicit config name (`salus.yaml`) and the default or base config (`salus-default.yaml`).
- I added some output to the normal report, not sure if its the best way to do it so lmk if you have other suggestions. It now adds an extra section that looks like this:
```
==== Salus Configuration Used:

  file:///salus.yaml
  file:///test_config.yml
```