### PR TITLE
fix incorrect url paths passed to semgrep

### DIFF
--- a/lib/salus/scanners/semgrep.rb
+++ b/lib/salus/scanners/semgrep.rb
@@ -172,7 +172,7 @@ module Salus::Scanners
 
       if has_external_config
         config = match['config']
-        config_val = if config.start_with?('http:') || config.start_with?('https:')
+        config_val = if config.start_with?('https:')
                        config
                      else
                        File.join(base_path, config)

--- a/lib/salus/scanners/semgrep.rb
+++ b/lib/salus/scanners/semgrep.rb
@@ -172,12 +172,17 @@ module Salus::Scanners
 
       if has_external_config
         config = match['config']
+        config_val = if config.start_with?('http:') || config.start_with?('https:')
+                       config
+                     else
+                       File.join(base_path, config)
+                     end
         command = [
           "semgrep",
           strict_flag,
           "--json",
           "--config",
-          File.join(base_path, config),
+          config_val,
           *exclude_directories_flags,
           base_path
         ].compact


### PR DESCRIPTION
You can pass a rule config file or a rule url to standalone semgrep, like
```
--config semgrep.yaml
--config https://semgrep.live/c/r/java.spring.security
```

This PR fixes a bug that causes `/home/repo` to be prepended to the front of a rule url, like below, which makes semgrep fail.
```
--config /home/repo/https://semgrep.live/c/r/java.spring.security
```