### PR TITLE
support --ignore_config_id

### DIFF
--- a/lib/salus.rb
+++ b/lib/salus.rb
@@ -29,6 +29,7 @@ module Salus
       repo_path: DEFAULT_REPO_PATH,
       use_colors: true,
       filter_sarif: "",
+      ignore_config_id: "",
       heartbeat: true
     )
 
@@ -41,7 +42,8 @@ module Salus
       # Config option would be: --config="<uri x> <uri y> etc"
       configuration_directives = (ENV['SALUS_CONFIGURATION'] || config || '').split(URI_DELIMITER)
       processor = Salus::Processor.new(configuration_directives, repo_path: repo_path,
-                                       filter_sarif: filter_sarif)
+                                       filter_sarif: filter_sarif,
+                                       ignore_config_id: ignore_config_id)
 
       ### Scan Project ###
       # Scan project with Salus client.

--- a/lib/salus/cli.rb
+++ b/lib/salus/cli.rb
@@ -31,6 +31,10 @@ module Salus
                  desc: 'Path to sarif file. Filters out results from the sarif file.',
                  type: :string,
                  default: ''
+    class_option :ignore_config_id,
+                 desc: 'Ignore id in salus config.',
+                 type: :string,
+                 default: ''
 
     desc 'scan', 'Scan the source code of a repository.'
     def scan
@@ -40,7 +44,8 @@ module Salus
         verbose: options[:verbose],
         repo_path: options[:repo_path],
         use_colors: !options[:no_colors],
-        filter_sarif: options[:filter_sarif]
+        filter_sarif: options[:filter_sarif],
+        ignore_config_id: options[:ignore_config_id]
       )
     end
   end

--- a/lib/salus/processor.rb
+++ b/lib/salus/processor.rb
@@ -11,9 +11,11 @@ module Salus
     # repo root for a configuration file with this default name
     DEFAULT_CONFIG_SOURCE = "file:///salus.yaml".freeze
 
-    def initialize(configuration_sources = [], repo_path: DEFAULT_REPO_PATH, filter_sarif: "")
+    def initialize(configuration_sources = [], repo_path: DEFAULT_REPO_PATH, filter_sarif: "",
+                   ignore_config_id: "")
       @repo_path = repo_path
       @filter_sarif = filter_sarif
+      ignore_ids = ignore_config_id.split(',').map(&:strip)
 
       # Add default file path to the configs if empty.
       configuration_sources << DEFAULT_CONFIG_SOURCE if configuration_sources.empty?
@@ -29,8 +31,7 @@ module Salus
         end
       end
 
-      @config = Salus::Config.new(source_data)
-
+      @config = Salus::Config.new(source_data, ignore_ids)
       report_uris = interpolate_local_report_uris(@config.report_uris)
       sources = {
         sources: {
@@ -46,7 +47,8 @@ module Salus
         custom_info: @config.custom_info,
         config: @config.to_h.merge(sources),
         repo_path: repo_path,
-        filter_sarif: filter_sarif
+        filter_sarif: filter_sarif,
+        ignore_config_id: ignore_config_id
       )
     end
 

--- a/lib/salus/report.rb
+++ b/lib/salus/report.rb
@@ -26,7 +26,7 @@ module Salus
     attr_reader :builds
 
     def initialize(report_uris: [], builds: {}, project_name: nil, custom_info: nil, config: nil,
-                   repo_path: nil, filter_sarif: nil)
+                   repo_path: nil, filter_sarif: nil, ignore_config_id: nil)
       @report_uris = report_uris     # where we will send this report
       @builds = builds               # build hash, could have arbitrary keys
       @project_name = project_name   # the project_name we are scanning
@@ -37,6 +37,7 @@ module Salus
       @running_time = nil            # overall running time for the scan; see #record
       @filter_sarif = filter_sarif   # Filter out results from this file
       @repo_path = repo_path         # path to repo
+      @ignore_config_id = ignore_config_id # ignore id in salus config
     end
 
     def record
@@ -109,6 +110,10 @@ module Salus
       end
 
       output += indent(wrapify(stringified_config, indented_wrap))
+
+      if @ignore_config_id != "" && !@ignore_config_id.nil?
+        output += "\n  IDs ignored in salus config:\n\t#{@ignore_config_id}"
+      end
 
       if !@errors.empty?
         stringified_errors = JSON.pretty_generate(@errors)

