### PR TITLE
add supported_languages

### DIFF
--- a/lib/salus/scanners/bandit.rb
+++ b/lib/salus/scanners/bandit.rb
@@ -68,6 +68,10 @@ module Salus::Scanners
       shell_return.stdout&.split("\n")&.dig(0)&.split&.dig(1)
     end
 
+    def self.supported_languages
+      ['python']
+    end
+
     # Taken from https://pypi.org/project/bandit/#usage
     def config_options
       string_to_flag_map = {

--- a/lib/salus/scanners/base.rb
+++ b/lib/salus/scanners/base.rb
@@ -40,6 +40,10 @@ module Salus::Scanners
       ''
     end
 
+    def self.supported_languages
+      []
+    end
+
     def version_valid?(version)
       return false if !version.is_a?(String)
 

--- a/lib/salus/scanners/brakeman.rb
+++ b/lib/salus/scanners/brakeman.rb
@@ -46,6 +46,10 @@ module Salus::Scanners
       Gem.loaded_specs["brakeman"].version.to_s
     end
 
+    def self.supported_languages
+      ['ruby']
+    end
+
     # Taken from https://brakemanscanner.org/docs/options/
     def config_options
       flag_with_two_dashes = { type: :flag, prefix: '--' }

--- a/lib/salus/scanners/bundle_audit.rb
+++ b/lib/salus/scanners/bundle_audit.rb
@@ -42,6 +42,10 @@ module Salus::Scanners
       Gem.loaded_specs['bundler-audit'].version.to_s
     end
 
+    def self.supported_languages
+      ['ruby']
+    end
+
     private
 
     def serialize_vuln(vuln)

--- a/lib/salus/scanners/cargo_audit.rb
+++ b/lib/salus/scanners/cargo_audit.rb
@@ -65,6 +65,10 @@ module Salus::Scanners
       shell_return.stdout&.split&.dig(1)
     end
 
+    def self.supported_languages
+      ['rust']
+    end
+
     protected
 
     def has_vulnerabilities?(json_string)

--- a/lib/salus/scanners/gosec.rb
+++ b/lib/salus/scanners/gosec.rb
@@ -60,6 +60,10 @@ module Salus::Scanners
       shell_return.stdout&.split('\n')&.dig(0)&.split&.dig(1)
     end
 
+    def self.supported_languages
+      ['go']
+    end
+
     # flag options taken from https://github.com/securego/gosec/blob/2.0.0/cmd/gosec/main.go
     def config_options
       lmh_regex = /\Alow|medium|high\z/i

--- a/lib/salus/scanners/npm_audit.rb
+++ b/lib/salus/scanners/npm_audit.rb
@@ -19,6 +19,10 @@ module Salus::Scanners
       shell_return.stdout&.strip
     end
 
+    def self.supported_languages
+      ['javascript']
+    end
+
     private
 
     def scan_for_cves

--- a/lib/salus/scanners/yarn_audit.rb
+++ b/lib/salus/scanners/yarn_audit.rb
@@ -58,6 +58,10 @@ module Salus::Scanners
       shell_return.stdout&.strip
     end
 
+    def self.supported_languages
+      ['javascript']
+    end
+
     private
 
     def parse_output(lines)

--- a/spec/lib/salus/scanners/bandit_spec.rb
+++ b/spec/lib/salus/scanners/bandit_spec.rb
@@ -467,4 +467,13 @@ describe Salus::Scanners::Bandit do
       end
     end
   end
+
+  describe '#supported_languages' do
+    context 'should return supported languages' do
+      it 'should return python' do
+        langs = Salus::Scanners::Bandit.supported_languages
+        expect(langs).to eq(['python'])
+      end
+    end
+  end
 end

--- a/spec/lib/salus/scanners/brakeman_spec.rb
+++ b/spec/lib/salus/scanners/brakeman_spec.rb
@@ -296,4 +296,13 @@ describe Salus::Scanners::Brakeman do
       end
     end
   end
+
+  describe '#supported_languages' do
+    context 'should return supported languages' do
+      it 'should return ruby' do
+        langs = Salus::Scanners::Brakeman.supported_languages
+        expect(langs).to eq(['ruby'])
+      end
+    end
+  end
 end

--- a/spec/lib/salus/scanners/bundle_audit_spec.rb
+++ b/spec/lib/salus/scanners/bundle_audit_spec.rb
@@ -115,4 +115,13 @@ describe Salus::Scanners::BundleAudit do
       end
     end
   end
+
+  describe '#supported_languages' do
+    context 'should return supported languages' do
+      it 'should return ruby' do
+        langs = Salus::Scanners::BundleAudit.supported_languages
+        expect(langs).to eq(['ruby'])
+      end
+    end
+  end
 end

--- a/spec/lib/salus/scanners/cargo_audit_spec.rb
+++ b/spec/lib/salus/scanners/cargo_audit_spec.rb
@@ -24,7 +24,7 @@ class ProcessStatusDouble
   end
 
   def success?
-    @exitstatus == 0
+    @exitstatus.zero?
   end
 end
 
@@ -164,6 +164,15 @@ describe Salus::Scanners::CargoAudit do
         repo = Salus::Repo.new("dir")
         scanner = Salus::Scanners::CargoAudit.new(repository: repo, config: {})
         expect(scanner.version).to be_a_valid_version
+      end
+    end
+  end
+
+  describe '#supported_languages' do
+    context 'should return supported languages' do
+      it 'should return rust' do
+        langs = Salus::Scanners::CargoAudit.supported_languages
+        expect(langs).to eq(['rust'])
       end
     end
   end

--- a/spec/lib/salus/scanners/gosec_spec.rb
+++ b/spec/lib/salus/scanners/gosec_spec.rb
@@ -328,4 +328,13 @@ describe Salus::Scanners::Gosec do
       end
     end
   end
+
+  describe '#supported_languages' do
+    context 'should return supported languages' do
+      it 'should return go' do
+        langs = Salus::Scanners::Gosec.supported_languages
+        expect(langs).to eq(['go'])
+      end
+    end
+  end
 end

--- a/spec/lib/salus/scanners/npm_audit_spec.rb
+++ b/spec/lib/salus/scanners/npm_audit_spec.rb
@@ -28,4 +28,13 @@ describe Salus::Scanners::NPMAudit do
       end
     end
   end
+
+  describe '#supported_languages' do
+    context 'should return supported languages' do
+      it 'should return javascript' do
+        langs = Salus::Scanners::NPMAudit.supported_languages
+        expect(langs).to eq(['javascript'])
+      end
+    end
+  end
 end

--- a/spec/lib/salus/scanners/pattern_search_spec.rb
+++ b/spec/lib/salus/scanners/pattern_search_spec.rb
@@ -483,4 +483,13 @@ describe Salus::Scanners::PatternSearch do
       end
     end
   end
+
+  describe '#supported_languages' do
+    context 'should return supported languages' do
+      it 'should return empty' do
+        langs = Salus::Scanners::PatternSearch.supported_languages
+        expect(langs).to eq([])
+      end
+    end
+  end
 end

--- a/spec/lib/salus/scanners/yarn_audit_spec.rb
+++ b/spec/lib/salus/scanners/yarn_audit_spec.rb
@@ -158,4 +158,13 @@ describe Salus::Scanners::YarnAudit do
       end
     end
   end
+
+  describe '#supported_languages' do
+    context 'should return supported languages' do
+      it 'should return javascript' do
+        langs = Salus::Scanners::YarnAudit.supported_languages
+        expect(langs).to eq(['javascript'])
+      end
+    end
+  end
 end


### PR DESCRIPTION
added `def supported_languages` for some scanners to return an array of supported languages. 
Default will be `[]`.