### PR TITLE
fix dependentBot config parse error

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,11 @@
 version: 2
 updates:
-  - package-ecosystem: "ruby:bundler"
+  - package-ecosystem: "bundler"
     directory: "/"
     schedule:
       interval: "daily"
-  - package-ecosystem: "Dockerfile"
+  - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "daily"
-
 


### PR DESCRIPTION
fix dependentBot config parse error on keywords.

#198 is the the original dependaBot config PR.
Not sure why the original config worked with my fork but not on master.

The new config has been validated with [Dependabot config validator](https://dependabot.com/docs/config-file/validator/) 