### PR TITLE
version bump to 2.10.16

### DIFF
--- a/lib/salus.rb
+++ b/lib/salus.rb
@@ -8,7 +8,7 @@ require 'salus/config'
 require 'salus/processor'
 
 module Salus
-  VERSION = '2.10.15'.freeze
+  VERSION = '2.10.16'.freeze
   DEFAULT_REPO_PATH = './repo'.freeze # This is inside the docker container at /home/repo.
 
   SafeYAML::OPTIONS[:default_mode] = :safe

--- a/spec/fixtures/integration/expected_report.json
+++ b/spec/fixtures/integration/expected_report.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.10.15",
+  "version": "2.10.16",
   "passed": true,
   "running_time": 0.0,
   "scans": {

--- a/spec/fixtures/processor/local_uri/expected_report.json
+++ b/spec/fixtures/processor/local_uri/expected_report.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.10.15",
+  "version": "2.10.16",
   "passed": true,
   "running_time": 0.0,
   "scans": {

--- a/spec/fixtures/processor/remote_uri/expected_report.json
+++ b/spec/fixtures/processor/remote_uri/expected_report.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.10.15",
+  "version": "2.10.16",
   "passed": true,
   "running_time": 0.0,
   "scans": {


### PR DESCRIPTION
Downgraded brakeman from 5.0.0 to 4.10.0. We plan to do more work before deploying  brakeman 5.0.0.