### PR TITLE
add misses section to Semgrep and PatternSearch json

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,7 +35,7 @@ Metrics/ClassLength:
   Max: 1000
 
 Metrics/AbcSize:
-  Max: 100
+  Max: 150
 
 Metrics/CyclomaticComplexity:
   Max: 30

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,7 +35,7 @@ Metrics/ClassLength:
   Max: 1000
 
 Metrics/AbcSize:
-  Max: 150
+  Max: 100
 
 Metrics/CyclomaticComplexity:
   Max: 30

--- a/lib/salus/scanners/pattern_search.rb
+++ b/lib/salus/scanners/pattern_search.rb
@@ -26,6 +26,7 @@ module Salus::Scanners
       failure_messages = []
       errors = []
       all_hits = []
+      all_misses = []
 
       Dir.chdir(@repository.path_to_repo) do
         @config['matches']&.each do |match|
@@ -96,6 +97,12 @@ module Salus::Scanners
               if match['required']
                 failure_messages << "Required pattern \"#{match['regex']}\" was not found " \
                   "- #{match['message']}"
+                all_misses << {
+                  regex: match['regex'],
+                  forbidden: match['forbidden'],
+                  required: match['required'],
+                  msg: match['message']
+                }
               end
             else
               errors << { status: shell_return.status, stderr: shell_return.stderr }
@@ -111,6 +118,7 @@ module Salus::Scanners
       end
 
       report_info(:hits, all_hits)
+      report_info(:misses, all_misses)
       errors.each { |error| report_error('Call to sift failed', error) }
 
       if failure_messages.empty?

--- a/lib/salus/scanners/semgrep.rb
+++ b/lib/salus/scanners/semgrep.rb
@@ -32,6 +32,7 @@ module Salus::Scanners
       errors = []
       warnings = []
       all_hits = []
+      all_misses = []
       override_keys = %w[pattern language message]
 
       Dir.chdir(@repository.path_to_repo) do
@@ -85,6 +86,13 @@ module Salus::Scanners
               if match["required"]
                 failure_messages << "\nRequired #{user_message} was not found " \
                 "- #{match['message']}"
+                all_misses << {
+                  pattern: match['pattern'],
+                  config: match['config'],
+                  forbidden: match["forbidden"],
+                  required: match["required"],
+                  msg: match['message']
+                }
               end
             else
               hits.each do |hit|
@@ -110,6 +118,13 @@ module Salus::Scanners
             if match['required']
               failure_messages << "Required #{user_message} was not found " \
                 "- #{match['message']}"
+              all_misses << {
+                pattern: match['pattern'],
+                config: match['config'],
+                forbidden: match["forbidden"],
+                required: match["required"],
+                msg: match['message']
+              }
             end
             begin
               # parse the output
@@ -145,6 +160,7 @@ module Salus::Scanners
         end
 
         report_info(:hits, all_hits)
+        report_info(:misses, all_misses)
         errors.each { |error| report_error("Call to semgrep failed", error) }
         report_warn(:semgrep_non_fatal, warnings) unless warnings.empty?
         warning_messages.each { |message| log(message) }

--- a/lib/salus/scanners/semgrep.rb
+++ b/lib/salus/scanners/semgrep.rb
@@ -22,6 +22,7 @@ require "json"
 
 module Salus::Scanners
   class Semgrep < Base
+    # rubocop:disable Metrics/AbcSize
     def run
       global_exclude_flags = flag_list('--exclude', @config['exclude'])
 
@@ -173,6 +174,7 @@ module Salus::Scanners
         end
       end
     end
+    # rubocop:enable Metrics/AbcSize
 
     def should_run?
       true # we will always run this on the provided folder

--- a/spec/fixtures/integration/expected_report.json
+++ b/spec/fixtures/integration/expected_report.json
@@ -19,6 +19,8 @@
             "msg": "",
             "hit": "README.md:1:# placeholder"
           }
