### PR TITLE
Add a custom header when posting Salus reports

### DIFF
--- a/lib/salus/report.rb
+++ b/lib/salus/report.rb
@@ -192,6 +192,7 @@ module Salus
       response = Faraday.post do |req|
         req.url remote_uri
         req.headers['Content-Type'] = CONTENT_TYPE_FOR_FORMAT[format]
+        req.headers['X-Scanner'] = "salus"
         req.body = data
       end
 


### PR DESCRIPTION
This adds a custom header when sending a POST to a report URI