### PR TITLE
Ensure we return a non-zero error code on bad params

### DIFF
--- a/lib/salus/cli.rb
+++ b/lib/salus/cli.rb
@@ -48,5 +48,9 @@ module Salus
         ignore_config_id: options[:ignore_config_id]
       )
     end
+
+    def self.exit_on_failure?
+      true
+    end
   end
 end

--- a/spec/lib/salus/cli_spec.rb
+++ b/spec/lib/salus/cli_spec.rb
@@ -1,0 +1,15 @@
+require_relative '../../spec_helper.rb'
+
+describe Salus::CLI do
+  it 'returns non-zero exit when invalid params are passed' do
+    expect { Salus::CLI.start(['foo bar']) }.to raise_error(SystemExit) do |error|
+      expect(error.status).to eq(1)
+    end
+  end
+
+  it 'returns zero on success' do
+    Salus::CLI.start([])
+  rescue SystemExit => e
+    expect(e.status).to eq 0 # exited with failure status
+  end
+end

--- a/spec/lib/salus/cli_spec.rb
+++ b/spec/lib/salus/cli_spec.rb
@@ -6,10 +6,4 @@ describe Salus::CLI do
       expect(error.status).to eq(1)
     end
   end
-
-  it 'returns zero on success' do
-    Salus::CLI.start([])
-  rescue SystemExit => e
-    expect(e.status).to eq 0 # exited with failure status
-  end
 end


### PR DESCRIPTION
Thor has an odd behavior of returning a zero status code even when the CLI params are invalid.  See https://github.com/rails/thor/issues/244

This PR updates Salus to return a non zero error code when Salus is called with unexpected parameters.