### PR TITLE
Expanded plugins

### DIFF
--- a/bin/salus
+++ b/bin/salus
@@ -4,5 +4,9 @@ lib = File.expand_path('../lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require 'salus'
+require 'salus/plugin_manager'
+
+Salus::PluginManager.load_plugins
+Salus::PluginManager.send_event(:cli, :startup, ARGV)
 
 Salus::CLI.start(ARGV)

--- a/bin/salus
+++ b/bin/salus
@@ -7,6 +7,6 @@ require 'salus'
 require 'salus/plugin_manager'
 
 Salus::PluginManager.load_plugins
-Salus::PluginManager.send_event(:cli, :startup, ARGV)
+Salus::PluginManager.send_event(:cli_startup, ARGV)
 
 Salus::CLI.start(ARGV)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -75,7 +75,7 @@ Events are published, plugins can register listeners for events.
 
 `Event: scanners_ran `
 
-- scanners_ran will be invoked after all scanners have ran.  The data playload will be an array of scanner names
+- scanners_ran will be invoked after all scanners have ran.  The data playload will be an array of scanners ran and a second parameter for the SalusReport object
 
 `Event :run_shell`
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,3 +15,20 @@ The source code being scanned is volumed into the container and Salus expects to
   - [`Salus::Repo`](../lib/salus/repo.rb): representation of the repository being scanned.
   - [`Salus::Report`](../lib/salus/report.rb): object that collects data about scans and compiles a report.
   - [`Salus::Scanners::<name>`](../lib/salus/scanners): scanner objects that can determine if a scanner should run, runs the scanner and collect the results.
+
+## Plugins
+
+Filters
+
+Salus::PluginManager.apply_filter(:salus_config, :filter_config, config_hash)
+Salus::PluginManager.apply_filter(:salus_report, :filter_report_hash, report_hash)
+
+Events
+
+Salus::PluginManager.send_event(:cli, :startup, ARGV)
+Salus::PluginManager.send_event(:cli, :scan, options)
+Salus::PluginManager.send_event(:salus, :scan, method(__method__).parameters)
+Salus::PluginManager.send_event(:salus_processor, :skip_scanner, scanner_name)
+Salus::PluginManager.send_event(:salus_processor, :run_scanner, scanner_name)
+Salus::PluginManager.send_event(:salus_processor, :scanners_ran, scanners_ran)
+Salus::PluginManager.send_event(:salus_scanner_base, :run_shell, command)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -77,7 +77,7 @@ Events are published, plugins can register listeners for events.  Like filters, 
 
 - salus_procesor scanners_ran will be invoked after all scanners have ran.  The data playload will be an array of scanner names
 
-`Group :salus_scanner_base, :run_shell`
+`Group :salus_scanner_base, Event :run_shell`
 
 - salus_scanner_base run_shell is called when a scanner executes a shell command to run a native scanner.  The data payload will be the array of arguments.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -51,33 +51,33 @@ Salus::PluginManager.register_filter(:salus_report, filter)
 
 ## Events
 
-Events are published, plugins can register listeners for events.  Like filters, events are namedspaced to grups
-`Group :cli, Event :startup`
+Events are published, plugins can register listeners for events.
+`Event :cli_startup`
 
-- cli startup is called when bin/salus calls out the Salus::CLI.start(ARGV) to begin the cli.  ARGV is passed as the data to this event
+- cli_startup is called when bin/salus calls out the Salus::CLI.start(ARGV) to begin the cli.  ARGV is passed as the data to this event
 
-`Group :cli, Event :scan`
-`Salus::PluginManager.send_event(:cli, :scan, options)`
+`Event :cli_scan`
+`Salus::PluginManager.send_event(:cli_scan, options)`
 
-- cli csan is called once the cli begins the scan,  The CLI options are passed as the data to the event
+- cli_csan is called once the cli begins the scan,  The CLI options are passed as the data to the event
 
-`Group :salus, Event :scan`
+`Event :salus_scan`
 
 - salus scan. This event will be called with the Salus scan has begun.  The data playload will be the params passed to the Salus.scan method
 
-`Group :salus_processor, Event: skip_scanner`
+`Event: skip_scanner`
 
-- salus_processor skip_scanner will be called if the scanner is determined to be non-active or not relevant for the codebase. The data playoad is the scanner name string.
+- skip_scanner will be called if the scanner is determined to be non-active or not relevant for the codebase. The data playoad is the scanner name string.
 
-`Group :salus_processor, Event: run_scanner`
+`Event: run_scanner`
 
-- salus_processor run_scanner is called immediately before running the scanner.  Only scanners that have been determined relevant for the codebase will trigger this event.  The data playoad is the scanner name string.
+- run_scanner is called immediately before running the scanner.  Only scanners that have been determined relevant for the codebase will trigger this event.  The data playoad is the scanner name string.
 
-`Group :salus_processor, Event: scanners_ran `
+`Event: scanners_ran `
 
-- salus_procesor scanners_ran will be invoked after all scanners have ran.  The data playload will be an array of scanner names
+- scanners_ran will be invoked after all scanners have ran.  The data playload will be an array of scanner names
 
-`Group :salus_scanner_base, Event :run_shell`
+`Event :run_shell`
 
-- salus_scanner_base run_shell is called when a scanner executes a shell command to run a native scanner.  The data payload will be the array of arguments.
+- run_shell is called when a scanner executes a shell command to run a native scanner.  The data payload will be the array of arguments.
 

--- a/lib/salus.rb
+++ b/lib/salus.rb
@@ -34,6 +34,8 @@ module Salus
       heartbeat: true
     )
 
