### PR TITLE
Fix yarn issue

### DIFF
--- a/spec/lib/salus/scanners/yarn_audit_spec.rb
+++ b/spec/lib/salus/scanners/yarn_audit_spec.rb
@@ -93,7 +93,7 @@ describe Salus::Scanners::YarnAudit do
       report = scanner.report.to_h
       expect(report.fetch(:passed)).to eq(false)
       info = scanner.report.to_h.fetch(:info)
-      err_msg = "Couldn't find any versions for \"classnames-repo-does-not-exist\" that matches"
+      err_msg = "Received malformed response from registry for \"classnames-repo-does-not-exist\""
       expect(info[:stderr]).to include(err_msg)
     end
 


### PR DESCRIPTION
This pr fixes the yarn issue:

```
 1) Salus::Scanners::YarnAudit#run should fail with error if there are errors
     Failure/Error: expect(info[:stderr]).to include(err_msg)

       expected "error Received malformed response from registry for \"classnames-repo-does-not-exist\". The registry may be down.\n" to include "Couldn't find any versions for \"classnames-repo-does-not-exist\" that matches"
       Diff:
       @@ -1 +1 @@
       -Couldn't find any versions for "classnames-repo-does-not-exist" that matches
       +error Received malformed response from registry for "classnames-repo-does-not-exist". The registry may be down.
     # ./spec/lib/salus/scanners/yarn_audit_spec.rb:97:in `block (3 levels) in <top (required)>'
     # ./vendor/bundle/ruby/2.7.0/gems/webmock-3.11.2/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'
```