### PR TITLE
fix failed specs due to bundle audit CVE update

### DIFF
--- a/spec/lib/sarif/bundle_audit_spec.rb
+++ b/spec/lib/sarif/bundle_audit_spec.rb
@@ -35,16 +35,30 @@ describe Sarif::BundleAuditSarif do
         issue = scanner.report.to_h[:info][:vulnerabilities][0]
 
         expected_details = bundle_audit_sarif.parse_issue(issue)[:details]
-        details = 'Advisory Title: Possible Information Disclosure / Unintended Method Execution'
-        expect(expected_details).to include(details)
 
-        expect(bundle_audit_sarif.parse_issue(issue)).to include(
-          id: "CVE-2021-22885",
-          name: "Possible Information Disclosure / Unintended Method Execution in Action Pack",
-          level: 0,
-          help_url: "https://groups.google.com/g/rubyonrails-security/c/NiQl-48cXYI",
-          uri: "Gemfile.lock"
-        )
+        if expected_details.include?('CVE-2021-22885')
+          details = 'Advisory Title: Possible Information Disclosure / Unintended Method Execution'
+          expect(expected_details).to include(details)
+
+          expect(bundle_audit_sarif.parse_issue(issue)).to include(
+            id: "CVE-2021-22885",
+            name: "Possible Information Disclosure / Unintended Method Execution in Action Pack",
+            level: 0,
+            help_url: "https://groups.google.com/g/rubyonrails-security/c/NiQl-48cXYI",
+            uri: "Gemfile.lock"
+          )
+        else
+          details = 'Advisory Title: Possible Strong Parameters Bypass in ActionPack'
+          expect(expected_details).to include(details)
+
+          expect(bundle_audit_sarif.parse_issue(issue)).to include(
+            id: "CVE-2020-8164",
+            name: "Possible Strong Parameters Bypass in ActionPack",
+            level: 0,
+            help_url: "https://groups.google.com/forum/#!topic/rubyonrails-security/f6ioe4sdpbY",
+            uri: "Gemfile.lock"
+          )
+        end
       end
     end
   end
@@ -72,20 +86,37 @@ describe Sarif::BundleAuditSarif do
         report.add_scan_report(scanner.report, required: false)
         result = JSON.parse(report.to_sarif)["runs"][0]["results"][0]
         rules = JSON.parse(report.to_sarif)["runs"][0]["tool"]["driver"]["rules"][0]
-        expected = 'Advisory Title: Possible Information Disclosure / Unintended'
 
-        # Check rule info
-        expect(rules['id']).to eq('CVE-2021-22885')
-        rule_name = 'Possible Information Disclosure / Unintended Method Execution in Action Pack'
-        expect(rules['name']).to eq(rule_name)
-        rule_uri = 'https://groups.google.com/g/rubyonrails-security/c/NiQl-48cXYI'
-        expect(rules['helpUri']).to eq(rule_uri)
-        expect(rules['fullDescription']['text']).to include(expected)
+        if rules['id'] == 'CVE-2021-22885'
+          # Check rule info
+          expect(rules['id']).to eq('CVE-2021-22885')
+          rule_name = 'Possible Information Disclosure / Unintended Method Execution in Action Pack'
+          expect(rules['name']).to eq(rule_name)
+          rule_uri = 'https://groups.google.com/g/rubyonrails-security/c/NiQl-48cXYI'
+          expect(rules['helpUri']).to eq(rule_uri)
+          expected = 'Advisory Title: Possible Information Disclosure / Unintended'
+          expect(rules['fullDescription']['text']).to include(expected)
 
-        # Check result info
-        expect(result['ruleId']).to eq('CVE-2021-22885')
-        expect(result['ruleIndex']).to eq(0)
-        expect(result['level']).to eq("note")
+          # Check result info
+          expect(result['ruleId']).to eq('CVE-2021-22885')
+          expect(result['ruleIndex']).to eq(0)
+          expect(result['level']).to eq("note")
+        else
+          # Check rule info
+          expect(rules['id']).to eq('CVE-2020-8164')
+          rule_name = 'Possible Strong Parameters Bypass in ActionPack'
+          expect(rules['name']).to eq(rule_name)
+          rule_uri = 'https://groups.google.com/forum/#!topic/rubyonrails-security/f6ioe4sdpbY'
+          expect(rules['helpUri']).to eq(rule_uri)
+          expect(rules['fullDescription']['text']).to include(expected)
+
+          # Check result info
+          expect(result['ruleId']).to eq('CVE-2020-8164')
+          expect(result['ruleIndex']).to eq(0)
+          expect(result['level']).to eq("note")
+          expected = 'Advisory Title: Possible Strong Parameters Bypass in ActionPack'
+        end
+
         expect(result['message']['text']).to include(expected)
       end
     end