+      Salus::PluginManager.send_event(:salus, :scan, method(__method__).parameters)
+
       ### Heartbeat ###
       if !quiet && heartbeat
         heartbeat_thr = heartbeat(60) # Print a heartbeat every 60s. [0s, 60s, 120s, ...]
@@ -42,7 +44,7 @@ module Salus
       ### Configuration ###
       # Config option would be: --config="<uri x> <uri y> etc"
       configuration_directives = (ENV['SALUS_CONFIGURATION'] || config || '').split(URI_DELIMITER)
-      Salus::PluginManager.load_plugins
+
       processor = Salus::Processor.new(configuration_directives, repo_path: repo_path,
                                        filter_sarif: filter_sarif,
                                        ignore_config_id: ignore_config_id)

--- a/lib/salus.rb
+++ b/lib/salus.rb
@@ -34,7 +34,7 @@ module Salus
       heartbeat: true
     )
 
-      Salus::PluginManager.send_event(:salus, :scan, method(__method__).parameters)
+      Salus::PluginManager.send_event(:salus_scan, method(__method__).parameters)
 
       ### Heartbeat ###
       if !quiet && heartbeat

--- a/lib/salus.rb
+++ b/lib/salus.rb
@@ -33,6 +33,7 @@ module Salus
       ignore_config_id: "",
       heartbeat: true
     )
+      Salus::PluginManager.load_plugins
 
       Salus::PluginManager.send_event(:salus_scan, method(__method__).parameters)
 

--- a/lib/salus/cli.rb
+++ b/lib/salus/cli.rb
@@ -1,4 +1,5 @@
 require 'thor'
+require 'salus/plugin_manager'
 
 module Salus
   class CLI < Thor
@@ -38,6 +39,8 @@ module Salus
 
     desc 'scan', 'Scan the source code of a repository.'
     def scan
