### PR TITLE
Updating our error handling to keep trying reports when one fails

### DIFF
--- a/lib/salus.rb
+++ b/lib/salus.rb
@@ -56,15 +56,7 @@ module Salus
       puts processor.string_report(verbose: verbose, use_colors: use_colors) unless quiet
 
       # Try to send Salus reports to remote server or local files.
-      begin
-        processor.export_report
-      rescue StandardError => e
-        raise e if ENV['RUNNING_SALUS_TESTS']
-
-        puts "Could not send Salus report: (#{e.class}: #{e.message})"
-        e = "Could not send Salus report. Exception: #{e}, Build info: #{processor.report.builds}"
-        bugsnag_notify(e)
-      end
+      processor.export_report
 
       heartbeat_thr&.kill
 

--- a/lib/salus/report.rb
+++ b/lib/salus/report.rb
@@ -214,17 +214,15 @@ module Salus
       end
     end
 
-
     def export_report
       @report_uris.each do |directive|
-        begin
-          publish_report(directive)
-        rescue StandardError => e
-          raise e if ENV['RUNNING_SALUS_TESTS']
-          puts "Could not send Salus report: (#{e.class}: #{e.message})"
-          e = "Could not send Salus report. Exception: #{e}, Build info: #{processor.report.builds}"
-          bugsnag_notify(e)
-        end
+        publish_report(directive)
+      rescue StandardError => e
+        raise e if ENV['RUNNING_SALUS_TESTS']
+
+        puts "Could not send Salus report: (#{e.class}: #{e.message})"
+        e = "Could not send Salus report. Exception: #{e}, Build info: #{processor.report.builds}"
+        bugsnag_notify(e)
       end
     end
 

--- a/lib/salus/report.rb
+++ b/lib/salus/report.rb
@@ -221,7 +221,7 @@ module Salus
         raise e if ENV['RUNNING_SALUS_TESTS']
 
         puts "Could not send Salus report: (#{e.class}: #{e.message})"
-        e = "Could not send Salus report. Exception: #{e}, Build info: #{processor.report.builds}"
+        e = "Could not send Salus report. Exception: #{e}, Build info: #{builds}"
         bugsnag_notify(e)
       end
     end

--- a/lib/salus/report.rb
+++ b/lib/salus/report.rb
@@ -185,33 +185,45 @@ module Salus
       sarif_results
     end
 
+    def publish_report(directive)
+      # First create the string for the report.
+      uri = directive['uri']
+      verbose = directive['verbose'] || false
+      # Now send this string to its destination.
+      report_string = case directive['format']
+                      when 'txt' then to_s(verbose: verbose)
+                      when 'json' then to_json
+                      when 'yaml' then to_yaml
+                      when 'sarif' then to_sarif(directive['sarif_options'] || {})
+                      when 'sarif_diff' then to_sarif_diff
+                      else
+                        raise ExportReportError, "unknown report format #{directive['format']}"
+                      end
+      if Salus::Config::REMOTE_URI_SCHEME_REGEX.match?(URI(uri).scheme)
+        send_report(uri, report_body(directive), directive['format'])
+      else
+        # must remove the file:// schema portion of the uri.
+        uri_object = URI(uri)
+        file_path = "#{uri_object.host}#{uri_object.path}"
+        if !safe_local_report_path?(file_path)
+          bad_path_msg = "Local report uri #{file_path} should be relative to repo path and " \
+                         "cannot have invalid chars"
+          raise StandardError, bad_path_msg
+        end
+        write_report_to_file(file_path, report_string)
+      end
+    end
+
+
     def export_report
       @report_uris.each do |directive|
-        # First create the string for the report.
-        uri = directive['uri']
-        verbose = directive['verbose'] || false
-        # Now send this string to its destination.
-        report_string = case directive['format']
-                        when 'txt' then to_s(verbose: verbose)
-                        when 'json' then to_json
-                        when 'yaml' then to_yaml
-                        when 'sarif' then to_sarif(directive['sarif_options'] || {})
-                        when 'sarif_diff' then to_sarif_diff
-                        else
-                          raise ExportReportError, "unknown report format #{directive['format']}"
-                        end
-        if Salus::Config::REMOTE_URI_SCHEME_REGEX.match?(URI(uri).scheme)
-          send_report(uri, report_body(directive), directive['format'])
-        else
-          # must remove the file:// schema portion of the uri.
-          uri_object = URI(uri)
-          file_path = "#{uri_object.host}#{uri_object.path}"
-          if !safe_local_report_path?(file_path)
-            bad_path_msg = "Local report uri #{file_path} should be relative to repo path and " \
-                           "cannot have invalid chars"
-            raise StandardError, bad_path_msg
-          end
-          write_report_to_file(file_path, report_string)
+        begin
+          publish_report(directive)
+        rescue StandardError => e
+          raise e if ENV['RUNNING_SALUS_TESTS']
+          puts "Could not send Salus report: (#{e.class}: #{e.message})"
+          e = "Could not send Salus report. Exception: #{e}, Build info: #{processor.report.builds}"
+          bugsnag_notify(e)
         end
       end
     end

