### PR TITLE
Loading Fix - 2.10.12

### DIFF
--- a/lib/salus.rb
+++ b/lib/salus.rb
@@ -8,7 +8,7 @@ require 'salus/config'
 require 'salus/processor'
 
 module Salus
-  VERSION = '2.10.11'.freeze
+  VERSION = '2.10.12'.freeze
   DEFAULT_REPO_PATH = './repo'.freeze # This is inside the docker container at /home/repo.
 
   SafeYAML::OPTIONS[:default_mode] = :safe

--- a/lib/salus/scanners.rb
+++ b/lib/salus/scanners.rb
@@ -4,5 +4,6 @@ module Salus::Scanners; end
 Dir.entries(File.expand_path('scanners', __dir__)).sort.each do |filename|
   next if ['.', '..'].include?(filename) # don't include FS pointers
   next unless /\.rb\z/.match?(filename)  # only include ruby files
+
   require "salus/scanners/#{filename}"
 end

--- a/lib/salus/scanners.rb
+++ b/lib/salus/scanners.rb
@@ -1,8 +1,8 @@
 module Salus::Scanners; end
 
-Dir.entries(File.expand_path('scanners', __dir__)).each do |filename|
+# We'll sort to avoid any race conditions in loading order
+Dir.entries(File.expand_path('scanners', __dir__)).sort.each do |filename|
   next if ['.', '..'].include?(filename) # don't include FS pointers
   next unless /\.rb\z/.match?(filename)  # only include ruby files
-
   require "salus/scanners/#{filename}"
 end

--- a/lib/salus/scanners/cargo_audit.rb
+++ b/lib/salus/scanners/cargo_audit.rb
@@ -1,4 +1,6 @@
 require 'json'
+require 'salus/scanners/base'
+
 # Rust Cargo Audit scanner integration. Flags known malicious or vulnerable
 # dependencies in rust projects that are packaged with cargo.
 # https://github.com/RustSec/cargo-audit

--- a/spec/fixtures/integration/expected_report.json
+++ b/spec/fixtures/integration/expected_report.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.10.11",
+  "version": "2.10.12",
   "passed": true,
   "running_time": 0.0,
   "scans": {

--- a/spec/fixtures/processor/local_uri/expected_report.json
+++ b/spec/fixtures/processor/local_uri/expected_report.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.10.11",
+  "version": "2.10.12",
   "passed": true,
   "running_time": 0.0,
   "scans": {

--- a/spec/fixtures/processor/remote_uri/expected_report.json
+++ b/spec/fixtures/processor/remote_uri/expected_report.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.10.11",
+  "version": "2.10.12",
   "passed": true,
   "running_time": 0.0,
   "scans": {


### PR DESCRIPTION
An omitted require in CargoAudit (2.10.11) caused a failure in production.  This was masked by a race condition in the loading order.  The require as been added and the loading is no longer random.