### PR TITLE
version bump to 2.10.4

### DIFF
--- a/lib/salus.rb
+++ b/lib/salus.rb
@@ -8,7 +8,7 @@ require 'salus/config'
 require 'salus/processor'
 
 module Salus
-  VERSION = '2.10.3'.freeze
+  VERSION = '2.10.4'.freeze
   DEFAULT_REPO_PATH = './repo'.freeze # This is inside the docker container at /home/repo.
 
   SafeYAML::OPTIONS[:default_mode] = :safe

--- a/spec/fixtures/integration/expected_report.json
+++ b/spec/fixtures/integration/expected_report.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.10.3",
+  "version": "2.10.4",
   "passed": true,
   "running_time": 0.0,
   "scans": {

--- a/spec/fixtures/processor/local_uri/expected_report.json
+++ b/spec/fixtures/processor/local_uri/expected_report.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.10.3",
+  "version": "2.10.4",
   "passed": true,
   "running_time": 0.0,
   "scans": {

--- a/spec/fixtures/processor/remote_uri/expected_report.json
+++ b/spec/fixtures/processor/remote_uri/expected_report.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.10.3",
+  "version": "2.10.4",
   "passed": true,
   "running_time": 0.0,
   "scans": {


### PR DESCRIPTION
Release Notes:

#157 Updated the processor to distinguish between configs that were valid and used, and configs that were not.
#157 Updated some comments to make it more clear about the difference between the implicit config name (salus.yaml) and the default or base config (salus-default.yaml).
#157 Updated salus output to include configs files used
#158 Fix incorrect salus config urls passed to semgrep