### PR TITLE
bump to 2.11.0

### DIFF
--- a/lib/salus.rb
+++ b/lib/salus.rb
@@ -9,7 +9,7 @@ require 'salus/processor'
 require 'sarif/sarif_report'
 
 module Salus
-  VERSION = '2.10.19'.freeze
+  VERSION = '2.11.0'.freeze
   DEFAULT_REPO_PATH = './repo'.freeze # This is inside the docker container at /home/repo.
 
   SafeYAML::OPTIONS[:default_mode] = :safe

--- a/spec/fixtures/integration/expected_report.json
+++ b/spec/fixtures/integration/expected_report.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.10.19",
+  "version": "2.11.0",
   "passed": true,
   "running_time": 0.0,
   "scans": {

--- a/spec/fixtures/processor/local_uri/expected_report.json
+++ b/spec/fixtures/processor/local_uri/expected_report.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.10.19",
+  "version": "2.11.0",
   "passed": true,
   "running_time": 0.0,
   "scans": {

--- a/spec/fixtures/processor/remote_uri/expected_report.json
+++ b/spec/fixtures/processor/remote_uri/expected_report.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.10.19",
+  "version": "2.11.0",
   "passed": true,
   "running_time": 0.0,
   "scans": {

--- a/spec/lib/salus/report_spec.rb
+++ b/spec/lib/salus/report_spec.rb
@@ -188,7 +188,7 @@ describe Salus::Report do
         report = build_report(directive)
 
         stub_request(:post, "https://nerv.tk3/salus-report").with(body: "{\n  \"foo\": \"bar\",\n"\
-          "  \"abc\": \"def\",\n  \"report\": {\n    \"version\": \"2.10.19\",\n    \"project_nam"\
+          "  \"abc\": \"def\",\n  \"report\": {\n    \"version\": \"2.11.0\",\n    \"project_nam"\
           "e\": \"eva00\",\n    \"passed\": false,\n    \"scans\": {\n      \"DerpScanner\": {\n "\
           "       \"scanner_name\": \"DerpScanner\",\n        \"passed\": false,\n        \"warn"\
           "\": {\n        },\n        \"info\": {\n          \"asdf\": \"qwerty\"\n        },\n "\
@@ -214,7 +214,7 @@ describe Salus::Report do
         report = build_report(directive)
 
         stub_request(:post, "https://nerv.tk3/salus-report").with(body: "---\nfoo: bar\nabc: def\n"\
-          "report:\n  :version: 2.10.19\n  :project_name: eva00\n  :passed: false\n  :scans:\n    "\
+          "report:\n  :version: 2.11.0\n  :project_name: eva00\n  :passed: false\n  :scans:\n    "\
           "DerpScanner:\n      :scanner_name: DerpScanner\n      :passed: false\n      :warn: {}\n"\
           "      :info:\n        :asdf: qwerty\n      :errors: []\n  :errors:\n  - :message: derp"\
           "\n  - :message: derp\n  - :message: derp\n  - :message: derp\n  - :message: derp\n  "\
@@ -239,7 +239,7 @@ describe Salus::Report do
         report.instance_variable_set(:@config, config)
 
         stub_request(:post, "https://nerv.tk3/salus-report").with(body: "{\"foo\"=>\"bar\", \"abc"\
-          "\"=>\"def\", \"report\"=>\"==== Salus Scan v2.10.19 for eva00\\n\\n==== Salus "\
+          "\"=>\"def\", \"report\"=>\"==== Salus Scan v2.11.0 for eva00\\n\\n==== Salus "\
           "Configuration Files Used:\\n\\n  word\\n\\n\\n==== Salus Errors\\n\\n  [\\n    {\\n    "\
           "  \\\"message\\\": \\\"derp\\\"\\n    },\\n    {\\n      \\\"message\\\": \\\"derp\\"\
           "\"\\n    },\\n    {\\n      \\\"message\\\": \\\"derp\\\"\\n    },\\n    {\\n      "\


### PR DESCRIPTION
## Added
* #335, #332, #339 PatternSearch sarif adapter
* #314, #332 Semgrep sarif adapter
* #324 Support for filtering out vulnerabilities in existing salus sarif output
* #328 Add suppressions for unenforced scanners
## Fixed
* #326 Bugsnag exceptions
* #336 BundleAudit sarif id error