### PR TITLE
bump semgrep to 0.14.0 and make salus compatible with 0.14.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,10 +72,10 @@ RUN curl -sfL "$GOSEC_DOWNLOAD_URL" -o gosec.tar.gz \
   && mv gosec /usr/bin
 
 ### semgrep tool install https://semgrep.dev
-ENV SEMGREP_VERSION 0.10.1
+ENV SEMGREP_VERSION 0.14.0
 ENV SEMGREP_TARBALL_FILE semgrep-v$SEMGREP_VERSION-ubuntu-16.04.tgz
 ENV SEMGREP_DOWNLOAD_URL https://github.com/returntocorp/semgrep/releases/download/v$SEMGREP_VERSION/$SEMGREP_TARBALL_FILE
-ENV SEMGREP_DOWNLOAD_SHA256 7d07d223e88d52a2e8886e748726e1c8488d8d81ced34b80b128c362d9b57a0a
+ENV SEMGREP_DOWNLOAD_SHA256 8b9437af0540ed9664904f9603d9d6ad011dad46433cba74e524c7753c7732c9
 
 RUN curl -fsSL "$SEMGREP_DOWNLOAD_URL" -o semgrep.tar.gz \
   && echo "$SEMGREP_DOWNLOAD_SHA256 semgrep.tar.gz" | sha256sum -c - \

