### PR TITLE
Sarif option update

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -64,7 +64,7 @@ custom_info: "PR-123"
 # Additional options are also available for sarif using the optional keyword: sarif_options
 # The available options for the sarif_options keyword are:
 # 1) `include_suppressed: true/false` -This option allows users to include/exclude suppressed/excluded results 
-#    in their sarif reports
+#    in their sarif reports. Currently this is supported for NPM audit reports
 reports:
   - uri: file://tests/salus-report.txt
     format: txt

--- a/lib/salus/report.rb
+++ b/lib/salus/report.rb
@@ -124,7 +124,7 @@ module Salus
       JSON.pretty_generate(to_h)
     end
 
-    def to_sarif(config: {})
+    def to_sarif(config = {})
       Sarif::SarifReport.new(@scan_reports, config).to_sarif
     rescue StandardError => e
       bugsnag_notify(e.class.to_s + " " + e.message + "\nBuild Info:" + @builds.to_s)
@@ -140,7 +140,7 @@ module Salus
                         when 'txt' then to_s(verbose: verbose)
                         when 'json' then to_json
                         when 'yaml' then to_yaml
-                        when 'sarif' then to_sarif(directive['sarif_options'] || {})
+                        when 'sarif' then to_sarif(directive['sarif_options'])
                         else
                           raise ExportReportError, "unknown report format #{directive['format']}"
                         end

--- a/lib/salus/report.rb
+++ b/lib/salus/report.rb
@@ -140,7 +140,7 @@ module Salus
                         when 'txt' then to_s(verbose: verbose)
                         when 'json' then to_json
                         when 'yaml' then to_yaml
-                        when 'sarif' then to_sarif(directive['sarif_options'])
+                        when 'sarif' then to_sarif(directive['sarif_options'] || {})
                         else
                           raise ExportReportError, "unknown report format #{directive['format']}"
                         end

--- a/lib/sarif/base_sarif.rb
+++ b/lib/sarif/base_sarif.rb
@@ -11,6 +11,8 @@ module Sarif
       note: "note"
     }.freeze
 
+    attr_accessor :config
+
     def initialize(scan_report, config = {})
       @scan_report = scan_report
       @mapped_rules = {} # map each rule to an index

--- a/lib/sarif/base_sarif.rb
+++ b/lib/sarif/base_sarif.rb
@@ -11,7 +11,7 @@ module Sarif
       note: "note"
     }.freeze
 
-    attr_accessor :config
+    attr_accessor :config # sarif_options
 
     def initialize(scan_report, config = {})
       @scan_report = scan_report

--- a/lib/sarif/base_sarif.rb
+++ b/lib/sarif/base_sarif.rb
@@ -11,7 +11,7 @@ module Sarif
       note: "note"
     }.freeze
 
-    def initialize(scan_report, config: {})
+    def initialize(scan_report, config = {})
       @scan_report = scan_report
       @mapped_rules = {} # map each rule to an index
       @rule_index = 0

--- a/lib/sarif/sarif_report.rb
+++ b/lib/sarif/sarif_report.rb
@@ -53,6 +53,7 @@ module Sarif
       adapter = "Sarif::#{scan_report.scanner_name}Sarif"
       begin
         converter = Object.const_get(adapter).new(scan_report)
+        converter.config = @config
         converter.build_runs_object(true)
       rescue NameError
         converter = BaseSarif.new(scan_report, @config)

--- a/lib/sarif/sarif_report.rb
+++ b/lib/sarif/sarif_report.rb
@@ -18,7 +18,7 @@ module Sarif
     SARIF_SCHEMA = "https://docs.oasis-open.org/sarif/sarif/v#{SARIF_VERSION}/csprd01/schemas/"\
     "sarif-schema-#{SARIF_VERSION}".freeze
 
-    def initialize(scan_reports, config: {})
+    def initialize(scan_reports, config = {})
       @scan_reports = scan_reports
       @config = config
     end


### PR DESCRIPTION
This PR fixes the error: 
```Could not send Salus report: (ArgumentError: wrong number of arguments (given 1, expected 0))```
produced when creating reports with sarif_options