--- a/spec/fixtures/processor/multiple_endpoints/expected_report.json
+++ b/spec/fixtures/processor/multiple_endpoints/expected_report.json
@@ -1,0 +1,159 @@
+{
+  "version": "2.11.8",
+  "passed": true,
+  "running_time": 0.0,
+  "scans": {
+    "PatternSearch": {
+      "scanner_name": "PatternSearch",
+      "version": "0.9.0",
+      "passed": true,
+      "running_time": 0.0,
+      "warn": {
+      },
+      "info": {
+        "hits": [
+
+        ],
+        "misses": [
+
+        ]
+      },
+      "errors": [
+
+      ]
+    },
+    "RepoNotEmpty": {
+      "scanner_name": "RepoNotEmpty",
+      "version": "",
+      "passed": true,
+      "running_time": 0.0,
+      "warn": {
+      },
+      "info": {
+      },
+      "errors": [
+
+      ]
+    },
+    "Semgrep": {
+      "scanner_name": "Semgrep",
+      "version": "0.36.0",
+      "passed": true,
+      "running_time": 0.0,
+      "warn": {
+      },
+      "info": {
+        "hits": [
+
+        ],
+        "misses": [
+
+        ]
+      },
+      "errors": [
+
+      ]
+    }
+  },
+  "errors": [
+
+  ],
+  "config": {
+    "active_scanners": [
+      "Bandit",
+      "Brakeman",
+      "BundleAudit",
+      "CargoAudit",
+      "Gosec",
+      "NPMAudit",
+      "PatternSearch",
+      "RepoNotEmpty",
+      "ReportGoDep",
+      "ReportNodeModules",
+      "ReportPythonModules",
+      "ReportRubyGems",
+      "ReportRustCrates",
+      "Semgrep",
+      "YarnAudit"
+    ],
+    "enforced_scanners": [
+      "Brakeman",
+      "BundleAudit",
+      "CargoAudit",
+      "Gosec",
+      "NPMAudit",
+      "PatternSearch",
+      "RepoNotEmpty",
+      "Semgrep",
+      "YarnAudit"
+    ],
+    "scanner_configs": {
+      "Bandit": {
+        "pass_on_raise": false
+      },
+      "Brakeman": {
+        "pass_on_raise": false
+      },
+      "BundleAudit": {
+        "pass_on_raise": false
+      },
+      "CargoAudit": {
+        "pass_on_raise": false
+      },
+      "Gosec": {
+        "pass_on_raise": false
+      },
+      "NPMAudit": {
+        "pass_on_raise": false
+      },
+      "PatternSearch": {
+        "pass_on_raise": false
+      },
+      "RepoNotEmpty": {
+        "pass_on_raise": false
+      },
+      "ReportGoDep": {
+        "pass_on_raise": false
+      },
+      "ReportNodeModules": {
+        "pass_on_raise": false
+      },
+      "ReportPythonModules": {
+        "pass_on_raise": false
+      },
+      "ReportRubyGems": {
+        "pass_on_raise": false
+      },
+      "ReportRustCrates": {
+        "pass_on_raise": false
+      },
+      "Semgrep": {
+        "pass_on_raise": false
+      },
+      "YarnAudit": {
+        "pass_on_raise": false
+      },
+      "NodeAudit": {
+        "pass_on_raise": false
+      }
+    },
+    "report_uris": [
+      {
+        "uri": "https://nerv.tk3/salus-report",
+        "format": "json"
+      }
+    ],
+    "builds": {
+      "url": "http://example.com/builds/123",
+      "service_name": "buildkite"
+    },
+    "sources": {
+      "configured": [
+        "file:///salus.yaml"
+      ],
+      "valid": [
+        "file:///salus.yaml"
+      ]
+    }
+  }
+}