--- a/docs/scanners/semgrep.md
+++ b/docs/scanners/semgrep.md
@@ -26,8 +26,10 @@ In salus.yaml, you can specify a set of semgrep rules with a path to a [Semgrep 
 
 In addition, you can **optionally** specify
 
-* `exclude_directory` - directory to exclude from scanning
-  - The glob pattern will match anywhere in the file path parts so for example `exclude_drectory: [node_modules]` will ignore both `./node_modules`, `lib/node_modules`, and `demo/demo2/node_modules`. Passing in full paths such as `exclude_drectory: [lib/node_modules]` is not supported.
+* `exclude` - Skip any file or directory that matches this pattern
+  - `--exclude='*.py'` will ignore the following: foo.py,
+    src/foo.py, foo.py/bar.sh. --exclude='tests' will ignore tests/foo.py as well as a/b/tests/c/foo.py. Can add
+    multiple times.
 
 Here is an example semgrep section of a salus.yaml.
 
@@ -39,7 +41,7 @@ scanner_configs:
         forbidden: true
       - config: semgrep_config_2.yaml
         forbidden: true
-        exclude_directory:
+        exclude:
           - tests
 ```
 
@@ -73,8 +75,10 @@ Each simple rule in salus.yaml **must** include
 * `language`- Any of: c, go, java, javascript, or python
 
 The user can **optionally** provide
-* `exclude_directory` - directory to exclude from scanning
-  - The glob pattern will match anywhere in the file path parts so for example `exclude_drectory: [node_modules]` will ignore both `./node_modules`, `lib/node_modules`, and `demo/demo2/node_modules`. Passing in full paths such as `exclude_drectory: [lib/node_modules]` is not supported.
+* `exclude` - Skip any file or directory that matches this pattern
+  - `--exclude='*.py'` will ignore the following: foo.py,
+    src/foo.py, foo.py/bar.sh. --exclude='tests' will ignore tests/foo.py as well as a/b/tests/c/foo.py. Can add
+    multiple times.
 * `message` - Message if rule (forbidden and found) or (required and not found)
 
 Example,
@@ -87,13 +91,13 @@ scanner_configs:
         message: Useless equlity check
         language: python
         forbidden: true
-        exclude_directory:
+        exclude:
           - tests
       - pattern: $X.unsanitize(...)
         message: Don't call `unsanitize()` methods without careful review
         language: js
         forbidden: true
-        exclude_directory:
+        exclude:
           - node_modules
       - pattern: $LOG_ENDPOINT = os.getenv("LOGGER_ENDPOINT", ...)
         message: All files need to get the dynamic logger. Please don't hardcode this.

--- a/docs/scanners/semgrep.md
+++ b/docs/scanners/semgrep.md
@@ -18,7 +18,7 @@ In adddition, simple rules can be specified directly in salus.yaml.
 
 ### Specifying path to Semgrep YAML config
 
-In salus.yaml, you can specify a semgrep rule with a path to a [Semgrep config file](https://github.com/returntocorp/semgrep/blob/develop/docs/configuration-files.md).  You **must** specify
+In salus.yaml, you can specify a set of semgrep rules with a path to a [Semgrep config file](https://github.com/returntocorp/semgrep/blob/develop/docs/configuration-files.md).  You **must** specify
 
 * `config` - a full Semgrep config file
 * Either `required: true` or `forbidden: true`
@@ -29,7 +29,7 @@ In addition, you can **optionally** specify
 * `exclude_directory` - directory to exclude from scanning
   - The glob pattern will match anywhere in the file path parts so for example `exclude_drectory: [node_modules]` will ignore both `./node_modules`, `lib/node_modules`, and `demo/demo2/node_modules`. Passing in full paths such as `exclude_drectory: [lib/node_modules]` is not supported.
 
-Here is an example semgrep section of a salus.yaml.  Each match represents a rule.
+Here is an example semgrep section of a salus.yaml.
 
 ```yaml
 scanner_configs:
@@ -56,7 +56,7 @@ rules:
     severity: ERROR
 ```
 Keywords in this file:
-* `id` - Unique, descriptive identifier (required)
+* `id` - Unique, descriptive identifier, cannot contain whitespaces (required)
 * `patterns` or `pattern` - patterns or pattern or pattern-regex (required)
 * `message` - Message if rule (forbidden and found) or (required and not found) (optional)
 * `languages` - Any of: c, go, java, javascript, or python (required)

--- a/docs/scanners/semgrep.md
+++ b/docs/scanners/semgrep.md
@@ -101,6 +101,10 @@ scanner_configs:
         required: true
 ```
 
+## Whitelisting Findings
+
+Please see [semgrep's ignoring findings documentation](https://github.com/returntocorp/semgrep/blob/develop/docs/configuration-files.md#ignoring-findings).
+
 ## Limitations of Semgrep
 
 * There may be parser-related issues from Semgrep

--- a/lib/salus/scanners/semgrep.rb
+++ b/lib/salus/scanners/semgrep.rb
@@ -207,7 +207,7 @@ module Salus::Scanners
     def message_from_hit(hit, match)
       has_external_config = !match['config'].nil?
       msg = if has_external_config
-              hit['extra']['message']
+              hit['extra']['message'] + "\n\trule_id: " + hit['check_id']
             else
               match['message']
             end

--- a/lib/salus/scanners/semgrep.rb
+++ b/lib/salus/scanners/semgrep.rb
@@ -86,14 +86,14 @@ module Salus::Scanners
             if hits.empty?
               # If there were no hits, but the pattern was required add an error message.
               if match["required"]
-                failure_messages << "Required #{user_message} was not found " \
+                failure_messages << "\nRequired #{user_message} was not found " \
                 "- #{match['message']}"
               end
             else
               hits.each do |hit|
                 msg = message_from_hit(hit, match)
                 if match["forbidden"]
-                  failure_messages << "Forbidden #{user_message} was found " \
+                  failure_messages << "\nForbidden #{user_message} was found " \
                   "- #{msg}\n" \
                   "\t#{hit_to_string(hit, base_path)}"
                 end

--- a/spec/lib/salus/scanners/semgrep_spec.rb
+++ b/spec/lib/salus/scanners/semgrep_spec.rb
@@ -92,7 +92,7 @@ describe Salus::Scanners::Semgrep do
             pattern: nil,
             forbidden: false,
             required: false,
-            msg: "3 == 3 is always true",
+            msg: "3 == 3 is always true\n\trule_id: semgrep-eqeq-test",
             hit: "trivial.py:3:if 3 == 3:"
           )
 
@@ -101,7 +101,7 @@ describe Salus::Scanners::Semgrep do
             pattern: nil,
             forbidden: false,
             required: false,
-            msg: "user.id == user.id is always true",
+            msg: "user.id == user.id is always true\n\trule_id: semgrep-eqeq-test",
             hit: "examples/trivial2.py:10:    if user.id == user.id:"
           )
 
@@ -110,7 +110,7 @@ describe Salus::Scanners::Semgrep do
             pattern: nil,
             forbidden: false,
             required: false,
-            msg: "user.id == user.id is always true",
+            msg: "user.id == user.id is always true\n\trule_id: semgrep-eqeq-test",
             hit: "vendor/trivial2.py:10:    if user.id == user.id:"
           )
         end
@@ -137,7 +137,7 @@ describe Salus::Scanners::Semgrep do
             pattern: nil,
             forbidden: true,
             required: false,
