### PR TITLE
fix pattern search sarif

### DIFF
--- a/lib/sarif/pattern_search_sarif.rb
+++ b/lib/sarif/pattern_search_sarif.rb
@@ -56,12 +56,7 @@ module Sarif
     end
 
     def parse_miss(miss)
-      return nil if miss[:msg].nil?
-      return nil if miss[:msg].include?("Required")
-      return nil if @issues.include?(miss[:msg])
-
-      @issues.add(miss[:msg])
-      {
+       {
         id: "Required Pattern Not Found",
         name: "Required Pattern Not Found",
         level: "HIGH",
@@ -78,9 +73,7 @@ module Sarif
 
       url_info = issue[:hit].split(':')
       id = issue[:regex] + ' ' + issue[:hit] # [filename, line, message]
-      return nil if @issues.include?(id)
 
-      @issues.add(id)
       {
         id: "Forbidden Pattern Found",
         name: "Forbidden Pattern Found",

--- a/lib/sarif/pattern_search_sarif.rb
+++ b/lib/sarif/pattern_search_sarif.rb
@@ -56,12 +56,12 @@ module Sarif
     end
 
     def parse_miss(miss)
-       {
+      {
         id: "Required Pattern Not Found",
-        name: "Required Pattern Not Found",
-        level: "HIGH",
-        details: message(miss, true),
-        help_url: PATTERN_SEARCH_URI
+       name: "Required Pattern Not Found",
+       level: "HIGH",
+       details: message(miss, true),
+       help_url: PATTERN_SEARCH_URI
       }
     end
 
@@ -72,7 +72,6 @@ module Sarif
       return nil if !issue[:forbidden]
 
       url_info = issue[:hit].split(':')
-      id = issue[:regex] + ' ' + issue[:hit] # [filename, line, message]
 
       {
         id: "Forbidden Pattern Found",


### PR DESCRIPTION
Fix bugs in PatternSearch sarif issues
* In `parse_miss`, deleted `return nil if miss[:msg].nil?` because the value can never be `nil`.  It could be empty string though, which `message()` already takes care of.
* In `parse_miss`, deleted `return nil if miss[:msg].include?("Required")` because the user-configurable `:msg` is irrelevant here.
* In `parse_miss` and `parse_hit`, removed unneeded (and buggy) code to eliminate duplicated vulns. 

Tested on actual repo with various PatternSearch rules.