--- a/spec/fixtures/processor/multiple_endpoints/salus.yaml
+++ b/spec/fixtures/processor/multiple_endpoints/salus.yaml
@@ -1,0 +1,9 @@
+---
+reports:
+  - uri: https://nerv.tk3/salus-report
+    format: json
+  - uri: https://nerv.tk3/foo-salus-report
+    format: json
+builds:
+  url: http://example.com/builds/123
+  service_name: buildkite

--- a/spec/lib/salus/processor_spec.rb
+++ b/spec/lib/salus/processor_spec.rb
@@ -189,7 +189,7 @@ describe Salus::Processor do
       let(:remote_uri_one) { 'https://nerv.tk3/foo-salus-report' }
       let(:remote_uri_two) { 'https://nerv.tk3/salus-repor' }
 
-      it 'should send the report to the remote URI' do
+      it 'should still send the 2nd report to the remote URI' do
         stub_request(:post, remote_uri_one)
           .with(headers: { 'Content-Type' => 'application/json' })
           .and_raise(StandardError.new("error"))

--- a/spec/lib/salus/processor_spec.rb
+++ b/spec/lib/salus/processor_spec.rb
@@ -181,5 +181,36 @@ describe Salus::Processor do
         remove_file(local_uri)
       end
     end
+
+   context 'multiple URIs' do
+      let(:expected_report) do
+        File.read('spec/fixtures/processor/remote_uri/expected_report.json').strip
+      end
+      let(:remote_uri_one) { 'https://nerv.tk3/foo-salus-report' }
+      let(:remote_uri_two) { 'https://nerv.tk3/salus-repor' }
+
+      it 'should send the report to the remote URI' do
+        stub_request(:post, remote_uri_one)
+          .with(headers: { 'Content-Type' => 'application/json' })
+          .and_raise(StandardError.new("error"))
+
+        stub_request(:post, remote_uri_two)
+          .with(headers: { 'Content-Type' => 'application/json' })
+          .to_return(status: 202)
+
+        processor = Salus::Processor.new(repo_path: 'spec/fixtures/processor/multiple_endpoints')
+        processor.scan_project
+        processor.export_report
+
+        assert_requested(
+          :post,
+          remote_uri,
+          headers: { 'Content-Type' => 'application/json' },
+          times: 1
+        ) do |req|
+          expect(req.body).to match_report_json(expected_report)
+        end
+      end
+    end
   end
 end

--- a/spec/lib/salus/processor_spec.rb
+++ b/spec/lib/salus/processor_spec.rb
@@ -187,7 +187,7 @@ describe Salus::Processor do
         File.read('spec/fixtures/processor/remote_uri/expected_report.json').strip
       end
       let(:remote_uri_one) { 'https://nerv.tk3/foo-salus-report' }
-      let(:remote_uri_two) { 'https://nerv.tk3/salus-repor' }
+      let(:remote_uri_two) { 'https://nerv.tk3/salus-report' }
 
       it 'should still send the 2nd report to the remote URI' do
         stub_request(:post, remote_uri_one)
@@ -198,18 +198,11 @@ describe Salus::Processor do
           .with(headers: { 'Content-Type' => 'application/json' })
           .to_return(status: 202)
 
+        expect_any_instance_of(Salus::Report).to receive(:send_report).twice
+
         processor = Salus::Processor.new(repo_path: 'spec/fixtures/processor/multiple_endpoints')
         processor.scan_project
         processor.export_report
-
-        assert_requested(
-          :post,
-          remote_uri,
-          headers: { 'Content-Type' => 'application/json' },
-          times: 1
-        ) do |req|
-          expect(req.body).to match_report_json(expected_report)
-        end
       end
     end
   end

--- a/spec/lib/salus/processor_spec.rb
+++ b/spec/lib/salus/processor_spec.rb
@@ -182,7 +182,7 @@ describe Salus::Processor do
       end
     end
 
-   context 'multiple URIs' do
+    context 'multiple URIs' do
       let(:expected_report) do
         File.read('spec/fixtures/processor/remote_uri/expected_report.json').strip
       end


### PR DESCRIPTION
Previously Salus would bail on sending reports to endpoints when an endpoint fails.  This change ensures that we attempt to send reports to all endpoints.