### PR TITLE
Add suppressions for unenforced scanners

### DIFF
--- a/lib/sarif/base_sarif.rb
+++ b/lib/sarif/base_sarif.rb
@@ -112,7 +112,6 @@ module Sarif
       end
 
       invocation = build_invocations(@scan_report, supported)
-      invocation[:executionSuccessful] = true if @required == false
       {
         "tool" => build_tool(rules: rules),
         "conversion" => build_conversion,

--- a/lib/sarif/base_sarif.rb
+++ b/lib/sarif/base_sarif.rb
@@ -11,7 +11,7 @@ module Sarif
       note: "note"
     }.freeze
 
-    attr_accessor :config # sarif_options
+    attr_accessor :config, :required # sarif_options
 
     def initialize(scan_report, config = {})
       @scan_report = scan_report
@@ -96,13 +96,14 @@ module Sarif
         parsed_issue = parse_issue(issue)
         next if !parsed_issue
         next if parsed_issue[:suppressed] && @config['include_suppressed'] == false
+        next if @required == false && @config['include_suppressed'] == false
 
         rule = build_rule(parsed_issue)
         rules << rule if rule
         result = build_result(parsed_issue)
 
         # Add suppresion object for suppressed results
-        if parsed_issue[:suppressed]
+        if parsed_issue[:suppressed] || @required == false
           result['suppressions'] = [{
             'kind': 'external'
           }]
@@ -110,11 +111,13 @@ module Sarif
         results << result
       end
 
+      invocation = build_invocations(@scan_report, supported)
+      invocation[:executionSuccessful] = true if @required == false
       {
         "tool" => build_tool(rules: rules),
         "conversion" => build_conversion,
         "results" => results,
-        "invocations" => [build_invocations(@scan_report, supported)]
+        "invocations" => [invocation]
       }
     end
 

--- a/spec/lib/sarif/base_sarif_spec.rb
+++ b/spec/lib/sarif/base_sarif_spec.rb
@@ -139,7 +139,7 @@ describe Sarif::BaseSarif do
         adapter.instance_variable_set(:@required, false)
         runs_object = adapter.build_runs_object(true)
         expect(runs_object['results'].empty?).to eq(false)
-        expect(runs_object["invocations"][0][:executionSuccessful]).to eq(true)
+        expect(runs_object["invocations"][0][:executionSuccessful]).to eq(false)
       end
       it 'results are not included for non enforced scanners when include_suppressed is false' do
         parsed_issue = {

--- a/spec/lib/sarif/base_sarif_spec.rb
+++ b/spec/lib/sarif/base_sarif_spec.rb
@@ -120,6 +120,46 @@ describe Sarif::BaseSarif do
         runs_object = adapter.build_runs_object(true)
         expect(runs_object['results'].empty?).to eq(false)
       end
+
+      it 'has a suppression object when scanner is not enforced and suppressions are included' do
+        parsed_issue = {
+          id: 'SAL002',
+          name: "Golang Error",
+          level: "NOTE",
+          details: 'error',
+          start_line: 1,
+          start_column: 1,
+          uri: '',
+          help_url: "https://github.com/coinbase/salus/blob/master/docs/salus_reports.md",
+          code: ""
+        }
+        adapter = Sarif::GosecSarif.new(scan_report)
+        adapter.instance_variable_set(:@logs, [parsed_issue])
+        adapter.instance_variable_set(:@config, { "include_suppressed": true }.stringify_keys)
+        adapter.instance_variable_set(:@required, false)
+        runs_object = adapter.build_runs_object(true)
+        expect(runs_object['results'].empty?).to eq(false)
+        expect(runs_object["invocations"][0][:executionSuccessful]).to eq(true)
+      end
+      it 'results are not included for non enforced scanners when include_suppressed is false' do
+        parsed_issue = {
+          id: 'SAL002',
+          name: "Golang Error",
+          level: "NOTE",
+          details: 'error',
+          start_line: 1,
+          start_column: 1,
+          uri: '',
+          help_url: "https://github.com/coinbase/salus/blob/master/docs/salus_reports.md",
+          code: ""
+        }
+        adapter = Sarif::GosecSarif.new(scan_report)
+        adapter.instance_variable_set(:@logs, [parsed_issue])
+        adapter.instance_variable_set(:@config, { "include_suppressed": false }.stringify_keys)
+        adapter.instance_variable_set(:@required, false)
+        runs_object = adapter.build_runs_object(true)
+        expect(runs_object['results'].empty?).to eq(true)
+      end
     end
   end
 end


### PR DESCRIPTION
This PR adds suppression objects to results of unenforced scanners. This would allow users the ability to include unenforced or allow only enforced scanners in their results using the include_suppressed configuration
