### PR TITLE
Update Semgrep Installation Link Hash and Add Yarn Install Link

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -15,7 +15,7 @@ bundle install
 # for NPM, install per https://www.npmjs.com/get-npm
 # for Go reporting, install Go per https://golang.org/doc/install#install
 # for PatternSearch, install sift per https://sift-tool.org/download
-# for Semgrep, install semgrep per https://github.com/returntocorp/semgrep#installation
+# for Semgrep, install semgrep per https://github.com/returntocorp/semgrep#getting-started
 # for end-to-end tests and running Salus, install Docker per https://docs.docker.com/install
 ```
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -13,6 +13,7 @@ bundle install
 
 ### Install other system dependencies
 # for NPM, install per https://www.npmjs.com/get-npm
+# for Yarn, install per https://classic.yarnpkg.com/en/docs/install/#mac-stable
 # for Go reporting, install Go per https://golang.org/doc/install#install
 # for PatternSearch, install sift per https://sift-tool.org/download
 # for Semgrep, install semgrep per https://github.com/returntocorp/semgrep#getting-started


### PR DESCRIPTION
Very tiny update that links the developer to the latest working install hash for the Semgrep GitHub page and adds the Yarn install link.