--- a/spec/lib/sarif/bundle_audit_spec.rb
+++ b/spec/lib/sarif/bundle_audit_spec.rb
@@ -108,13 +108,13 @@ describe Sarif::BundleAuditSarif do
           expect(rules['name']).to eq(rule_name)
           rule_uri = 'https://groups.google.com/forum/#!topic/rubyonrails-security/f6ioe4sdpbY'
           expect(rules['helpUri']).to eq(rule_uri)
+          expected = 'Advisory Title: Possible Strong Parameters Bypass in ActionPack'
           expect(rules['fullDescription']['text']).to include(expected)
 
           # Check result info
           expect(result['ruleId']).to eq('CVE-2020-8164')
           expect(result['ruleIndex']).to eq(0)
           expect(result['level']).to eq("note")
-          expected = 'Advisory Title: Possible Strong Parameters Bypass in ActionPack'
         end
 
         expect(result['message']['text']).to include(expected)

--- a/spec/lib/sarif/bundle_audit_spec.rb
+++ b/spec/lib/sarif/bundle_audit_spec.rb
@@ -34,31 +34,15 @@ describe Sarif::BundleAuditSarif do
         bundle_audit_sarif = Sarif::BundleAuditSarif.new(scanner.report)
         issue = scanner.report.to_h[:info][:vulnerabilities][0]
 
-        # should Parse and fill out hash
-        expected = "Package Name: actionpack\nType: UnpatchedGem\nVersion: 4.1.15\n Advisory"\
-        " Title: Possible Strong Parameters Bypass in ActionPack\nDesciption: There is a strong"\
-        " parameters bypass vector in ActionPack.\n\nVersions Affected:  rails <= 6.0.3\nNot "\
-        "affected:       rails < 4.0.0\nFixed Versions:     rails >= 5.2.4.3, rails >= 6.0.3.1"\
-        "\n\nImpact\n------\nIn some cases user supplied information can be inadvertently leaked"\
-        " from\nStrong Parameters.  Specifically the return value of `each`, or `each_value`,\nor"\
-        " `each_pair` will return the underlying \"untrusted\" hash of data that was\nread from "\
-        "the parameters.  Applications that use this return value may be\ninadvertently use "\
-        "untrusted user input.\n\nImpacted code will look something like this:\n\n```\ndef update"\
-        "\n  # Attacker has included the parameter: `{ is_admin: true }`\n  "\
-        "User.update(clean_up_params)\nend\n\ndef clean_up_params\n   params.each { |k, v|  "\
-        "SomeModel.check(v) if k == :name }\nend\n```\n\nNote the mistaken use of `each` in the"\
-        " `clean_up_params` method in the above\nexample.\n\nWorkarounds\n-----------\nDo not use"\
-        " the return values of `each`, `each_value`, or `each_pair` in your\napplication.\n\n"\
-        "Patched Versions: [\"~> 5.2.4, >= 5.2.4.3\", \">= 6.0.3.1\"]\nUnaffected Versions: "\
-        "[\"< 4.0.0\"]\n"\
-        "CVSS: \nOSVDB "
+        expected_details = bundle_audit_sarif.parse_issue(issue)[:details]
+        details = 'Advisory Title: Possible Information Disclosure / Unintended Method Execution'
+        expect(expected_details).to include(details)
 
         expect(bundle_audit_sarif.parse_issue(issue)).to include(
-          id: "CVE-2020-8164",
-          details: expected,
-          name: "Possible Strong Parameters Bypass in ActionPack",
+          id: "CVE-2021-22885",
+          name: "Possible Information Disclosure / Unintended Method Execution in Action Pack",
           level: 0,
-          help_url: "https://groups.google.com/forum/#!topic/rubyonrails-security/f6ioe4sdpbY",
+          help_url: "https://groups.google.com/g/rubyonrails-security/c/NiQl-48cXYI",
           uri: "Gemfile.lock"
         )
       end
