### PR TITLE
Ensure we pass config to SARIF http reports

### DIFF
--- a/lib/salus/report.rb
+++ b/lib/salus/report.rb
@@ -269,7 +269,7 @@ module Salus
       return report_body_hash(config, to_s(verbose: verbose)).to_s if config['format'] == 'txt'
 
       body = report_body_hash(config, JSON.parse(to_json)) if config['format'] == 'json'
-      body = report_body_hash(config, JSON.parse(to_sarif)) if config['format'] == 'sarif'
+      body = report_body_hash(config, JSON.parse(to_sarif(config['sarif_options'] || {}))) if config['format'] == 'sarif'
       body = report_body_hash(config, JSON.parse(to_sarif_diff)) if config['format'] == 'sarif_diff'
       return JSON.pretty_generate(body) if %w[json sarif sarif_diff].include?(config['format'])
 

--- a/spec/lib/salus/report_spec.rb
+++ b/spec/lib/salus/report_spec.rb
@@ -258,7 +258,9 @@ describe Salus::Report do
         url = 'https://nerv.tk3/salus-report'
         params = { 'salus_report_param_name' => 'report',
           'additional_params' => { "foo" => "bar", "abc" => "def" } }
-        directive = { 'uri' => url, 'format' => 'sarif', 'post' => params, 'verbose': false }
+        options = {'foo' => 'bar' }
+        directive = { 'uri' => url, 'format' => 'sarif', 'post' => params,
+                      'verbose': false, 'sarif_options' => options  }
         report = build_report(directive)
         report.instance_variable_set(:@scan_reports, [])
 
@@ -273,6 +275,7 @@ describe Salus::Report do
             'X-Scanner' => 'salus' }
         ).to_return(status: 200, body: "", headers: {})
 
+        expect(report).to receive(:to_sarif).with(options).and_call_original.twice
         expect { report.export_report }.not_to raise_error
       end
     end


### PR DESCRIPTION
HTTP SARIF reports were missing the configurations sarif_options.  

We can probably circle back here and cleanup a the dual creation of local vs http.