### PR TITLE
Plugin spike for user-friendly config overrides

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -90,6 +90,10 @@ scanner_configs:
   BundleAudit:
     ignore:
       - CVE-XXXX-YYYY # irrelevant CVE which does not have a patch yet
+
+# String        - path to plugins directory (optional)
+plugins_directory: plugins
+
 ```
 
 Special configuration that exist for particular scanners is defined in the [scanners directory](/docs/scanners).

--- a/lib/salus/plugin_manager.rb
+++ b/lib/salus/plugin_manager.rb
@@ -1,0 +1,18 @@
+module Salus
+  class PluginManager
+    DEFAULT_DIRECTORY = 'plugins'.freeze
+
+    def self.load_plugins(directory = nil)
+      directory ||= DEFAULT_DIRECTORY
+      # Note we should add zeitwerk to salus and clean up how we do require's
+      # in salus. Short of that, we probably should memoize this per directory
+      # passed
+      project_dir = File.expand_path('../../', __dir__)
+      search = File.expand_path(File.join(directory, '*.rb'), project_dir)
+
+      Dir[search].sort.each do |filename|
+        require filename
+      end
+    end
+  end
+end

--- a/spec/fixtures/plugins/reverse_project_name.rb
+++ b/spec/fixtures/plugins/reverse_project_name.rb
@@ -1,0 +1,14 @@
+# Sample Config Filter Plugin
+# This filter simple reverse the supplied project_name before the config is applied
+
+module Filter
+  module ReverseProjectName
+    def self.filter_config(config_hash)
+      config_hash['project_name'] ||= ''
+      config_hash['project_name'].reverse!
+      config_hash
+    end
+  end
+end
+
+Salus::Config.register_filter(Filter::ReverseProjectName)

--- a/spec/fixtures/salus/plugin_config/repo/salus.yaml
+++ b/spec/fixtures/salus/plugin_config/repo/salus.yaml
@@ -1,0 +1,3 @@
+---
+plugin_directory: spec/fixtures/plugins
+project_name: 'foobar'

--- a/spec/lib/salus_spec.rb
+++ b/spec/lib/salus_spec.rb
@@ -46,6 +46,22 @@ describe Salus::CLI do
       end
     end
 
+    context 'with plugin and configuration build hash' do
+      it 'applies the plugin custom logic to the config' do
+        Dir.chdir('spec/fixtures/salus/plugin_config') do
+          ENV['SALUS_CONFIGURATION'] = 'file:///salus.yaml'
+
+          expect(Salus::Report).to receive(:new).with(report_uris: anything,
+            builds: anything,
+            project_name: 'raboof',
+            custom_info: anything,
+            config: anything).at_least(:once).and_call_original
+
+          expect(Salus.scan(quiet: true)).to eq(Salus::EXIT_SUCCESS)
+        end
+      end
+    end
+
     context 'With heartbeat set' do
       it 'outputs a heartbeat' do
         Dir.chdir('spec/fixtures/salus/success') do


### PR DESCRIPTION
PR to discuss opening up a plugin architecture.  In practice, if we want to move forward we'd want to do some light refactoring to Salus to support various filters, classes, hooks via plugins.

Some low hanging fruit might be telemetry (statsd plugin, etc), report plublishers (kafka, etc), config processors.  Expanding the plugin process to also simply allowing gems names in the salus config etc.

Opening up Salus with a plugin architecture might afford a clean approach to expanding the feature set and a good catalyst for public extensions to Salus.   This PR is provides a quick spike to show how we could plugin custom config logic.