### PR TITLE
bump to version 2.11.11

### DIFF
--- a/lib/salus.rb
+++ b/lib/salus.rb
@@ -10,7 +10,7 @@ require 'salus/plugin_manager'
 require 'sarif/sarif_report'
 
 module Salus
-  VERSION = '2.11.10'.freeze
+  VERSION = '2.11.11'.freeze
   DEFAULT_REPO_PATH = './repo'.freeze # This is inside the docker container at /home/repo.
 
   SafeYAML::OPTIONS[:default_mode] = :safe

--- a/spec/fixtures/integration/expected_report.json
+++ b/spec/fixtures/integration/expected_report.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.11.10",
+  "version": "2.11.11",
   "passed": true,
   "running_time": 0.0,
   "scans": {

--- a/spec/fixtures/processor/local_uri/expected_report.json
+++ b/spec/fixtures/processor/local_uri/expected_report.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.11.10",
+  "version": "2.11.11",
   "passed": true,
   "running_time": 0.0,
   "scans": {

--- a/spec/fixtures/processor/multiple_endpoints/expected_report.json
+++ b/spec/fixtures/processor/multiple_endpoints/expected_report.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.11.10",
+  "version": "2.11.11",
   "passed": true,
   "running_time": 0.0,
   "scans": {

--- a/spec/fixtures/processor/remote_uri/expected_report.json
+++ b/spec/fixtures/processor/remote_uri/expected_report.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.11.10",
+  "version": "2.11.11",
   "passed": true,
   "running_time": 0.0,
   "scans": {

--- a/spec/lib/salus/report_spec.rb
+++ b/spec/lib/salus/report_spec.rb
@@ -209,7 +209,7 @@ describe Salus::Report do
         report = build_report(directive)
 
         stub_request(:post, "https://nerv.tk3/salus-report").with(body: "{\n  \"foo\": \"bar\",\n"\
-          "  \"abc\": \"def\",\n  \"report\": {\n    \"version\": \"2.11.10\",\n    \"project_nam"\
+          "  \"abc\": \"def\",\n  \"report\": {\n    \"version\": \"2.11.11\",\n    \"project_nam"\
           "e\": \"eva00\",\n    \"passed\": false,\n    \"scans\": {\n      \"DerpScanner\": {\n "\
           "       \"scanner_name\": \"DerpScanner\",\n        \"passed\": false,\n        \"warn"\
           "\": {\n        },\n        \"info\": {\n          \"asdf\": \"qwerty\"\n        },\n "\
@@ -235,7 +235,7 @@ describe Salus::Report do
         report = build_report(directive)
 
         stub_request(:post, "https://nerv.tk3/salus-report").with(body: "---\nfoo: bar\nabc: def\n"\
-          "report:\n  :version: 2.11.10\n  :project_name: eva00\n  :passed: false\n  :scans:\n    "\
+          "report:\n  :version: 2.11.11\n  :project_name: eva00\n  :passed: false\n  :scans:\n    "\
           "DerpScanner:\n      :scanner_name: DerpScanner\n      :passed: false\n      :warn: {}\n"\
           "      :info:\n        :asdf: qwerty\n      :errors: []\n  :errors:\n  - :message: derp"\
           "\n  - :message: derp\n  - :message: derp\n  - :message: derp\n  - :message: derp\n  "\
@@ -260,7 +260,7 @@ describe Salus::Report do
         report.instance_variable_set(:@config, config)
 
         stub_request(:post, "https://nerv.tk3/salus-report").with(body: "{\"foo\"=>\"bar\", \"abc"\
-          "\"=>\"def\", \"report\"=>\"==== Salus Scan v2.11.10 for eva00\\n\\n==== Salus "\
+          "\"=>\"def\", \"report\"=>\"==== Salus Scan v2.11.11 for eva00\\n\\n==== Salus "\
           "Configuration Files Used:\\n\\n  word\\n\\n\\n==== Salus Errors\\n\\n  [\\n    {\\n    "\
           "  \\\"message\\\": \\\"derp\\\"\\n    },\\n    {\\n      \\\"message\\\": \\\"derp\\"\
           "\"\\n    },\\n    {\\n      \\\"message\\\": \\\"derp\\\"\\n    },\\n    {\\n      "\


### PR DESCRIPTION
- #385 Circle CI Orb: Use parameterized name for storage_artifact
- #382 Expanded plugin support.  Added events cli_startup, cli_scan, salus_scan, skip_scanner, run_scanner, scanners_ran, run_shell
- #380 Non zero error code for bad invocations
- #379 SARIF refactor to messageStrings
- #378 Addition of SARIF filter for plugins
- #376 Bundler 2.2.19