### PR TITLE
Removed race condition and added missing require

### DIFF
--- a/lib/salus/scanners.rb
+++ b/lib/salus/scanners.rb
@@ -1,6 +1,7 @@
 module Salus::Scanners; end
 
-Dir.entries(File.expand_path('scanners', __dir__)).each do |filename|
+# Sort to avoid race coniditions in what order scanners are loaded
+Dir.entries(File.expand_path('scanners', __dir__)).sort.each do |filename|
   next if ['.', '..'].include?(filename) # don't include FS pointers
   next unless /\.rb\z/.match?(filename)  # only include ruby files
 

--- a/lib/salus/scanners.rb
+++ b/lib/salus/scanners.rb
@@ -1,6 +1,6 @@
 module Salus::Scanners; end
 
-# Sort to avoid race coniditions in what order scanners are loaded
+# Sort to avoid race coniditions in what order scanners are loaded.
 Dir.entries(File.expand_path('scanners', __dir__)).sort.each do |filename|
   next if ['.', '..'].include?(filename) # don't include FS pointers
   next unless /\.rb\z/.match?(filename)  # only include ruby files

--- a/lib/salus/scanners.rb
+++ b/lib/salus/scanners.rb
@@ -1,6 +1,6 @@
 module Salus::Scanners; end
 
-# Sort to avoid race coniditions in what order scanners are loaded.
+# Sort to avoid race coniditions in what order scanners are loaded
 Dir.entries(File.expand_path('scanners', __dir__)).sort.each do |filename|
   next if ['.', '..'].include?(filename) # don't include FS pointers
   next unless /\.rb\z/.match?(filename)  # only include ruby files

--- a/lib/salus/scanners/cargo_audit.rb
+++ b/lib/salus/scanners/cargo_audit.rb
@@ -1,4 +1,6 @@
 require 'json'
+require 'salus/scanners/base'
+
 # Rust Cargo Audit scanner integration. Flags known malicious or vulnerable
 # dependencies in rust projects that are packaged with cargo.
 # https://github.com/RustSec/cargo-audit


### PR DESCRIPTION
An omitted require in CargoAudit (2.10.11) caused a failure in production. This was masked by a race condition in the loading order. The require as been added and the loading is no longer random.