+        ],
+        "misses": [
         ]
       },
       "errors": [

--- a/spec/fixtures/processor/local_uri/expected_report.json
+++ b/spec/fixtures/processor/local_uri/expected_report.json
@@ -13,6 +13,9 @@
       "info": {
         "hits": [
 
+        ],
+        "misses": [
+
         ]
       },
       "errors": [
@@ -41,6 +44,9 @@
       },
       "info": {
         "hits": [
+
+        ],
+        "misses": [
 
         ]
       },

--- a/spec/fixtures/processor/remote_uri/expected_report.json
+++ b/spec/fixtures/processor/remote_uri/expected_report.json
@@ -13,6 +13,9 @@
       "info": {
         "hits": [
 
+        ],
+        "misses": [
+
         ]
       },
       "errors": [
@@ -41,6 +44,9 @@
       },
       "info": {
         "hits": [
+
+        ],
+        "misses": [
 
         ]
       },

--- a/spec/lib/salus/scanners/pattern_search_spec.rb
+++ b/spec/lib/salus/scanners/pattern_search_spec.rb
@@ -28,6 +28,8 @@ describe Salus::Scanners::PatternSearch do
           msg: '',
           hit: 'seal.txt:3:Nerv is tasked with taking over when the UN fails.'
         )
+
+        expect(info[:misses]).to be_empty
       end
 
       it 'should report matches with a message' do
@@ -64,6 +66,8 @@ describe Salus::Scanners::PatternSearch do
           msg: 'Shaken, not stirred.',
           hit: 'seal.txt:3:Nerv is tasked with taking over when the UN fails.'
         )
+
+        expect(info[:misses]).to be_empty
       end
     end
 
@@ -85,6 +89,7 @@ describe Salus::Scanners::PatternSearch do
           msg: '',
           hit: 'lance.txt:3:Nerv housed the lance.'
         )
+        expect(info[:misses]).to be_empty
 
         logs = scanner.report.to_h.fetch(:logs)
         failure_str = 'seal.txt:3:Nerv is tasked with taking over when the UN fails'
@@ -96,6 +101,7 @@ describe Salus::Scanners::PatternSearch do
           msg: '',
           hit: 'seal.txt:3:Nerv is tasked with taking over when the UN fails.'
         )
+        expect(info[:misses]).to be_empty
       end
     end
 
@@ -122,6 +128,7 @@ describe Salus::Scanners::PatternSearch do
           msg: 'important string',
           hit: 'lance.txt:3:Nerv housed the lance.'
         )
+        expect(info[:misses]).to be_empty
       end
 
       it 'should failed the scan if a required pattern is not found' do
@@ -140,6 +147,16 @@ describe Salus::Scanners::PatternSearch do
         failure_messages = scanner.report.to_h.fetch(:logs)
         expect(failure_messages)
           .to include('Required pattern "Tokyo3" was not found - current location')
+
+        info = scanner.report.to_h.fetch(:info)
+        expect(info[:hits]).to be_empty
+        expect(info[:misses].size).to eq(1)
+        expect(info[:misses]).to include(
+          regex: 'Tokyo3',
+          forbidden: false,
+          required: true,
+          msg: 'current location'
+        )
       end
     end
 

--- a/spec/lib/salus/scanners/semgrep_spec.rb
+++ b/spec/lib/salus/scanners/semgrep_spec.rb
@@ -739,8 +739,6 @@ describe Salus::Scanners::Semgrep do
             }
           ]
         )
-
-        info = scanner.report.to_h.fetch(:info)
       end
     end
 

--- a/spec/lib/salus/scanners/semgrep_spec.rb
+++ b/spec/lib/salus/scanners/semgrep_spec.rb
@@ -47,6 +47,8 @@ describe Salus::Scanners::Semgrep do
           msg: "",
           hit: "vendor/trivial2.py:10:    if user.id == user.id:"
         )
+
+        expect(info[:misses]).to be_empty
       end
 
       context "external config" do
@@ -113,6 +115,8 @@ describe Salus::Scanners::Semgrep do
             msg: "user.id == user.id is always true\n\trule_id: semgrep-eqeq-test",
             hit: "vendor/trivial2.py:10:    if user.id == user.id:"
           )
+
+          expect(info[:misses]).to be_empty
         end
 
         it "should report forbidden matches" do
@@ -158,6 +162,8 @@ describe Salus::Scanners::Semgrep do
             msg: "user.id == user.id is always true\n\trule_id: semgrep-eqeq-test",
             hit: "vendor/trivial2.py:10:    if user.id == user.id:"
           )
+
+          expect(info[:misses]).to be_empty
         end
 
         it "should report required matches" do
@@ -203,6 +209,8 @@ describe Salus::Scanners::Semgrep do
             msg: "user.id == user.id is always true\n\trule_id: semgrep-eqeq-test",
             hit: "vendor/trivial2.py:10:    if user.id == user.id:"
           )
