### PR TITLE
Race condition and require fix

### DIFF
--- a/lib/salus/scanners.rb
+++ b/lib/salus/scanners.rb
@@ -1,6 +1,6 @@
 module Salus::Scanners; end
 
-# Sort to avoid race conditions caused by differing load orders
+# Sort to avoid race conditions caused by differing load orders.
 Dir.entries(File.expand_path('scanners', __dir__)).sort.each do |filename|
   next if ['.', '..'].include?(filename) # don't include FS pointers
   next unless /\.rb\z/.match?(filename)  # only include ruby files

--- a/lib/salus/scanners.rb
+++ b/lib/salus/scanners.rb
@@ -1,6 +1,7 @@
 module Salus::Scanners; end
 
-Dir.entries(File.expand_path('scanners', __dir__)).each do |filename|
+# Sort to avoid race conditions caused by differing load orders
+Dir.entries(File.expand_path('scanners', __dir__)).sort.each do |filename|
   next if ['.', '..'].include?(filename) # don't include FS pointers
   next unless /\.rb\z/.match?(filename)  # only include ruby files
 

--- a/lib/salus/scanners/cargo_audit.rb
+++ b/lib/salus/scanners/cargo_audit.rb
@@ -1,4 +1,6 @@
 require 'json'
+require 'salus/scanners/base'
+
 # Rust Cargo Audit scanner integration. Flags known malicious or vulnerable
 # dependencies in rust projects that are packaged with cargo.
 # https://github.com/RustSec/cargo-audit


### PR DESCRIPTION
The order in which Salus loaded the scanner classes was not guaranteed by ruby (varied by OS).  This caused a race condition for the require graph traversal.  This PR sorts the classes to load to ensure it's processed in the same order between dev / testing / production.

This PR also a missing require for Cargo Audit that was hidden by the race condition here.

Also updated specs to insulate them from cargo database updates.