### PR TITLE
add new ids for bundler audit

### DIFF
--- a/lib/sarif/bundle_audit_sarif.rb
+++ b/lib/sarif/bundle_audit_sarif.rb
@@ -12,8 +12,8 @@ module Sarif
       return nil if @issues.include?(issue[:url])
 
       @issues.add(issue[:url])
-      {
-        id: issue[:cve],
+      result = {
+        id: issue[:cve] || issue[:osvdb].to_s,
         name: issue[:advisory_title],
         level: issue[:cvss].to_i,
         details: "Package Name: #{issue[:name]}\nType: #{issue[:type]}\nVersion: "\
@@ -24,6 +24,9 @@ module Sarif
         uri: 'Gemfile.lock',
         help_url: issue[:url]
       }
+      result[:details] = issue[:source] if issue[:type] == "InsecureSource"
+      result[:id] = issue[:type] if result[:id].empty?
+      result
     end
 
     def sarif_level(severity)

--- a/lib/sarif/bundle_audit_sarif.rb
+++ b/lib/sarif/bundle_audit_sarif.rb
@@ -9,9 +9,6 @@ module Sarif
     end
 
     def parse_issue(issue)
-      return nil if @issues.include?(issue[:url])
-
-      @issues.add(issue[:url])
       result = {
         id: issue[:cve] || issue[:osvdb].to_s,
         name: issue[:advisory_title],
@@ -24,10 +21,13 @@ module Sarif
         uri: 'Gemfile.lock',
         help_url: issue[:url]
       }
+
       if issue[:type] == "InsecureSource"
+        result[:id] = issue[:type]
+        result[:name] = issue[:type] + ' ' + issue[:source]
         result[:details] = "Type: #{issue[:type]}\nSource: #{issue[:source]}"
       end
-      result[:id] = issue[:type] if result[:id].empty?
+
       result
     end
 

--- a/lib/sarif/bundle_audit_sarif.rb
+++ b/lib/sarif/bundle_audit_sarif.rb
@@ -24,7 +24,9 @@ module Sarif
         uri: 'Gemfile.lock',
         help_url: issue[:url]
       }
-      result[:details] = issue[:source] if issue[:type] == "InsecureSource"
+      if issue[:type] == "InsecureSource"
+        result[:details] = "Type: #{issue[:type]}\nSource: #{issue[:source]}"
+      end
       result[:id] = issue[:type] if result[:id].empty?
       result
     end

--- a/spec/lib/sarif/bundle_audit_spec.rb
+++ b/spec/lib/sarif/bundle_audit_spec.rb
@@ -7,6 +7,27 @@ describe Sarif::BundleAuditSarif do
 
     context 'scan report with logged vulnerabilities' do
       let(:repo) { Salus::Repo.new('spec/fixtures/bundle_audit/cves_found') }
+
+      it 'updates ids accordingly' do
+        bundle_audit_sarif = Sarif::BundleAuditSarif.new(scanner.report)
+        issue = { "type": "InsecureSource",
+          "source": "http://rubygems.org/" }
+
+        parsed_issue = bundle_audit_sarif.parse_issue(issue)
+        expect(parsed_issue[:id]).to eq("InsecureSource")
+        expect(parsed_issue[:details]).to eq("Type: InsecureSource\nSource: http://rubygems.org/")
+
+        issue = { "type": "UnpatchedGem",
+        "url": '1' }
+        parsed_issue = bundle_audit_sarif.parse_issue(issue)
+        expect(parsed_issue[:id]).to eq("UnpatchedGem")
+
+        issue = { "osvdb": "osvd value",
+          "url": '3' }
+        parsed_issue = bundle_audit_sarif.parse_issue(issue)
+        expect(parsed_issue[:id]).to eq("osvd value")
+      end
+
       it 'parses information correctly' do
         bundle_audit_sarif = Sarif::BundleAuditSarif.new(scanner.report)
         issue = scanner.report.to_h[:info][:vulnerabilities][0]

--- a/spec/lib/sarif/bundle_audit_spec.rb
+++ b/spec/lib/sarif/bundle_audit_spec.rb
@@ -15,12 +15,14 @@ describe Sarif::BundleAuditSarif do
 
         parsed_issue = bundle_audit_sarif.parse_issue(issue)
         expect(parsed_issue[:id]).to eq("InsecureSource")
+        expect(parsed_issue[:name]).to eq("InsecureSource http://rubygems.org/")
         expect(parsed_issue[:details]).to eq("Type: InsecureSource\nSource: http://rubygems.org/")
 
         issue = { "type": "UnpatchedGem",
-        "url": '1' }
+                  "cve": "CVE1234",
+                  "url": '1' }
         parsed_issue = bundle_audit_sarif.parse_issue(issue)
-        expect(parsed_issue[:id]).to eq("UnpatchedGem")
+        expect(parsed_issue[:id]).to eq("CVE1234")
 
         issue = { "osvdb": "osvd value",
           "url": '3' }
@@ -47,7 +49,8 @@ describe Sarif::BundleAuditSarif do
         "SomeModel.check(v) if k == :name }\nend\n```\n\nNote the mistaken use of `each` in the"\
         " `clean_up_params` method in the above\nexample.\n\nWorkarounds\n-----------\nDo not use"\
         " the return values of `each`, `each_value`, or `each_pair` in your\napplication.\n\n"\
-        "Patched Versions: [\"~> 5.2.4.3\", \">= 6.0.3.1\"]\nUnaffected Versions: [\"< 4.0.0\"]\n"\
+        "Patched Versions: [\"~> 5.2.4, >= 5.2.4.3\", \">= 6.0.3.1\"]\nUnaffected Versions: "\
+        "[\"< 4.0.0\"]\n"\
         "CVSS: \nOSVDB "
 
         expect(bundle_audit_sarif.parse_issue(issue)).to include(
@@ -100,7 +103,8 @@ describe Sarif::BundleAuditSarif do
         "SomeModel.check(v) if k == :name }\nend\n```\n\nNote the mistaken use of `each` in the"\
         " `clean_up_params` method in the above\nexample.\n\nWorkarounds\n-----------\nDo not use"\
         " the return values of `each`, `each_value`, or `each_pair` in your\napplication.\n\n"\
-        "Patched Versions: [\"~> 5.2.4.3\", \">= 6.0.3.1\"]\nUnaffected Versions: [\"< 4.0.0\"]\n"\
+        "Patched Versions: [\"~> 5.2.4, >= 5.2.4.3\", \">= 6.0.3.1\"]\nUnaffected Versions: "\
+        "[\"< 4.0.0\"]\n"\
         "CVSS: \nOSVDB "
 
         # Check rule info


### PR DESCRIPTION
This PR Modifies ids for bundler audit. using CVEs as id is not sufficient since some results might not have CVE