### PR TITLE
add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "ruby:bundler"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "Dockerfile"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+


### PR DESCRIPTION
Added a dependabot config.  After we merge the PR into master, DependaBot should start making version upgrade PRs.

The config specifies
* Detect newer versions Ruby gems with "ruby:bundler"
* Detect newer version of the FROM value in Dockerfile
* Gemfile and Docker file are stored in the root directory `/`
* Check for upgrades daily.  