--- a/spec/fixtures/config/multiple_reports.yaml
+++ b/spec/fixtures/config/multiple_reports.yaml
@@ -1,0 +1,10 @@
+reports:
+  - uri: file://out.json
+    format: json
+    id: json
+  - uri: file://out.sarif
+    format: sarif
+    id: sarif
+  - uri: file://out.txt
+    format: txt
+    id: txt

--- a/spec/fixtures/config/multiple_reports2.yaml
+++ b/spec/fixtures/config/multiple_reports2.yaml
@@ -1,0 +1,10 @@
+reports:
+  - uri: file://out2.json
+    format: json
+    id: json
+  - uri: file://out2.sarif
+    format: sarif
+    id: sarif
+  - uri: file://out2.txt
+    format: txt
+    id: txt

--- a/spec/fixtures/config/multiple_reports3.yaml
+++ b/spec/fixtures/config/multiple_reports3.yaml
@@ -1,0 +1,10 @@
+reports:
+  - uri: file://out3.json
+    format: json
+    id: json
+  - uri: file://out3.sarif
+    format: sarif
+    id: sarif
+  - uri: file://out3.txt
+    format: txt
+    id: txt

--- a/spec/lib/salus/processor_spec.rb
+++ b/spec/lib/salus/processor_spec.rb
@@ -32,12 +32,11 @@ describe Salus::Processor do
         stub_request(:get, http_config_uri).to_return(status: 200, body: config_file)
         expect(Salus::Config).to receive(:new)
           .once
-          .with([file_config_file, http_config_file])
+          .with([file_config_file, http_config_file], [])
           .and_call_original
 
         Dir.chdir('spec/fixtures/processor/explicit_config') do
           processor = Salus::Processor.new([file_config_uri, http_config_uri])
-
           reported_config = processor.report.to_h[:config]
           expect(reported_config[:sources][:valid]).to include(file_config_uri, http_config_uri)
           expect(reported_config[:active_scanners]).to include(
@@ -76,7 +75,7 @@ describe Salus::Processor do
 
     context 'implicitly look for file' do
       it 'should load the default config from the salus.yaml and add to report' do
-        expect(Salus::Config).to receive(:new).once.with([config_file]).and_call_original
+        expect(Salus::Config).to receive(:new).once.with([config_file], []).and_call_original
         Dir.chdir('spec/fixtures/processor') do
           processor = Salus::Processor.new
 

--- a/spec/lib/salus_spec.rb
+++ b/spec/lib/salus_spec.rb
@@ -105,5 +105,31 @@ describe Salus::CLI do
         end
       end
     end
+
+    context 'With --ignore_config_id' do
+      it 'Should filter out report ids' do
+        Dir.chdir('spec/fixtures/config') do
+          # These salus configs write json, sarif, and txt
+
+          ENV['SALUS_CONFIGURATION'] = 'file:///multiple_reports.yaml'
+          Salus.scan(quiet: true, repo_path: '.')
+          expect(File).to exist('out.sarif')
+          expect(File).to exist('out.json')
+          expect(File).to exist('out.txt')
+
+          ENV['SALUS_CONFIGURATION'] = 'file:///multiple_reports2.yaml'
+          Salus.scan(quiet: true, repo_path: '.', ignore_config_id: 'reports:txt')
+          expect(File).to exist('out2.sarif')
+          expect(File).to exist('out2.json')
+          expect(File).not_to exist('out2.txt')
+
+          ENV['SALUS_CONFIGURATION'] = 'file:///multiple_reports3.yaml'
+          Salus.scan(quiet: true, repo_path: '.', ignore_config_id: 'reports:txt,reports:json')
+          expect(File).to exist('out3.sarif')
+          expect(File).not_to exist('out3.json')
+          expect(File).not_to exist('out3.txt')
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
### What changed?

Support for `--ignore_config_id`.

Suppose salus config contains
```yaml
reports:
  - uri: file://out.json
    format: json
    id: report_json
  - uri: file://out.sarif
    format: sarif
    id: report_sarif
  - uri: file://out.txt
    format: txt
    id: report_txt
```

This command will ignore the `uri: file://out.txt` section.  
```
docker run --rm -t -v $(pwd):/home/repo coinbase/salus --ignore_config_id "reports:report_txt"
```
Note in `reports:report_txt`, `reports` matches the "reports" key in the salus config, and `report_txt` matches the "id"

Multiple ignores can be specified with comma separators, like
```
docker run --rm -t -v $(pwd):/home/repo coinbase/salus --ignore_config_id "reports:report_txt,reports:report_json"
```

### How has this been tested?

* new specs 
* Manually running `docker run ... --ignore_config_id ...`