### PR TITLE
fix bugsnag error

### DIFF
--- a/lib/sarif/bandit_sarif.rb
+++ b/lib/sarif/bandit_sarif.rb
@@ -12,12 +12,10 @@ module Sarif
 
     def parse_scan_report!
       logs = @scan_report.log('')
-      if !logs.size.zero?
-        parsed_result = JSON.parse(@scan_report.log(''))
-        parsed_result['results'].concat(parsed_result['errors'])
-      else
-        []
-      end
+      return [] if logs.size.zero?
+
+      parsed_result = JSON.parse(logs)
+      parsed_result['results'].concat(parsed_result['errors'])
     rescue JSON::ParserError => e
       bugsnag_notify(e.message)
       []

--- a/lib/sarif/bandit_sarif.rb
+++ b/lib/sarif/bandit_sarif.rb
@@ -11,9 +11,13 @@ module Sarif
     end
 
     def parse_scan_report!
-      parsed_result = JSON.parse(@scan_report.log(''))
-
-      parsed_result['results'].concat(parsed_result['errors'])
+      logs = @scan_report.log('')
+      if !logs.size.zero?
+        parsed_result = JSON.parse(@scan_report.log(''))
+        parsed_result['results'].concat(parsed_result['errors'])
+      else
+        []
+      end
     rescue JSON::ParserError => e
       bugsnag_notify(e.message)
       []

--- a/lib/sarif/brakeman_sarif.rb
+++ b/lib/sarif/brakeman_sarif.rb
@@ -11,8 +11,13 @@ module Sarif
     end
 
     def parse_scan_report!
-      parsed_result = JSON.parse(@scan_report.log(''))
-      parsed_result['warnings'].concat(parsed_result['errors'])
+      logs = @scan_report.log('')
+      if !logs.size.zero?
+        parsed_result = JSON.parse(@scan_report.log(''))
+        parsed_result['warnings'].concat(parsed_result['errors'])
+      else
+        []
+      end
     rescue JSON::ParserError => e
       bugsnag_notify(e.message)
       []

--- a/lib/sarif/brakeman_sarif.rb
+++ b/lib/sarif/brakeman_sarif.rb
@@ -12,12 +12,10 @@ module Sarif
 
     def parse_scan_report!
       logs = @scan_report.log('')
-      if !logs.size.zero?
-        parsed_result = JSON.parse(@scan_report.log(''))
-        parsed_result['warnings'].concat(parsed_result['errors'])
-      else
-        []
-      end
+      return [] if logs.size.zero?
+
+      parsed_result = JSON.parse(logs)
+      parsed_result['warnings'].concat(parsed_result['errors'])
     rescue JSON::ParserError => e
       bugsnag_notify(e.message)
       []

--- a/lib/sarif/cargo_audit_sarif.rb
+++ b/lib/sarif/cargo_audit_sarif.rb
@@ -11,14 +11,19 @@ module Sarif
     end
 
     def parse_scan_report!
-      x = JSON.parse(@scan_report.log(''))
-      vulnerabilities = x['vulnerabilities']['list'] || []
-      unmaintained = x['warnings']['unmaintained'] || []
-      yanked = x['warnings']['yanked'] || []
-      @logs = vulnerabilities.concat(unmaintained, yanked)
+      logs = @scan_report.log('')
+      if !logs.size.zero?
+        x = JSON.parse(@scan_report.log(''))
+        vulnerabilities = x['vulnerabilities']['list'] || []
+        unmaintained = x['warnings']['unmaintained'] || []
+        yanked = x['warnings']['yanked'] || []
+        vulnerabilities.concat(unmaintained, yanked)
+      else
+        []
+      end
     rescue JSON::ParserError => e
       bugsnag_notify(e.message)
-      @logs = []
+      []
     end
 
     def parse_yanked(issue)

--- a/lib/sarif/cargo_audit_sarif.rb
+++ b/lib/sarif/cargo_audit_sarif.rb
@@ -12,15 +12,13 @@ module Sarif
 
     def parse_scan_report!
       logs = @scan_report.log('')
-      if !logs.size.zero?
-        x = JSON.parse(@scan_report.log(''))
-        vulnerabilities = x['vulnerabilities']['list'] || []
-        unmaintained = x['warnings']['unmaintained'] || []
-        yanked = x['warnings']['yanked'] || []
-        vulnerabilities.concat(unmaintained, yanked)
-      else
-        []
-      end
+      return [] if logs.size.zero?
+
+      x = JSON.parse(logs)
+      vulnerabilities = x['vulnerabilities']['list'] || []
+      unmaintained = x['warnings']['unmaintained'] || []
+      yanked = x['warnings']['yanked'] || []
+      vulnerabilities.concat(unmaintained, yanked)
     rescue JSON::ParserError => e
       bugsnag_notify(e.message)
       []

--- a/lib/sarif/gosec_sarif.rb
+++ b/lib/sarif/gosec_sarif.rb
@@ -13,18 +13,23 @@ module Sarif
     end
 
     def parse_scan_report!(scan_report)
-      json_obj = JSON.parse(scan_report.log(''))
-      issues = json_obj['Issues']
-      errors = json_obj['Golang errors']
-      parsed_errors = []
-      errors.each do |key|
-        key[1].each do |location|
-          location['uri'] = key[0]
-          parsed_errors << parse_error(location)
+      log = scan_report.log("")
+      if !log.size.zero?
+        json_obj = JSON.parse(log)
+        issues = json_obj['Issues']
+        errors = json_obj['Golang errors']
+        parsed_errors = []
+        errors.each do |key|
+          key[1].each do |location|
+            location['uri'] = key[0]
+            parsed_errors << parse_error(location)
+          end
         end
+        parsed_errors.compact!
+        issues.concat parsed_errors
+      else
+        []
       end
-      parsed_errors.compact!
-      issues.concat parsed_errors
     rescue JSON::ParserError => e
       bugsnag_notify(e.message)
       []

--- a/lib/sarif/gosec_sarif.rb
+++ b/lib/sarif/gosec_sarif.rb
@@ -13,23 +13,21 @@ module Sarif
     end
 
     def parse_scan_report!(scan_report)
-      log = scan_report.log("")
-      if !log.size.zero?
-        json_obj = JSON.parse(log)
-        issues = json_obj['Issues']
-        errors = json_obj['Golang errors']
-        parsed_errors = []
-        errors.each do |key|
-          key[1].each do |location|
-            location['uri'] = key[0]
-            parsed_errors << parse_error(location)
-          end
+      logs = scan_report.log('')
+      return [] if logs.size.zero?
+
+      json_obj = JSON.parse(logs)
+      issues = json_obj['Issues']
+      errors = json_obj['Golang errors']
+      parsed_errors = []
+      errors.each do |key|
+        key[1].each do |location|
+          location['uri'] = key[0]
+          parsed_errors << parse_error(location)
         end
-        parsed_errors.compact!
-        issues.concat parsed_errors
-      else
-        []
       end
+      parsed_errors.compact!
+      issues.concat parsed_errors
     rescue JSON::ParserError => e
       bugsnag_notify(e.message)
       []


### PR DESCRIPTION
Parse error messages are sent to bugsnag when logs are empty. This PR provides a fix to avoid this