-            msg: "3 == 3 is always true",
+            msg: "3 == 3 is always true\n\trule_id: semgrep-eqeq-test",
             hit: "trivial.py:3:if 3 == 3:"
           )
 
@@ -146,7 +146,7 @@ describe Salus::Scanners::Semgrep do
             pattern: nil,
             forbidden: true,
             required: false,
-            msg: "user.id == user.id is always true",
+            msg: "user.id == user.id is always true\n\trule_id: semgrep-eqeq-test",
             hit: "examples/trivial2.py:10:    if user.id == user.id:"
           )
 
@@ -155,7 +155,7 @@ describe Salus::Scanners::Semgrep do
             pattern: nil,
             forbidden: true,
             required: false,
-            msg: "user.id == user.id is always true",
+            msg: "user.id == user.id is always true\n\trule_id: semgrep-eqeq-test",
             hit: "vendor/trivial2.py:10:    if user.id == user.id:"
           )
         end
@@ -182,7 +182,7 @@ describe Salus::Scanners::Semgrep do
             pattern: nil,
             forbidden: false,
             required: true,
-            msg: "3 == 3 is always true",
+            msg: "3 == 3 is always true\n\trule_id: semgrep-eqeq-test",
             hit: "trivial.py:3:if 3 == 3:"
           )
 
@@ -191,7 +191,7 @@ describe Salus::Scanners::Semgrep do
             pattern: nil,
             forbidden: false,
             required: true,
-            msg: "user.id == user.id is always true",
+            msg: "user.id == user.id is always true\n\trule_id: semgrep-eqeq-test",
             hit: "examples/trivial2.py:10:    if user.id == user.id:"
           )
 
@@ -200,7 +200,7 @@ describe Salus::Scanners::Semgrep do
             pattern: nil,
             forbidden: false,
             required: true,
-            msg: "user.id == user.id is always true",
+            msg: "user.id == user.id is always true\n\trule_id: semgrep-eqeq-test",
             hit: "vendor/trivial2.py:10:    if user.id == user.id:"
           )
         end

--- a/spec/lib/salus/scanners/semgrep_spec.rb
+++ b/spec/lib/salus/scanners/semgrep_spec.rb
@@ -621,7 +621,7 @@ describe Salus::Scanners::Semgrep do
         expect(errors).to include(
           status: 4, # semgrep exit code documentation
           stderr: "error: invalid pattern\n\nPattern could not be parsed as a Python " \
-                  "semgrep pattern (error)\n\tCLI Input:1",
+                  "semgrep pattern (error)\n\tCLI Input:1-1",
           message: "Call to semgrep failed"
         )
       end
@@ -647,7 +647,7 @@ describe Salus::Scanners::Semgrep do
         expect(errors).to include(
           status: 3, # semgrep exit code documentation
           stderr: "warn: parse error\n\nCould not parse unparsable_py.py as python (warn)" \
-                  "\n\tunparsable_py.py:3",
+                  "\n\tunparsable_py.py:3-3",
           message: "Call to semgrep failed"
         )
       end
@@ -716,7 +716,7 @@ describe Salus::Scanners::Semgrep do
         expect(errors).to include(
           status: 3, # semgrep exit code documentation
           stderr: "warn: parse error\n\nCould not parse unparsable_js.js as js (warn)" \
-                  "\n\tunparsable_js.js:3",
+                  "\n\tunparsable_js.js:3-3",
           message: "Call to semgrep failed"
         )
       end


### PR DESCRIPTION
* Bump semgrep to 0.14.0
* Update salus semgrep to  work with the `--exclude` config option, which supercedes the old `--exclude-dir`. 
* Add `rule_id` to patterns found output.  This can be useful with the new whitelisting feature.
* Add whitelisting info in semgrep doc.
* Update salus semgrep to be compatible with new semgrep output format changes. 
  *  ```
        # old semgrep parser error format

        "message": "syntax error ....",
        "details": {
          "path": "junk.js",
          "start": {
             "line": 1,
             "col": 1
          },
          "end": {
             ....
          },
          "message": "...",
          "line": ...
        }
      } 

  * ```
        # new semgrep parser error format

          "type": "SourceParseError",
          "short_msg": "parse error",
          "long_msg": "Could not parse junk.js as javascript",
          "level": "warn",
          "spans": [
            {
              "start": {
                "line": 1,
                "col": 1
              },
              "end": {
                ...
              },
              "source_hash": "...",
              "file": "doh.js",
            }