@@ -88,34 +72,18 @@ describe Sarif::BundleAuditSarif do
         report.add_scan_report(scanner.report, required: false)
         result = JSON.parse(report.to_sarif)["runs"][0]["results"][0]
         rules = JSON.parse(report.to_sarif)["runs"][0]["tool"]["driver"]["rules"][0]
-
-        expected = "Package Name: actionpack\nType: UnpatchedGem\nVersion: 4.1.15\n Advisory"\
-        " Title: Possible Strong Parameters Bypass in ActionPack\nDesciption: There is a strong"\
-        " parameters bypass vector in ActionPack.\n\nVersions Affected:  rails <= 6.0.3\nNot "\
-        "affected:       rails < 4.0.0\nFixed Versions:     rails >= 5.2.4.3, rails >= 6.0.3.1"\
-        "\n\nImpact\n------\nIn some cases user supplied information can be inadvertently leaked"\
-        " from\nStrong Parameters.  Specifically the return value of `each`, or `each_value`,\nor"\
-        " `each_pair` will return the underlying \"untrusted\" hash of data that was\nread from "\
-        "the parameters.  Applications that use this return value may be\ninadvertently use "\
-        "untrusted user input.\n\nImpacted code will look something like this:\n\n```\ndef update"\
-        "\n  # Attacker has included the parameter: `{ is_admin: true }`\n  "\
-        "User.update(clean_up_params)\nend\n\ndef clean_up_params\n   params.each { |k, v|  "\
-        "SomeModel.check(v) if k == :name }\nend\n```\n\nNote the mistaken use of `each` in the"\
-        " `clean_up_params` method in the above\nexample.\n\nWorkarounds\n-----------\nDo not use"\
-        " the return values of `each`, `each_value`, or `each_pair` in your\napplication.\n\n"\
-        "Patched Versions: [\"~> 5.2.4, >= 5.2.4.3\", \">= 6.0.3.1\"]\nUnaffected Versions: "\
-        "[\"< 4.0.0\"]\n"\
-        "CVSS: \nOSVDB "
+        expected = 'Advisory Title: Possible Information Disclosure / Unintended'
 
         # Check rule info
-        expect(rules['id']).to eq('CVE-2020-8164')
-        expect(rules['name']).to eq("Possible Strong Parameters Bypass in ActionPack")
-        expect(rules['helpUri']).to eq("https://groups.google.com/forum/#!topic/rubyonrails"\
-          "-security/f6ioe4sdpbY")
+        expect(rules['id']).to eq('CVE-2021-22885')
+        rule_name = 'Possible Information Disclosure / Unintended Method Execution in Action Pack'
+        expect(rules['name']).to eq(rule_name)
+        rule_uri = 'https://groups.google.com/g/rubyonrails-security/c/NiQl-48cXYI'
+        expect(rules['helpUri']).to eq(rule_uri)
         expect(rules['fullDescription']['text']).to include(expected)
 
         # Check result info
-        expect(result['ruleId']).to eq('CVE-2020-8164')
+        expect(result['ruleId']).to eq('CVE-2021-22885')
         expect(result['ruleIndex']).to eq(0)
         expect(result['level']).to eq("note")
         expect(result['message']['text']).to include(expected)

--- a/spec/lib/sarif/bundle_audit_spec.rb
+++ b/spec/lib/sarif/bundle_audit_spec.rb
@@ -99,8 +99,6 @@ describe Sarif::BundleAuditSarif do
 
           # Check result info
           expect(result['ruleId']).to eq('CVE-2021-22885')
-          expect(result['ruleIndex']).to eq(0)
-          expect(result['level']).to eq("note")
         else
           # Check rule info
           expect(rules['id']).to eq('CVE-2020-8164')
@@ -113,10 +111,10 @@ describe Sarif::BundleAuditSarif do
 
           # Check result info
           expect(result['ruleId']).to eq('CVE-2020-8164')
-          expect(result['ruleIndex']).to eq(0)
-          expect(result['level']).to eq("note")
         end
 
+        expect(result['ruleIndex']).to eq(0)
+        expect(result['level']).to eq("note")
         expect(result['message']['text']).to include(expected)
       end
     end


### PR DESCRIPTION
Bundle Audit updated the CVE on a package, which caused the specs to fail.