+
+          expect(info[:misses]).to be_empty
         end
 
         it "should report required matches" do
@@ -223,6 +231,17 @@ describe Salus::Scanners::Semgrep do
           failure_messages = scanner.report.to_h.fetch(:logs)
           expect(failure_messages).to include(
             'Required patterns in config "semgrep-config-required.yml" was not found - '
+          )
+
+          info = scanner.report.to_h.fetch(:info)
+          expect(info[:hits]).to be_empty
+          expect(info[:misses].size).to eq(1)
+          expect(info[:misses][0]).to eq(
+            config: "semgrep-config-required.yml",
+            pattern: nil,
+            forbidden: false,
+            required: true,
+            msg: ""
           )
         end
       end
@@ -273,6 +292,8 @@ describe Salus::Scanners::Semgrep do
           msg: "Useless equality test.",
           hit: "vendor/trivial2.py:10:    if user.id == user.id:"
         )
+
+        expect(info[:misses]).to be_empty
       end
     end
 
@@ -321,6 +342,8 @@ describe Salus::Scanners::Semgrep do
           msg: "",
           hit: "vendor/trivial2.py:10:    if user.id == user.id:"
         )
+
+        expect(info[:misses]).to be_empty
       end
     end
 
@@ -371,6 +394,8 @@ describe Salus::Scanners::Semgrep do
           msg: "Useless equality test.",
           hit: "vendor/trivial2.py:10:    if user.id == user.id:"
         )
+
+        expect(info[:misses]).to be_empty
       end
 
       it "should failed the scan if a required pattern is not found" do
@@ -394,6 +419,17 @@ describe Salus::Scanners::Semgrep do
         failure_messages = scanner.report.to_h.fetch(:logs)
         expect(failure_messages).to include(
           'Required pattern "$X == 42" was not found - Should be 42'
+        )
+
+        info = scanner.report.to_h.fetch(:info)
+        expect(info[:hits]).to be_empty
+        expect(info[:misses].size).to eq(1)
+        expect(info[:misses][0]).to eq(
+          config: nil,
+          pattern: "$X == 42",
+          forbidden: false,
+          required: true,
+          msg: "Should be 42"
         )
       end
     end
@@ -623,6 +659,10 @@ describe Salus::Scanners::Semgrep do
         expect(errors[0][:stderr]).to include("Pattern could not be parsed as a Python " \
                                               "semgrep pattern (error)\n\tCLI Input:1-1")
         expect(errors[0][:message]).to eq("Call to semgrep failed")
+
+        info = scanner.report.to_h.fetch(:info)
+        expect(info[:misses]).to be_empty
+        expect(info[:hits]).to be_empty
       end
     end
 
@@ -649,6 +689,10 @@ describe Salus::Scanners::Semgrep do
           /Could not parse unparsable_py\.py as python \(warn\)\n\t.+?unparsable_py\.py:3-3/
         )
         expect(errors[0][:message]).to eq("Call to semgrep failed")
+
+        info = scanner.report.to_h.fetch(:info)
+        expect(info[:misses]).to be_empty
+        expect(info[:hits]).to be_empty
       end
     end
 
@@ -695,6 +739,8 @@ describe Salus::Scanners::Semgrep do
             }
           ]
         )
+
+        info = scanner.report.to_h.fetch(:info)
       end
     end
 
@@ -721,6 +767,10 @@ describe Salus::Scanners::Semgrep do
           /Could not parse unparsable_js\.js as js \(warn\)\n\t.+?unparsable_js\.js:3-3/
         )
         expect(errors[0][:message]).to eq("Call to semgrep failed")
+
+        info = scanner.report.to_h.fetch(:info)
+        expect(info[:misses]).to be_empty
+        expect(info[:hits]).to be_empty
       end
     end
   end


### PR DESCRIPTION
PatternSearch / Semgrep json contained structured `hits` info for patterns that were detected, like below.  But there is no structured section for patterns that were required but not detected.
```json
        "hits": [
          {
            "regex": "bar",
            "forbidden": true,
            "required": false,
            "msg": "bar is forbidden",
            "hit": "doh.js:1:bar"
          },
```

This PR adds the "misses" section, like
```json
        "misses": [
          {
            "regex": "foo",
            "forbidden": false,
            "required": true,
            "msg": "foo is required"
          },
```