### PR TITLE
support running gosec from a configurable list of subdirs

### DIFF
--- a/docs/scanners/gosec.md
+++ b/docs/scanners/gosec.md
@@ -29,4 +29,7 @@ The [Gosec Scanner](https://github.com/securego/gosec) is a static analysis tool
         - tests
         - temp
         - vendor
+      run_from_dirs:                     # run gosec from the specified subdirs only
+        - subdir1                        # for now, any other gosec config will apply to all subdir runs
+        - subdir2
 ```

--- a/lib/salus/scanners/gosec.rb
+++ b/lib/salus/scanners/gosec.rb
@@ -7,26 +7,77 @@ require 'json'
 module Salus::Scanners
   class Gosec < Base
     def run
+      return run_from_dir if @config['run_from_dirs'].nil?
+
+      @gosec_failed = false
+      @gosec_stderr = ''
+      @gosec_stdout = ''
+      @gosec_json = {}
+      run_from_dirs = @config['run_from_dirs'].sort
+      @config.delete('run_from_dirs')
+      run_from_dirs.each do |dir|
+        if dir.start_with?("/") || dir.start_with?("./") || dir.include?("..")
+          msg = "run_from_dirs values should be relative paths to subdirs in the repo " \
+                "and cannot start with ./"
+          report_stderr(msg)
+          report_error(
+            msg,
+            status: 1
+          )
+          return report_failure
+        else
+          run_from_dir(dir)
+        end
+      end
+
+      return report_success if @gosec_failed == false
+
+      log(JSON.pretty_generate(@gosec_json)) if !@gosec_json.empty?
+      report_stderr(@gosec_stderr) if @gosec_stderr.empty?
+      report_stdout(@gosec_stdout) if @gosec_stdout.empty?
+      report_failure
+    end
+
+    # rubocop:disable Style/IfInsideElse
+    def run_from_dir(dir = nil)
       # Shell Instructions:
       #   - -fmt=json for JSON output
-      shell_return = Dir.chdir(@repository.path_to_repo) do
+      work_dir = if dir
+                   File.join(@repository.path_to_repo, dir)
+                 else
+                   @repository.path_to_repo
+                 end
+
+      shell_return = Dir.chdir(work_dir) do
         cmd = "gosec #{config_options}-fmt=json ./..."
         run_shell(cmd)
       end
 
       # This produces no JSON output so must be checked before parsing stdout
       if shell_return.stdout.blank? && shell_return.stderr.include?('No packages found')
-        report_error(
-          '0 lines of code were scanned',
-          status: shell_return.status
-        )
-        report_stderr(shell_return.stderr)
+        if dir.nil?
+          report_error(
+            '0 lines of code were scanned',
+            status: shell_return.status
+          )
+          report_stderr(shell_return.stderr)
+        else
+          report_error(
+            "0 lines of code were scanned in #{dir}",
+            status: shell_return.status
+          )
+          @gosec_failed = true
+          @gosec_stderr += shell_return.stderr + "\n"
+        end
         return report_failure
       end
 
       shell_return_json = JSON.parse(shell_return.stdout)
       lines_scanned = shell_return_json['Stats']['lines']  # number of lines scanned
-      golang_errors = shell_return_json['Golang errors']   # a hash of compile errors
+      files_scanned = shell_return_json['Stats']['files']  # number of files scanned
+      num_nosec = shell_return_json['Stats']['nosec']  # number of nosec
+      num_found = shell_return_json['Stats']['found']  # number found
+      golang_errors = shell_return_json['Golang errors'] # a hash of compile errors
       found_issues = shell_return_json['Issues'] # a list of found issues
 
       # Gosec's Logging Behavior:
@@ -35,24 +86,63 @@ module Salus::Scanners
       #   - build error    - status 1, logs to STDERR only
       return report_success if shell_return.success? && lines_scanned.positive?
 
+      @gosec_failed = true
       report_failure
       if shell_return.status == 1 && (!golang_errors.empty? || !found_issues.empty?)
-        report_stdout(shell_return.stdout)
-        log(shell_return.stdout)
+        if dir.nil?
+          report_stdout(shell_return.stdout)
+          log(shell_return.stdout)
+        else
+          @gosec_stdout += shell_return.stdout + "\n"
+
+          if @gosec_json == {}
+            @gosec_json['Golang errors'] = {}
+            @gosec_json['Issues'] = []
+            @gosec_json['Stats'] = {}
+            %w[files lines nosec found].each do |name|
+              @gosec_json['Stats'][name] = 0
+            end
+          end
+
+          @gosec_json['Issues'] += found_issues
+          @gosec_json['Stats']['files'] += files_scanned
+          @gosec_json['Stats']['lines'] += lines_scanned
+          @gosec_json['Stats']['nosec'] += num_nosec
+          @gosec_json['Stats']['found'] += num_found
+          golang_errors = golang_errors.map { |ek, ev| [dir + '/' + ek, ev] }.to_h
+          @gosec_json['Golang errors'].merge!(golang_errors)
+        end
       elsif lines_scanned.zero?
-        report_error(
-          "0 lines of code were scanned",
-          status: shell_return.status
-        )
-        report_stderr(shell_return.stderr)
+        if dir.nil?
+          report_error(
+            "0 lines of code were scanned",
+            status: shell_return.status
+          )
+          report_stderr(shell_return.stderr)
+        else
+          report_error(
+            "0 lines of code were scanned in #{dir}",
+            status: shell_return.status
+          )
+          @gosec_stderr += shell_return.stderr + "\n"
+        end
       else
-        report_error(
-          "gosec exited with build error: #{shell_return.stderr}",
-          status: shell_return.status
-        )
-        report_stderr(shell_return.stderr)
+        if dir.nil?
+          report_error(
+            "gosec exited with build error: #{shell_return.stderr}",
+            status: shell_return.status
+          )
+          report_stderr(shell_return.stderr)
+        else
+          report_error(
+            "gosec exited with build error in #{dir}: #{shell_return.stderr}",
+            status: shell_return.status
+          )
+          @gosec_stderr += shell_return.stderr + "\n"
+        end
       end
     end
+    # rubocop:enable Style/IfInsideElse
 
     def version
       shell_return = run_shell('gosec --version')

--- a/lib/salus/scanners/gosec.rb
+++ b/lib/salus/scanners/gosec.rb
@@ -37,8 +37,8 @@ module Salus::Scanners
       return report_success if @gosec_failed == false
 
       log(JSON.pretty_generate(@gosec_json)) if !@gosec_json.empty?
-      report_stderr(@gosec_stderr) if @gosec_stderr.empty?
-      report_stdout(@gosec_stdout) if @gosec_stdout.empty?
+      report_stderr(@gosec_stderr) if !@gosec_stderr.empty?
+      report_stdout(@gosec_stdout) if !@gosec_stdout.empty?
       report_failure
     end
 

--- a/lib/salus/scanners/gosec.rb
+++ b/lib/salus/scanners/gosec.rb
@@ -16,7 +16,7 @@ module Salus::Scanners
       @gosec_stdout = ''   # ...      stdout ...
       @gosec_json = {}     # combined json result on all runs
       run_from_dirs = @config['run_from_dirs'].sort
-      @config.delete('run_from_dirs')
+      run_from_dirs_val = @config.delete('run_from_dirs')
       run_from_dirs.each do |dir|
         if dir.start_with?("/") || dir.start_with?("./") || dir.include?("..")
           msg = "run_from_dirs values should be relative paths to subdirs in the repo " \
@@ -36,6 +36,7 @@ module Salus::Scanners
       # success only if none of the runs set @gosec_failed = true
       return report_success if @gosec_failed == false
 
+      @config['run_from_dirs'] = run_from_dirs_val
       log(JSON.pretty_generate(@gosec_json)) if !@gosec_json.empty?
       report_stderr(@gosec_stderr) if !@gosec_stderr.empty?
       report_stdout(@gosec_stdout) if !@gosec_stdout.empty?

--- a/salus.yaml
+++ b/salus.yaml
@@ -9,3 +9,4 @@ scanner_configs:
       - spec/fixtures/gosec/vulnerable_goapp
       - spec/fixtures/gosec/multifolder_goapp
       - spec/fixtures/gosec/recursive_vulnerable_goapp
+      - spec/fixtures/gosec/multi_goapps

--- a/spec/fixtures/gosec/multi_goapps/app1/hello.go
+++ b/spec/fixtures/gosec/multi_goapps/app1/hello.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"crypto/md5"
+	"fmt"
+	"io"
+)
+
+func main() {
+
+	password := "hhend77dyyydbh&^psNSSZ)JSM--_%"
+
+	h := md5.New()
+	fmt.Printf("%x", h.Sum(nil))
+
+	fmt.Println("hello, from the vulnerable app" + password)
+}

--- a/spec/fixtures/gosec/multi_goapps/app2/hello.go
+++ b/spec/fixtures/gosec/multi_goapps/app2/hello.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"crypto/md5"
+	"fmt"
+	"io"
+)
+
+func main() {
+
+	password := "hhend77dyyydbh&^psNSSZ)JSM--_%"
+
+	h := md5.New()
+	fmt.Printf("%x", h.Sum(nil))
+
+	fmt.Println("hello, from the vulnerable app" + password)
+}

--- a/spec/fixtures/gosec/multi_goapps/app3/hello.go
+++ b/spec/fixtures/gosec/multi_goapps/app3/hello.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"crypto/md5"
+	"fmt"
+	"io"
+)
+
+func main() {
+
+	password := "hhend77dyyydbh&^psNSSZ)JSM--_%"
+
+	h := md5.New()
+	fmt.Printf("%x", h.Sum(nil))
+
+	fmt.Println("hello, from the vulnerable app" + password)
+}

--- a/spec/fixtures/gosec/multi_goapps/salus.yaml
+++ b/spec/fixtures/gosec/multi_goapps/salus.yaml
@@ -1,0 +1,5 @@
+scanner_configs:
+  Gosec:
+    run_from_dirs:
+      - app1
+      - app2

--- a/spec/fixtures/gosec/multi_goapps/salus.yaml
+++ b/spec/fixtures/gosec/multi_goapps/salus.yaml
@@ -1,5 +1,6 @@
 scanner_configs:
   Gosec:
+    no-fail: true
     run_from_dirs:
       - app1
       - app2

--- a/spec/fixtures/gosec/multi_goapps/salus.yaml
+++ b/spec/fixtures/gosec/multi_goapps/salus.yaml
@@ -1,6 +1,5 @@
 scanner_configs:
   Gosec:
-    no-fail: true
     run_from_dirs:
       - app1
       - app2

--- a/spec/lib/salus/scanners/gosec_spec.rb
+++ b/spec/lib/salus/scanners/gosec_spec.rb
@@ -77,6 +77,32 @@ describe Salus::Scanners::Gosec do
     end
   end
 
+  describe '#run from multiple subdirs' do
+    context 'go project with multiple sub-projects' do
+      let(:repo) { 'spec/fixtures/gosec/multi_goapps' }
+
+      it 'should report failures in both sub-projects' do
+        config_file = "#{repo}/salus.yaml"
+        configs = Salus::Config.new([File.read(config_file)]).scanner_configs['Gosec']
+        scanner = Salus::Scanners::Gosec.new(repository: Salus::Repo.new(repo), config: configs)
+        scanner.run
+
+        expect(scanner.report.passed?).to eq(false)
+
+        logs = JSON.parse(scanner.report.to_h[:logs])
+        issues_arr = logs['Issues']
+        golang_errs = logs['Golang errors']
+
+        expect(issues_arr.size).to eq(6)
+        expect(issues_arr.to_s).to include('/multi_goapps/app1/hello.go')
+        expect(issues_arr.to_s).to include('/multi_goapps/app2/hello.go')
+        expect(golang_errs.size).to eq(2)
+        expect(golang_errs.to_s).to include('/multi_goapps/app1/hello.go')
+        expect(golang_errs.to_s).to include('/multi_goapps/app2/hello.go')
+      end
+    end
+  end
+
   describe '#should_run?' do
     let(:scanner) { Salus::Scanners::Gosec.new(repository: repo, config: {}) }
 

--- a/spec/lib/salus/scanners/gosec_spec.rb
+++ b/spec/lib/salus/scanners/gosec_spec.rb
@@ -82,6 +82,10 @@ describe Salus::Scanners::Gosec do
       let(:repo) { 'spec/fixtures/gosec/multi_goapps' }
 
       it 'should report failures in both sub-projects' do
+        # test case shows gosec only runs from the specified subdirs in salus.yaml
+        # there are 3 identical subdirs in the repo: app1, app2, app3, all with vulns
+        # salus.yaml says run_from_dirs = [app1, app2]
+        # so result vulns are reported for app1 and app2 only, not app3
         config_file = "#{repo}/salus.yaml"
         configs = Salus::Config.new([File.read(config_file)]).scanner_configs['Gosec']
         scanner = Salus::Scanners::Gosec.new(repository: Salus::Repo.new(repo), config: configs)


### PR DESCRIPTION
Support option to run gosec only from specified subdirs.  Example salus.yaml
```yaml
scanner_configs:
  Gosec:
    run_from_dirs:
      - app1
      - app2
      - app3
```