### PR TITLE
add support for do_not_run_from_dirs options

### DIFF
--- a/lib/salus/scanners/gosec.rb
+++ b/lib/salus/scanners/gosec.rb
@@ -16,10 +16,11 @@ module Salus::Scanners
       @gosec_stderr = ''   # combined stderr on all runs (one for each configured subdir)
       @gosec_stdout = ''   # ...      stdout ...
       @gosec_json = {}     # combined json result on all runs
+      # default run_from_dirs to all subidrs (but not nested subdirs)
       run_from_dirs = @config['run_from_dirs'] || ["*/"]
 
       Dir.chdir(@repository.path_to_repo) do
-        run_from_dirs = select_dirs_from_glob(@config['run_from_dirs'])
+        run_from_dirs = select_dirs_from_glob(run_from_dirs)
 
         if @config['do_not_run_from_dirs']
           do_not_run_from_dirs = select_dirs_from_glob(@config['do_not_run_from_dirs'])

--- a/spec/fixtures/gosec/multi_goapps/salus2.yaml
+++ b/spec/fixtures/gosec/multi_goapps/salus2.yaml
@@ -1,0 +1,4 @@
+scanner_configs:
+  Gosec:
+    run_from_dirs:
+      - "*/"

--- a/spec/fixtures/gosec/multi_goapps/salus3.yaml
+++ b/spec/fixtures/gosec/multi_goapps/salus3.yaml
@@ -1,0 +1,7 @@
+scanner_configs:
+  Gosec:
+    run_from_dirs:
+      - "*/"
+    do_not_run_from_dirs:
+      - app1
+      - app2      


### PR DESCRIPTION
Recently we added a `run_from_dirs` option for Gosec to run from subdirs, like

```yaml
scanner_configs:
  Gosec:
    run_from_dirs:
      - subdir1
      - subdir2
      - subdir3
```

But people said they may add a new subdir to the repo, but then forget to update salus.yaml to add the new subdir.

So this PR updates `run_from_dirs` from regular paths to global patterns, and adds a `do_not_run_from_dirs` option like:
```yaml
scanner_configs
  Gosec:
    run_from_dirs:
       - "*/"
    do_not_run_from_dirs:
      - test_dir
```
Meaning run Gosec from all subdirs, except `test_dir`