+      Salus::PluginManager.send_event(:cli, :scan, options)
+
       Salus.scan(
         config: options[:config],
         quiet: options[:quiet],

--- a/lib/salus/cli.rb
+++ b/lib/salus/cli.rb
@@ -39,7 +39,7 @@ module Salus
 
     desc 'scan', 'Scan the source code of a repository.'
     def scan
-      Salus::PluginManager.send_event(:cli, :scan, options)
+      Salus::PluginManager.send_event(:cli_scan, options)
 
       Salus.scan(
         config: options[:config],

--- a/lib/salus/config.rb
+++ b/lib/salus/config.rb
@@ -42,8 +42,6 @@ module Salus
     REMOTE_URI_SCHEME_REGEX = /\Ahttps?\z/.freeze
     REPORT_FORMATS = %w[txt json yaml sarif].freeze
 
-    @@filters = []
-
     def initialize(configuration_files = [], ignore_ids = [])
       # Merge default and custom configuration files.
       # The later files in the array take superiority by overwriting configuration already
@@ -78,15 +76,14 @@ module Salus
       apply_node_audit_patch!
     end
 
+    # Syntatical sugar to apply salus config filters
     def apply_config_filters(config_hash)
-      @@filters.each do |filter|
-        config_hash = filter.filter_config(config_hash) if filter.respond_to?(:filter_config)
-      end
-      config_hash
+      Salus::PluginManager.apply_filter(:salus_config, :filter_config, config_hash)
     end
 
+    # Syntatical sugar register salus_config filters
     def self.register_filter(filter)
-      @@filters << filter
+      Salus::PluginManager.register_filter(:salus_config, filter)
     end
 
     def valid_name?(name)

--- a/lib/salus/plugin_manager.rb
+++ b/lib/salus/plugin_manager.rb
@@ -14,14 +14,14 @@ module Salus
         @@filters[filter_family] << filter
       end
 
-      def register_listener(filter_family, _listener)
+      def register_listener(filter_family, listener)
         @@listners[filter_family] ||= []
-        @@listners[filter_family] << listners
+        @@listners[filter_family] << listener
       end
 
       def apply_filter(filter_family, _filter_method, data)
         @@filters[filter_family]&.each do |f|
-          data = f.send(filter, data) if f.respond_to?(filter)
+          data = f.send(_filter_method, data) if f.respond_to?(_filter_method)
         end
         data
       end

--- a/lib/salus/plugin_manager.rb
+++ b/lib/salus/plugin_manager.rb
@@ -2,10 +2,9 @@ module Salus
   class PluginManager
     PLUGIN_DIRECTORY = 'plugins'.freeze
     class << self
-  
       # Salus::Config.register_filter(Filter::MyCustomConfig)
       # Salus::PluginManager.register_filter()
-      
+
       # Our hashmap of filters
       @@filters = {}
       @@listners = {}
@@ -15,25 +14,21 @@ module Salus
         @@filters[filter_family] << filter
       end
 
-      def register_listener(filter_family, listener)
+      def register_listener(filter_family, _listener)
         @@listners[filter_family] ||= []
         @@listners[filter_family] << listners
       end
 
-      def apply_filter(filter_family, filter_method, data)
+      def apply_filter(filter_family, _filter_method, data)
         @@filters[filter_family]&.each do |f|
-          if f.respond_to?(filter)
-            data = f.send(filter, data)
-          end
+          data = f.send(filter, data) if f.respond_to?(filter)
         end
         data
       end
 
       def send_event(filter_family, event_name, data)
         @@listners[filter_family]&.each do |f|
-          if f.respond_to?(event_name)
-            f.send(event_name, data)
-          end
+          f.send(event_name, data) if f.respond_to?(event_name)
         end
       end
 

--- a/lib/salus/plugin_manager.rb
+++ b/lib/salus/plugin_manager.rb
@@ -20,14 +20,14 @@ module Salus
 
       def apply_filter(filter_family, filter_method, data)
         @@filters[filter_family]&.each do |f|
-          data = f.send(filter_method, data) if f.respond_to?(filter_method)
+          data = f.__send__(filter_method, data) if f.respond_to?(filter_method)
         end
         data
       end
 
-      def send_event(event_name, data)
+      def send_event(event_name, *data)
         @@listners.each do |l|
-          l.send(event_name, data) if l.respond_to?(event_name)
+          l.__send__(event_name, *data) if l.respond_to?(event_name)
         end
       end
 
@@ -36,12 +36,12 @@ module Salus
         File.join(project_dir, PLUGIN_DIRECTORY)
       end
 
-      @@loaded = false
+      @@loaded = Set.new()
       def load_plugins
         # We only need to load once
-        return if !Dir.exist?(plugin_dir) || @@loaded
+        return if !Dir.exist?(plugin_dir) || @@loaded.include?(plugin_dir)
 
-        @@loaded = true
+        @@loaded.add(plugin_dir)
 
         Dir.entries(plugin_dir).sort.each do |filename| # load like how scanners are loaded
           next if ['.', '..'].include?(filename) # don't include FS pointers

--- a/lib/salus/plugin_manager.rb
+++ b/lib/salus/plugin_manager.rb
@@ -1,20 +1,56 @@
 module Salus
   class PluginManager
     PLUGIN_DIRECTORY = 'plugins'.freeze
+    class << self
+  
+      # Salus::Config.register_filter(Filter::MyCustomConfig)
+      # Salus::PluginManager.register_filter()
+      
+      # Our hashmap of filters
+      @@filters = {}
+      @@listners = {}
 
-    def self.plugin_dir
-      project_dir = File.expand_path('../salus/', __dir__)
-      File.join(project_dir, PLUGIN_DIRECTORY)
-    end
+      def register_filter(filter_family, filter)
+        @@filters[filter_family] ||= []
+        @@filters[filter_family] << filter
+      end
 
-    def self.load_plugins
-      return if !Dir.exist?(plugin_dir)
+      def register_listener(filter_family, listener)
+        @@listners[filter_family] ||= []
+        @@listners[filter_family] << listners
+      end
 
-      Dir.entries(plugin_dir).sort.each do |filename| # load like how scanners are loaded
-        next if ['.', '..'].include?(filename) # don't include FS pointers
-        next unless /\.rb\z/.match?(filename)  # only include ruby files
+      def apply_filter(filter_family, filter_method, data)
+        @@filters[filter_family]&.each do |f|
+          if f.respond_to?(filter)
+            data = f.send(filter, data)
+          end
+        end
+        data
+      end
 
-        require "#{plugin_dir}/#{filename}"
+      def send_event(filter_family, event_name, data)
+        @@listners[filter_family]&.each do |f|
+          if f.respond_to?(event_name)
+            f.send(event_name, data)
+          end
+        end
+      end
+
+      def plugin_dir
+        project_dir = File.expand_path('../salus/', __dir__)
+        File.join(project_dir, PLUGIN_DIRECTORY)
+      end
+
+      def load_plugins
+        return if !Dir.exist?(plugin_dir)
+
+        Dir.entries(plugin_dir).sort.each do |filename| # load like how scanners are loaded
+          next if ['.', '..'].include?(filename) # don't include FS pointers
+          next unless /\.rb\z/.match?(filename)  # only include ruby files
+
+          require "#{plugin_dir}/#{filename}"
+        end
       end
     end
   end

--- a/lib/salus/plugin_manager.rb
+++ b/lib/salus/plugin_manager.rb
@@ -7,16 +7,15 @@ module Salus
 
       # Our hashmap of filters
       @@filters = {}
-      @@listners = {}
+      @@listners = []
 
       def register_filter(filter_family, filter)
         @@filters[filter_family] ||= []
         @@filters[filter_family] << filter
       end
 
-      def register_listener(filter_family, listener)
-        @@listners[filter_family] ||= []
-        @@listners[filter_family] << listener
+      def register_listener(listener)
+        @@listners << listener
       end
 
       def apply_filter(filter_family, filter_method, data)
@@ -26,9 +25,9 @@ module Salus
         data
       end
 
-      def send_event(filter_family, event_name, data)
-        @@listners[filter_family]&.each do |f|
-          f.send(event_name, data) if f.respond_to?(event_name)
+      def send_event(event_name, data)
+        @@listners.each do |l|
+          l.send(event_name, data) if l.respond_to?(event_name)
         end
       end
 

--- a/lib/salus/plugin_manager.rb
+++ b/lib/salus/plugin_manager.rb
@@ -36,7 +36,7 @@ module Salus
         File.join(project_dir, PLUGIN_DIRECTORY)
       end
 
-      @@loaded = Set.new()
+      @@loaded = Set.new
       def load_plugins
         # We only need to load once
         return if !Dir.exist?(plugin_dir) || @@loaded.include?(plugin_dir)

--- a/lib/salus/plugin_manager.rb
+++ b/lib/salus/plugin_manager.rb
@@ -19,9 +19,9 @@ module Salus
         @@listners[filter_family] << listener
       end
 
-      def apply_filter(filter_family, _filter_method, data)
+      def apply_filter(filter_family, filter_method, data)
         @@filters[filter_family]&.each do |f|
-          data = f.send(_filter_method, data) if f.respond_to?(_filter_method)
+          data = f.send(filter_method, data) if f.respond_to?(filter_method)
         end
         data
       end
@@ -37,8 +37,12 @@ module Salus
         File.join(project_dir, PLUGIN_DIRECTORY)
       end
 
+      @@loaded = false
       def load_plugins
-        return if !Dir.exist?(plugin_dir)
+        # We only need to load once
+        return if !Dir.exist?(plugin_dir) || @@loaded
+
+        @@loaded = true
 
         Dir.entries(plugin_dir).sort.each do |filename| # load like how scanners are loaded
           next if ['.', '..'].include?(filename) # don't include FS pointers

--- a/lib/salus/processor.rb
+++ b/lib/salus/processor.rb
@@ -81,11 +81,11 @@ module Salus
 
           scanner = scanner_class.new(repository: repo, config: config)
           unless @config.scanner_active?(scanner_name) && scanner.should_run?
-            Salus::PluginManager.send_event(:salus_processor, :skip_scanner, scanner_name)
+            Salus::PluginManager.send_event(:skip_scanner, scanner_name)
             next
           end
           scanners_ran << scanner_name
-          Salus::PluginManager.send_event(:salus_processor, :run_scanner, scanner_name)
+          Salus::PluginManager.send_event(:run_scanner, scanner_name)
 
           required = @config.enforced_scanners.include?(scanner_name)
 
@@ -96,7 +96,7 @@ module Salus
             reraise: reraise_exceptions
           )
         end
-        Salus::PluginManager.send_event(:salus_processor, :scanners_ran, scanners_ran)
+        Salus::PluginManager.send_event(:scanners_ran, scanners_ran, @report)
       end
     end
 

--- a/lib/salus/processor.rb
+++ b/lib/salus/processor.rb
@@ -84,7 +84,7 @@ module Salus
             Salus::PluginManager.send_event(:skip_scanner, scanner_name)
             next
           end
-          scanners_ran << scanner_name
+          scanners_ran << scanner
           Salus::PluginManager.send_event(:run_scanner, scanner_name)
 
           required = @config.enforced_scanners.include?(scanner_name)

--- a/lib/salus/report.rb
+++ b/lib/salus/report.rb
@@ -43,9 +43,10 @@ module Salus
     # Syntatical sugar to apply report hash filters
     def apply_report_hash_filters(report_hash)
       Salus::PluginManager.apply_filter(:salus_report, :filter_report_hash, report_hash)
+    end
 
     def apply_report_sarif_filters(sarif_json)
-      Salus::PluginManager.apply_filter(:salus_report, :filter_report_sarif, sarif_jso)
+      Salus::PluginManager.apply_filter(:salus_report, :filter_report_sarif, sarif_json)
     end
 
     # Syntatical sugar register salus_report filters

--- a/lib/salus/report.rb
+++ b/lib/salus/report.rb
@@ -159,7 +159,7 @@ module Salus
       curr_sarif_results = get_sarif_results(curr_sarif_data)
       filter_sarif_results = get_sarif_results(filter_sarif_data)
       diff = (curr_sarif_results - filter_sarif_results).to_a
-      binding.pry
+
       diff_report['report_type'] = 'salus_sarif_diff'
       diff_report['filtered_results'] = diff
       diff_report['builds'] = to_h[:config][:builds]

--- a/lib/salus/report.rb
+++ b/lib/salus/report.rb
@@ -25,8 +25,6 @@ module Salus
 
     attr_reader :builds
 
-    @@filters = []
-
     def initialize(report_uris: [], builds: {}, project_name: nil, custom_info: nil, config: nil,
                    repo_path: nil, filter_sarif: nil, ignore_config_id: nil)
       @report_uris = report_uris     # where we will send this report
@@ -42,17 +40,14 @@ module Salus
       @ignore_config_id = ignore_config_id # ignore id in salus config
     end
 
+    # Syntatical sugar to apply report hash filters
     def apply_report_hash_filters(report_hash)
-      @@filters.each do |filter|
-        if filter.respond_to?(:filter_report_hash)
-          report_hash = filter.filter_report_hash(report_hash)
-        end
-      end
-      report_hash
+      Salus::PluginManager.apply_filter(:salus_report, :filter_report_hash, report_hash)
     end
 
+    # Syntatical sugar register salus_report filters
     def self.register_filter(filter)
-      @@filters << filter
+      Salus::PluginManager.register_filter(:salus_report, filter)
     end
 
     def record
@@ -164,6 +159,7 @@ module Salus
       curr_sarif_results = get_sarif_results(curr_sarif_data)
       filter_sarif_results = get_sarif_results(filter_sarif_data)
       diff = (curr_sarif_results - filter_sarif_results).to_a
+      binding.pry
       diff_report['report_type'] = 'salus_sarif_diff'
       diff_report['filtered_results'] = diff
       diff_report['builds'] = to_h[:config][:builds]

--- a/lib/salus/scanners/base.rb
+++ b/lib/salus/scanners/base.rb
@@ -96,7 +96,8 @@ module Salus::Scanners
 
         raise if reraise
       ensure
-        Salus::PluginManager.send_event(:scan_executed, { salus_report: @salus_report, scan_report: @report })
+        Salus::PluginManager.send_event(:scan_executed, { salus_report: @salus_report,
+                                                          scan_report: @report })
       end
     end
 

--- a/lib/salus/scanners/base.rb
+++ b/lib/salus/scanners/base.rb
@@ -3,6 +3,7 @@ require 'salus/scan_report'
 require 'salus/shell_result'
 require 'salus/bugsnag'
 require 'shellwords'
+require 'salus/plugin_manager'
 
 module Salus::Scanners
   # Super class for all scanner objects.
@@ -101,6 +102,7 @@ module Salus::Scanners
     def run_shell(command, env: {}, stdin_data: '')
       # If we're passed a string, convert it to an array before passing to capture3
       command = command.split unless command.is_a?(Array)
+      Salus::PluginManager.send_event(:salus_scanner_base, :run_shell, command)
       Salus::ShellResult.new(*Open3.capture3(env, *command, stdin_data: stdin_data))
     end
 

--- a/lib/salus/scanners/base.rb
+++ b/lib/salus/scanners/base.rb
@@ -93,10 +93,10 @@ module Salus::Scanners
         # Record the error so that the Salus report captures the issue.
         @report.error(error_data)
         salus_report.error(error_data)
-   
+
         raise if reraise
       ensure
-        Salus::PluginManager.send_event(:scan_executed, { salus_report: @salus_report, scan_report:@report })
+        Salus::PluginManager.send_event(:scan_executed, { salus_report: @salus_report, scan_report: @report })
       end
     end
 

--- a/lib/salus/scanners/base.rb
+++ b/lib/salus/scanners/base.rb
@@ -93,8 +93,10 @@ module Salus::Scanners
         # Record the error so that the Salus report captures the issue.
         @report.error(error_data)
         salus_report.error(error_data)
-
+   
         raise if reraise
+      ensure
+        Salus::PluginManager.send_event(:scan_executed, { salus_report: @salus_report, scan_report:@report })
       end
     end
 
@@ -102,7 +104,7 @@ module Salus::Scanners
     def run_shell(command, env: {}, stdin_data: '')
       # If we're passed a string, convert it to an array before passing to capture3
       command = command.split unless command.is_a?(Array)
-      Salus::PluginManager.send_event(:salus_scanner_base, :run_shell, command)
+      Salus::PluginManager.send_event(:run_shell, command)
       Salus::ShellResult.new(*Open3.capture3(env, *command, stdin_data: stdin_data))
     end
 

--- a/spec/lib/salus/plugin_manager_spec.rb
+++ b/spec/lib/salus/plugin_manager_spec.rb
@@ -1,0 +1,39 @@
+require_relative '../../spec_helper.rb'
+
+describe Salus::PluginManager do
+  describe 'apply_filter' do
+    let(:filter) { Object.new }
+    before(:each) do
+      def filter.say_hello(subject)
+        "hello #{subject}"
+      end
+    end
+
+    it 'applies the filter' do
+      Salus::PluginManager.register_filter('test-filters', filter)
+      data = Salus::PluginManager.apply_filter('test-filters', :say_hello, 'foobar')
+      expect(data).to eq('hello foobar')
+    end
+
+    it 'does not apply filter from a different context' do
+      Salus::PluginManager.register_filter('test-filters', filter)
+      data = Salus::PluginManager.apply_filter('test', :say_hello, 'foobar')
+      expect(data).to eq('foobar')
+    end
+  end
+
+  describe 'send_event' do
+    let(:listener) { Object.new }
+    before(:each) do
+      def listener.myevent(data)
+        data
+      end
+    end
+
+    it 'sends the event' do
+      Salus::PluginManager.register_listener('testing', listener)
+      expect(listener).to receive(:myevent).with('foo')
+      Salus::PluginManager.send_event('testing', 'myevent', "foo")
+    end
+  end
+end

--- a/spec/lib/salus/plugin_manager_spec.rb
+++ b/spec/lib/salus/plugin_manager_spec.rb
@@ -31,9 +31,9 @@ describe Salus::PluginManager do
     end
 
     it 'sends the event' do
-      Salus::PluginManager.register_listener('testing', listener)
+      Salus::PluginManager.register_listener(listener)
       expect(listener).to receive(:myevent).with('foo')
-      Salus::PluginManager.send_event('testing', 'myevent', "foo")
+      Salus::PluginManager.send_event('myevent', "foo")
     end
   end
 end

--- a/spec/lib/salus_spec.rb
+++ b/spec/lib/salus_spec.rb
@@ -188,6 +188,7 @@ describe Salus::CLI do
           ENV['SALUS_CONFIGURATION'] = 'file:///salus.yaml'
           expect(Salus::PluginManager).to receive(:plugin_dir).and_return(plugin_dir)
             .at_least(:once)
+          Salus::PluginManager.load_plugins
           Salus.scan(quiet: true, repo_path: '.')
           expect(File).to exist('out.json')
 

--- a/spec/lib/salus_spec.rb
+++ b/spec/lib/salus_spec.rb
@@ -136,7 +136,7 @@ describe Salus::CLI do
           data = JSON.parse(File.read(diff_file))
 
           expect(data['report_type']).to eq('salus_sarif_diff')
-
+          binding.pry
           rule_ids = data['filtered_results'].map { |r| r['ruleId'] }.sort
           expect(rule_ids).to eq(%w[G401 G501])
 
@@ -175,6 +175,13 @@ describe Salus::CLI do
     end
 
     context 'With plugins' do
+      xit 'should send scan event' do
+        Dir.chdir('spec/fixtures/blank_repository2') do
+          expect(Salus::PluginManager).to receive(:send_event).at_least(:once)
+          Salus.scan(quiet: true, repo_path: '.')
+        end
+      end
+ 
       it 'Should update config based on plugin' do
         Dir.chdir('spec/fixtures/blank_repository2') do
           plugin_dir = File.join(__dir__, '../fixtures/blank_repository2/test_plugins')

--- a/spec/lib/salus_spec.rb
+++ b/spec/lib/salus_spec.rb
@@ -136,7 +136,7 @@ describe Salus::CLI do
           data = JSON.parse(File.read(diff_file))
 
           expect(data['report_type']).to eq('salus_sarif_diff')
-          binding.pry
+
           rule_ids = data['filtered_results'].map { |r| r['ruleId'] }.sort
           expect(rule_ids).to eq(%w[G401 G501])
 
@@ -175,13 +175,13 @@ describe Salus::CLI do
     end
 
     context 'With plugins' do
-      xit 'should send scan event' do
+      it 'should send scan event' do
         Dir.chdir('spec/fixtures/blank_repository2') do
           expect(Salus::PluginManager).to receive(:send_event).at_least(:once)
           Salus.scan(quiet: true, repo_path: '.')
         end
       end
- 
+
       it 'Should update config based on plugin' do
         Dir.chdir('spec/fixtures/blank_repository2') do
           plugin_dir = File.join(__dir__, '../fixtures/blank_repository2/test_plugins')

--- a/spec/lib/salus_spec.rb
+++ b/spec/lib/salus_spec.rb
@@ -138,6 +138,7 @@ describe Salus::CLI do
           expect(data['report_type']).to eq('salus_sarif_diff')
 
           rule_ids = data['filtered_results'].map { |r| r['ruleId'] }.sort
+
           expect(rule_ids).to eq(%w[G401 G501])
 
           builds = data['builds']
@@ -188,7 +189,6 @@ describe Salus::CLI do
           ENV['SALUS_CONFIGURATION'] = 'file:///salus.yaml'
           expect(Salus::PluginManager).to receive(:plugin_dir).and_return(plugin_dir)
             .at_least(:once)
-          Salus::PluginManager.load_plugins
           Salus.scan(quiet: true, repo_path: '.')
           expect(File).to exist('out.json')
 


### PR DESCRIPTION
Expanded support for plugins.  Refactored the two filter instances by DRYing up the code to move the loaded filters to SalusPluginManger.

Added support for a few initial events:

`Event :cli_startup`
`Event :cli_scan`
`Event :salus_scan`
`Event: skip_scanner`
`Event: run_scanner`
`Event: scanners_ran `
`Event :run_shell`