### PR TITLE
add report filter

### DIFF
--- a/lib/salus/report.rb
+++ b/lib/salus/report.rb
@@ -44,7 +44,9 @@ module Salus
 
     def apply_report_hash_filters(report_hash)
       @@filters.each do |filter|
-        report_hash = filter.filter_report_hash(report_hash) if filter.respond_to?(:filter_report_hash)
+        if filter.respond_to?(:filter_report_hash)
+          report_hash = filter.filter_report_hash(report_hash)
+        end
       end
       report_hash
     end

--- a/lib/salus/report.rb
+++ b/lib/salus/report.rb
@@ -44,7 +44,7 @@ module Salus
 
     def apply_report_hash_filters(report_hash)
       @@filters.each do |filter|
-        report_hash = filter.filter_config(report_hash) if filter.respond_to?(:filter_config)
+        report_hash = filter.filter_report_hash(report_hash) if filter.respond_to?(:filter_report_hash)
       end
       report_hash
     end

--- a/spec/fixtures/blank_repository2/test_plugins/report_filter.rb
+++ b/spec/fixtures/blank_repository2/test_plugins/report_filter.rb
@@ -1,11 +1,11 @@
 module Filter
-  module TestReportConfig
-    def self.filter_config(report_hash)
+  module TestReportFilter
+    def self.filter_report_hash(report_hash)
       report_hash[:config][:builds] ||= {}
       report_hash[:config][:builds][:mykey] = 'myval'
       report_hash
     end
   end
 
-  Salus::Report.register_filter(Filter::TestReportConfig)
+  Salus::Report.register_filter(Filter::TestReportFilter)
 end

--- a/spec/fixtures/blank_repository2/test_plugins/report_filter.rb
+++ b/spec/fixtures/blank_repository2/test_plugins/report_filter.rb
@@ -1,0 +1,11 @@
+module Filter
+  module TestReportConfig
+    def self.filter_config(report_hash)
+      report_hash[:config][:builds] ||= {}
+      report_hash[:config][:builds][:mykey] = 'myval'
+      report_hash
+    end
+  end
+
+  Salus::Report.register_filter(Filter::TestReportConfig)
+end

--- a/spec/lib/salus_spec.rb
+++ b/spec/lib/salus_spec.rb
@@ -190,7 +190,7 @@ describe Salus::CLI do
                               "abcd" => "xyzw",
                               "service_name" => "circle_CI",
                               "url" => "my_url",
-                              "mykey"=>"myval"}
+                              "mykey" => "myval" }
           expect(builds).to eq(expected_builds)
         end
       end

--- a/spec/lib/salus_spec.rb
+++ b/spec/lib/salus_spec.rb
@@ -189,7 +189,8 @@ describe Salus::CLI do
           expected_builds = { "abc" => "xyz",
                               "abcd" => "xyzw",
                               "service_name" => "circle_CI",
-                              "url" => "my_url" }
+                              "url" => "my_url",
+                              "mykey"=>"myval"}
           expect(builds).to eq(expected_builds)
         end
       end


### PR DESCRIPTION
Added reporter filter support, so we can add something like
```ruby
module Filter
  module TestReportFilter
    def self.filter_report_hash(report_hash)
      report_hash[:config][:builds] ||= {}
      report_hash[:config][:builds][:mykey] = 'myval'
      report_hash
    end
  end

  Salus::Report.register_filter(Filter::TestReportFilter)
end
```

Then the report hash will include `[:config][:builds][:mykey] = 'myval'`