### PR TITLE
Enable Timeouts for Individual Scanners

### DIFF
--- a/docs/scanners/base.md
+++ b/docs/scanners/base.md
@@ -37,17 +37,17 @@ scanner_configs:
 
 #### Maximum Lifespan
 
-At times, scanners may perform scans for unacceptable lengths of time. To limit this behavior, you can define `scanner-timeout-ms` with the number of milliseconds you wish the scan to last before it times out.  
+At times, scanners may perform scans for unacceptable lengths of time. To limit this behavior, you can define `scanner-timeout-s` with the number of seconds you wish the scan to last before it times out.  
 
 Example with `YarnAudit` configuration:
 
 ```yaml
 scanner_configs:
   YarnAudit:
-    scanner-timeout-ms: 60000
+    scanner-timeout-s: 60
 ```
 
-This will limit YarnAudit scans to 1 minute (60,000 milliseconds) in execution time.
+This will limit YarnAudit scans to 1 minute (60 seconds) in execution time.
 
 ## Reading/setting up custom configs for your scanner
 

--- a/docs/scanners/base.md
+++ b/docs/scanners/base.md
@@ -37,14 +37,14 @@ scanner_configs:
 
 #### Maximum Lifespan
 
-At times, scanners may perform scans for unacceptable lengths of time. To limit this behavior, you can define `max-lifespan` with the number of milliseconds you wish the scan to last before it times out.  
+At times, scanners may perform scans for unacceptable lengths of time. To limit this behavior, you can define `scanner-timeout-ms` with the number of milliseconds you wish the scan to last before it times out.  
 
 Example with `YarnAudit` configuration:
 
 ```yaml
 scanner_configs:
   YarnAudit:
-    max-lifespan: 60000
+    scanner-timeout-ms: 60000
 ```
 
 This will limit YarnAudit scans to 1 minute (60,000 milliseconds) in execution time.

--- a/docs/scanners/base.md
+++ b/docs/scanners/base.md
@@ -37,14 +37,14 @@ scanner_configs:
 
 #### Maximum Lifespan
 
-At times, scanners may perform scans for unacceptable lengths of time. To limit this behavior, you can define `scanner-timeout-s` with the number of seconds you wish the scan to last before it times out.  
+At times, scanners may perform scans for unacceptable lengths of time. To limit this behavior, you can define `scanner_timeout_s` with the number of seconds you wish the scan to last before it times out.  
 
 Example with `YarnAudit` configuration:
 
 ```yaml
 scanner_configs:
   YarnAudit:
-    scanner-timeout-s: 60
+    scanner_timeout_s: 60
 ```
 
 This will limit YarnAudit scans to 1 minute (60 seconds) in execution time.

--- a/docs/scanners/base.md
+++ b/docs/scanners/base.md
@@ -35,6 +35,20 @@ scanner_configs:
       Slack channel: #security
 ```
 
+#### Maximum Lifespan
+
+At times, scanners may perform scans for unacceptable lengths of time. To limit this behavior, you can define `max-lifespan` with the number of milliseconds you wish the scan to last before it times out.  
+
+Example with `YarnAudit` configuration:
+
+```yaml
+scanner_configs:
+  YarnAudit:
+    max-lifespan: 60000
+```
+
+This will limit YarnAudit scans to 1 minute (60,000 milliseconds) in execution time.
+
 ## Reading/setting up custom configs for your scanner
 
 For setting up custom configurations for your scanner, you can optionally use the helper method ```build_options```.

--- a/lib/salus/config.rb
+++ b/lib/salus/config.rb
@@ -38,7 +38,7 @@ module Salus
 
     DEFAULT_SCANNER_CONFIG = {
       'pass_on_raise' => false, # strong default - if a scanner raises, it counts as failure.
-      'scanner-timeout-s' => 0 # Scanner can run indefinitely if a max lifespan isn't provided
+      'scanner_timeout_s' => 0 # Scanner can run indefinitely if a max lifespan isn't provided
     }.freeze
 
     LOCAL_FILE_SCHEME_REGEX = /\Afile\z/.freeze # like file://foobar

--- a/lib/salus/config.rb
+++ b/lib/salus/config.rb
@@ -36,7 +36,7 @@ module Salus
 
     DEFAULT_SCANNER_CONFIG = {
       'pass_on_raise' => false, # strong default - if a scanner raises, it counts as failure.
-      'max-lifespan' => 0 # Scanner can run indefinitely if a max lifespan isn't provided
+      'scanner-timeout-ms' => 0 # Scanner can run indefinitely if a max lifespan isn't provided
     }.freeze
 
     LOCAL_FILE_SCHEME_REGEX = /\Afile\z/.freeze # like file://foobar

--- a/lib/salus/config.rb
+++ b/lib/salus/config.rb
@@ -35,7 +35,7 @@ module Salus
     ).freeze
 
     DEFAULT_SCANNER_CONFIG = {
-      'pass_on_raise' => false # strong default - if a scanner raises, it counts as failure.
+      'pass_on_raise' => false, # strong default - if a scanner raises, it counts as failure.
       'max-lifespan' => 0 # If a max lifespan isn't explicitly provided, the scanner can run indefinitely
     }.freeze
 

--- a/lib/salus/config.rb
+++ b/lib/salus/config.rb
@@ -36,7 +36,7 @@ module Salus
 
     DEFAULT_SCANNER_CONFIG = {
       'pass_on_raise' => false, # strong default - if a scanner raises, it counts as failure.
-      'max-lifespan' => 0 # If a max lifespan isn't explicitly provided, the scanner can run indefinitely
+      'max-lifespan' => 0 # Scanner can run indefinitely if a max lifespan isn't provided
     }.freeze
 
     LOCAL_FILE_SCHEME_REGEX = /\Afile\z/.freeze # like file://foobar

--- a/lib/salus/config.rb
+++ b/lib/salus/config.rb
@@ -36,7 +36,7 @@ module Salus
 
     DEFAULT_SCANNER_CONFIG = {
       'pass_on_raise' => false, # strong default - if a scanner raises, it counts as failure.
-      'scanner-timeout-ms' => 0 # Scanner can run indefinitely if a max lifespan isn't provided
+      'scanner-timeout-s' => 0 # Scanner can run indefinitely if a max lifespan isn't provided
     }.freeze
 
     LOCAL_FILE_SCHEME_REGEX = /\Afile\z/.freeze # like file://foobar

--- a/lib/salus/config.rb
+++ b/lib/salus/config.rb
@@ -36,6 +36,7 @@ module Salus
 
     DEFAULT_SCANNER_CONFIG = {
       'pass_on_raise' => false # strong default - if a scanner raises, it counts as failure.
+      'max-lifespan' => 0 # If a max lifespan isn't explicitly provided, the scanner can run indefinitely
     }.freeze
 
     LOCAL_FILE_SCHEME_REGEX = /\Afile\z/.freeze # like file://foobar

--- a/lib/salus/scanners/base.rb
+++ b/lib/salus/scanners/base.rb
@@ -87,7 +87,7 @@ module Salus::Scanners
           pass_on_raise ? @report.pass : @report.fail
         end
       rescue Timeout::Error
-        error_message = "Scanner #{name} timed out after #{@report.running_time} seconds"
+        error_message = "Scanner #{name} timed out after #{scanner_timeout} seconds"
         timeout_error_data = {
           message: error_message,
           error_class: ScannerTimeoutError

--- a/lib/salus/scanners/base.rb
+++ b/lib/salus/scanners/base.rb
@@ -479,11 +479,11 @@ module Salus::Scanners
     end
 
     def max_lifespan
-      max_lifespan_config_param = @config['max-lifespan']
+      max_lifespan_config_param = @config['scanner-timeout-ms']
       # If a developer mistakenly defines this parameter
       # as a non-integer value, let it be known
       unless max_lifespan_config_param.is_a? Integer
-        raise ConfigFormatError, "'max-lifespan' parameter should be an integer"
+        raise ConfigFormatError, "'scanner-timeout-ms' parameter should be an integer"
       end
 
       max_lifespan_config_param

--- a/lib/salus/scanners/base.rb
+++ b/lib/salus/scanners/base.rb
@@ -81,22 +81,22 @@ module Salus::Scanners
       begin
         @report.record do
           Timeout.timeout(max_lifespan / 1000.to_f) { run }
-          rescue Timeout::Error => e
-            timeout_error_data = {
-              message: "Scanner #{name} timed out during execution",
-              error_class: ScannerTimeoutError,
-              backtrace: e.backtrace.take(5)
-            }
-            @report.error(timeout_error_data)
-            salus_report.error(timeout_error_data)
-
-            # Propagate this error if desired
-            raise ScannerTimeoutError, timeout_error_data.message if reraise
         end
 
         if @report.errors.any?
           pass_on_raise ? @report.pass : @report.fail
         end
+      rescue Timeout::Error => e
+        timeout_error_data = {
+          message: "Scanner #{name} timed out during execution",
+          error_class: ScannerTimeoutError,
+          backtrace: e.backtrace.take(5)
+        }
+        @report.error(timeout_error_data)
+        salus_report.error(timeout_error_data)
+
+        # Propagate this error if desired
+        raise ScannerTimeoutError, timeout_error_data.message if reraise
       rescue StandardError => e
         error_data = {
           message: "Unhandled exception running #{name}: #{e.class}: #{e}",

--- a/lib/salus/scanners/base.rb
+++ b/lib/salus/scanners/base.rb
@@ -10,6 +10,7 @@ module Salus::Scanners
   class Base
     class UnhandledExitStatusError < StandardError; end
     class InvalidScannerInvocationError < StandardError; end
+    class ConfigFormatError < StandardError; end
 
     include Salus::SalusBugsnag
 
@@ -460,6 +461,17 @@ module Salus::Scanners
                  end
         options + option
       end
+    end
+
+
+    def max_lifespan
+      max_lifespan_config_param = @config['max-lifespan']
+      # If a developer mistakenly defines this parameter 
+      # as a non-integer value, let it be known
+      unless max_lifespan_config_param.is_a? Integer
+        raise ConfigFormatError.new "'max-lifespan' parameter should be an integer"
+      end
+      max_lifespan_config_param
     end
   end
 end

--- a/lib/salus/scanners/base.rb
+++ b/lib/salus/scanners/base.rb
@@ -80,7 +80,7 @@ module Salus::Scanners
 
       begin
         @report.record do
-          Timeout.timeout(max_lifespan) { run }
+          Timeout.timeout(scanner_timeout) { run }
         end
 
         if @report.errors.any?
@@ -480,15 +480,15 @@ module Salus::Scanners
       end
     end
 
-    def max_lifespan
-      max_lifespan_config_param = @config['scanner-timeout-s']
+    def scanner_timeout
+      scanner_timeout_config_param = @config['scanner_timeout_s']
       # If a developer mistakenly defines this parameter
       # as a non-integer value, let it be known
-      unless max_lifespan_config_param.is_a? Integer
-        raise ConfigFormatError, "'scanner-timeout-s' parameter should be an integer"
+      unless scanner_timeout_config_param.is_a? Integer
+        raise ConfigFormatError, "'scanner_timeout_s' parameter should be an integer"
       end
 
-      max_lifespan_config_param
+      scanner_timeout_config_param
     end
   end
 end

--- a/lib/salus/scanners/base.rb
+++ b/lib/salus/scanners/base.rb
@@ -81,7 +81,7 @@ module Salus::Scanners
       begin
         @report.record do
           begin
-            Timeout.timeout(max_lifespan) { run }
+            Timeout.timeout(max_lifespan / 1000.to_f) { run }
           rescue Timeout::Error => timeout_e
             timeout_error_data = {
               message: "Scanner #{name} timed out during execution",

--- a/spec/fixtures/integration/expected_report.json
+++ b/spec/fixtures/integration/expected_report.json
@@ -41,7 +41,7 @@
     "scanner_configs": {
       "PatternSearch": {
         "pass_on_raise": false,
-        "scanner-timeout-s": 0,
+        "scanner_timeout_s": 0,
         "exclude_extension": [
           "json",
           "yaml"
@@ -57,63 +57,63 @@
       },
       "Bandit": {
         "pass_on_raise": false,
-        "scanner-timeout-s": 0
+        "scanner_timeout_s": 0
       },
       "Brakeman": {
         "pass_on_raise": false,
-        "scanner-timeout-s": 0
+        "scanner_timeout_s": 0
       },
       "BundleAudit": {
         "pass_on_raise": false,
-        "scanner-timeout-s": 0
+        "scanner_timeout_s": 0
       },
       "CargoAudit": {
         "pass_on_raise": false,
-        "scanner-timeout-s": 0
+        "scanner_timeout_s": 0
       },
       "Gosec": {
         "pass_on_raise": false,
-        "scanner-timeout-s": 0
+        "scanner_timeout_s": 0
       },
       "NPMAudit": {
         "pass_on_raise": false,
-        "scanner-timeout-s": 0
+        "scanner_timeout_s": 0
       },
       "RepoNotEmpty": {
         "pass_on_raise": false,
-        "scanner-timeout-s": 0
+        "scanner_timeout_s": 0
       },
       "ReportGoDep": {
         "pass_on_raise": false,
-        "scanner-timeout-s": 0
+        "scanner_timeout_s": 0
       },
       "ReportNodeModules": {
         "pass_on_raise": false,
-        "scanner-timeout-s": 0
+        "scanner_timeout_s": 0
       },
       "ReportPythonModules": {
         "pass_on_raise": false,
-        "scanner-timeout-s": 0
+        "scanner_timeout_s": 0
       },
       "ReportRubyGems": {
         "pass_on_raise": false,
-        "scanner-timeout-s": 0
+        "scanner_timeout_s": 0
       },
       "ReportRustCrates": {
         "pass_on_raise": false,
-        "scanner-timeout-s": 0
+        "scanner_timeout_s": 0
       },
       "Semgrep": {
         "pass_on_raise": false,
-        "scanner-timeout-s": 0
+        "scanner_timeout_s": 0
       },
       "YarnAudit": {
         "pass_on_raise": false,
-        "scanner-timeout-s": 0
+        "scanner_timeout_s": 0
       },
       "NodeAudit": {
         "pass_on_raise": false,
-        "scanner-timeout-s": 0
+        "scanner_timeout_s": 0
       }
     },
     "report_uris": [

--- a/spec/fixtures/integration/expected_report.json
+++ b/spec/fixtures/integration/expected_report.json
@@ -41,7 +41,7 @@
     "scanner_configs": {
       "PatternSearch": {
         "pass_on_raise": false,
-        "scanner-timeout-ms": 0,
+        "scanner-timeout-s": 0,
         "exclude_extension": [
           "json",
           "yaml"
@@ -57,63 +57,63 @@
       },
       "Bandit": {
         "pass_on_raise": false,
-        "scanner-timeout-ms": 0
+        "scanner-timeout-s": 0
       },
       "Brakeman": {
         "pass_on_raise": false,
-        "scanner-timeout-ms": 0
+        "scanner-timeout-s": 0
       },
       "BundleAudit": {
         "pass_on_raise": false,
-        "scanner-timeout-ms": 0
+        "scanner-timeout-s": 0
       },
       "CargoAudit": {
         "pass_on_raise": false,
-        "scanner-timeout-ms": 0
+        "scanner-timeout-s": 0
       },
       "Gosec": {
         "pass_on_raise": false,
-        "scanner-timeout-ms": 0
+        "scanner-timeout-s": 0
       },
       "NPMAudit": {
         "pass_on_raise": false,
-        "scanner-timeout-ms": 0
+        "scanner-timeout-s": 0
       },
       "RepoNotEmpty": {
         "pass_on_raise": false,
-        "scanner-timeout-ms": 0
+        "scanner-timeout-s": 0
       },
       "ReportGoDep": {
         "pass_on_raise": false,
-        "scanner-timeout-ms": 0
+        "scanner-timeout-s": 0
       },
       "ReportNodeModules": {
         "pass_on_raise": false,
-        "scanner-timeout-ms": 0
+        "scanner-timeout-s": 0
       },
       "ReportPythonModules": {
         "pass_on_raise": false,
-        "scanner-timeout-ms": 0
+        "scanner-timeout-s": 0
       },
       "ReportRubyGems": {
         "pass_on_raise": false,
-        "scanner-timeout-ms": 0
+        "scanner-timeout-s": 0
       },
       "ReportRustCrates": {
         "pass_on_raise": false,
-        "scanner-timeout-ms": 0
+        "scanner-timeout-s": 0
       },
       "Semgrep": {
         "pass_on_raise": false,
-        "scanner-timeout-ms": 0
+        "scanner-timeout-s": 0
       },
       "YarnAudit": {
         "pass_on_raise": false,
-        "scanner-timeout-ms": 0
+        "scanner-timeout-s": 0
       },
       "NodeAudit": {
         "pass_on_raise": false,
-        "scanner-timeout-ms": 0
+        "scanner-timeout-s": 0
       }
     },
     "report_uris": [

--- a/spec/fixtures/integration/expected_report.json
+++ b/spec/fixtures/integration/expected_report.json
@@ -41,7 +41,7 @@
     "scanner_configs": {
       "PatternSearch": {
         "pass_on_raise": false,
-        "max-lifespan": 0,
+        "scanner-timeout-ms": 0,
         "exclude_extension": [
           "json",
           "yaml"
@@ -57,63 +57,63 @@
       },
       "Bandit": {
         "pass_on_raise": false,
-        "max-lifespan": 0
+        "scanner-timeout-ms": 0
       },
       "Brakeman": {
         "pass_on_raise": false,
-        "max-lifespan": 0
+        "scanner-timeout-ms": 0
       },
       "BundleAudit": {
         "pass_on_raise": false,
-        "max-lifespan": 0
+        "scanner-timeout-ms": 0
       },
       "CargoAudit": {
         "pass_on_raise": false,
-        "max-lifespan": 0
+        "scanner-timeout-ms": 0
       },
       "Gosec": {
         "pass_on_raise": false,
-        "max-lifespan": 0
+        "scanner-timeout-ms": 0
       },
       "NPMAudit": {
         "pass_on_raise": false,
-        "max-lifespan": 0
+        "scanner-timeout-ms": 0
       },
       "RepoNotEmpty": {
         "pass_on_raise": false,
-        "max-lifespan": 0
+        "scanner-timeout-ms": 0
       },
       "ReportGoDep": {
         "pass_on_raise": false,
-        "max-lifespan": 0
+        "scanner-timeout-ms": 0
       },
       "ReportNodeModules": {
         "pass_on_raise": false,
-        "max-lifespan": 0
+        "scanner-timeout-ms": 0
       },
       "ReportPythonModules": {
         "pass_on_raise": false,
-        "max-lifespan": 0
+        "scanner-timeout-ms": 0
       },
       "ReportRubyGems": {
         "pass_on_raise": false,
-        "max-lifespan": 0
+        "scanner-timeout-ms": 0
       },
       "ReportRustCrates": {
         "pass_on_raise": false,
-        "max-lifespan": 0
+        "scanner-timeout-ms": 0
       },
       "Semgrep": {
         "pass_on_raise": false,
-        "max-lifespan": 0
+        "scanner-timeout-ms": 0
       },
       "YarnAudit": {
         "pass_on_raise": false,
-        "max-lifespan": 0
+        "scanner-timeout-ms": 0
       },
       "NodeAudit": {
         "pass_on_raise": false,
-        "max-lifespan": 0
+        "scanner-timeout-ms": 0
       }
     },
     "report_uris": [

--- a/spec/fixtures/integration/expected_report.json
+++ b/spec/fixtures/integration/expected_report.json
@@ -41,6 +41,7 @@
     "scanner_configs": {
       "PatternSearch": {
         "pass_on_raise": false,
+        "max-lifespan": 0,
         "exclude_extension": [
           "json",
           "yaml"
@@ -55,49 +56,64 @@
         ]
       },
       "Bandit": {
-        "pass_on_raise": false
+        "pass_on_raise": false,
+        "max-lifespan": 0
       },
       "Brakeman": {
-        "pass_on_raise": false
+        "pass_on_raise": false,
+        "max-lifespan": 0
       },
       "BundleAudit": {
-        "pass_on_raise": false
+        "pass_on_raise": false,
+        "max-lifespan": 0
       },
       "CargoAudit": {
-        "pass_on_raise": false
+        "pass_on_raise": false,
+        "max-lifespan": 0
       },
       "Gosec": {
-        "pass_on_raise": false
+        "pass_on_raise": false,
+        "max-lifespan": 0
       },
       "NPMAudit": {
-        "pass_on_raise": false
+        "pass_on_raise": false,
+        "max-lifespan": 0
       },
       "RepoNotEmpty": {
-        "pass_on_raise": false
+        "pass_on_raise": false,
+        "max-lifespan": 0
       },
       "ReportGoDep": {
-        "pass_on_raise": false
+        "pass_on_raise": false,
+        "max-lifespan": 0
       },
       "ReportNodeModules": {
-        "pass_on_raise": false
+        "pass_on_raise": false,
+        "max-lifespan": 0
       },
       "ReportPythonModules": {
-        "pass_on_raise": false
+        "pass_on_raise": false,
+        "max-lifespan": 0
       },
       "ReportRubyGems": {
-        "pass_on_raise": false
+        "pass_on_raise": false,
+        "max-lifespan": 0
       },
       "ReportRustCrates": {
-        "pass_on_raise": false
+        "pass_on_raise": false,
+        "max-lifespan": 0
       },
       "Semgrep": {
-        "pass_on_raise": false
+        "pass_on_raise": false,
+        "max-lifespan": 0
       },
       "YarnAudit": {
-        "pass_on_raise": false
+        "pass_on_raise": false,
+        "max-lifespan": 0
       },
       "NodeAudit": {
-        "pass_on_raise": false
+        "pass_on_raise": false,
+        "max-lifespan": 0
       }
     },
     "report_uris": [

--- a/spec/fixtures/processor/local_uri/expected_report.json
+++ b/spec/fixtures/processor/local_uri/expected_report.json
@@ -90,67 +90,67 @@
     "scanner_configs": {
       "Bandit": {
         "pass_on_raise": false,
-        "scanner-timeout-ms": 0
+        "scanner-timeout-s": 0
       },
       "Brakeman": {
         "pass_on_raise": false,
-        "scanner-timeout-ms": 0
+        "scanner-timeout-s": 0
       },
       "BundleAudit": {
         "pass_on_raise": false,
-        "scanner-timeout-ms": 0
+        "scanner-timeout-s": 0
       },
       "CargoAudit": {
         "pass_on_raise": false,
-        "scanner-timeout-ms": 0
+        "scanner-timeout-s": 0
       },
       "Gosec": {
         "pass_on_raise": false,
-        "scanner-timeout-ms": 0
+        "scanner-timeout-s": 0
       },
       "NPMAudit": {
         "pass_on_raise": false,
-        "scanner-timeout-ms": 0
+        "scanner-timeout-s": 0
       },
       "PatternSearch": {
         "pass_on_raise": false,
-        "scanner-timeout-ms": 0
+        "scanner-timeout-s": 0
       },
       "RepoNotEmpty": {
         "pass_on_raise": false,
-        "scanner-timeout-ms": 0
+        "scanner-timeout-s": 0
       },
       "ReportGoDep": {
         "pass_on_raise": false,
-        "scanner-timeout-ms": 0
+        "scanner-timeout-s": 0
       },
       "ReportNodeModules": {
         "pass_on_raise": false,
-        "scanner-timeout-ms": 0
+        "scanner-timeout-s": 0
       },
       "ReportPythonModules": {
         "pass_on_raise": false,
-        "scanner-timeout-ms": 0
+        "scanner-timeout-s": 0
       },
       "ReportRubyGems": {
         "pass_on_raise": false,
-        "scanner-timeout-ms": 0
+        "scanner-timeout-s": 0
       },
       "ReportRustCrates": {
         "pass_on_raise": false,
-        "scanner-timeout-ms": 0
+        "scanner-timeout-s": 0
       },
       "Semgrep": {
         "pass_on_raise": false,
-        "scanner-timeout-ms": 0
+        "scanner-timeout-s": 0
       },
       "YarnAudit": {
         "pass_on_raise": false,
-        "scanner-timeout-ms": 0
+        "scanner-timeout-s": 0
       },
       "NodeAudit": {
         "pass_on_raise": false,
-        "scanner-timeout-ms": 0
+        "scanner-timeout-s": 0
       }
     },
     "report_uris": [

--- a/spec/fixtures/processor/local_uri/expected_report.json
+++ b/spec/fixtures/processor/local_uri/expected_report.json
@@ -90,67 +90,67 @@
     "scanner_configs": {
       "Bandit": {
         "pass_on_raise": false,
-        "max-lifespan": 0
+        "scanner-timeout-ms": 0
       },
       "Brakeman": {
         "pass_on_raise": false,
-        "max-lifespan": 0
+        "scanner-timeout-ms": 0
       },
       "BundleAudit": {
         "pass_on_raise": false,
-        "max-lifespan": 0
+        "scanner-timeout-ms": 0
       },
       "CargoAudit": {
         "pass_on_raise": false,
-        "max-lifespan": 0
+        "scanner-timeout-ms": 0
       },
       "Gosec": {
         "pass_on_raise": false,
-        "max-lifespan": 0
+        "scanner-timeout-ms": 0
       },
       "NPMAudit": {
         "pass_on_raise": false,
-        "max-lifespan": 0
+        "scanner-timeout-ms": 0
       },
       "PatternSearch": {
         "pass_on_raise": false,
-        "max-lifespan": 0
+        "scanner-timeout-ms": 0
       },
       "RepoNotEmpty": {
         "pass_on_raise": false,
-        "max-lifespan": 0
+        "scanner-timeout-ms": 0
       },
       "ReportGoDep": {
         "pass_on_raise": false,
-        "max-lifespan": 0
+        "scanner-timeout-ms": 0
       },
       "ReportNodeModules": {
         "pass_on_raise": false,
-        "max-lifespan": 0
+        "scanner-timeout-ms": 0
       },
       "ReportPythonModules": {
         "pass_on_raise": false,
-        "max-lifespan": 0
+        "scanner-timeout-ms": 0
       },
       "ReportRubyGems": {
         "pass_on_raise": false,
-        "max-lifespan": 0
+        "scanner-timeout-ms": 0
       },
       "ReportRustCrates": {
         "pass_on_raise": false,
-        "max-lifespan": 0
+        "scanner-timeout-ms": 0
       },
       "Semgrep": {
         "pass_on_raise": false,
-        "max-lifespan": 0
+        "scanner-timeout-ms": 0
       },
       "YarnAudit": {
         "pass_on_raise": false,
-        "max-lifespan": 0
+        "scanner-timeout-ms": 0
       },
       "NodeAudit": {
         "pass_on_raise": false,
-        "max-lifespan": 0
+        "scanner-timeout-ms": 0
       }
     },
     "report_uris": [

--- a/spec/fixtures/processor/local_uri/expected_report.json
+++ b/spec/fixtures/processor/local_uri/expected_report.json
@@ -89,52 +89,68 @@
     ],
     "scanner_configs": {
       "Bandit": {
-        "pass_on_raise": false
+        "pass_on_raise": false,
+        "max-lifespan": 0
       },
       "Brakeman": {
-        "pass_on_raise": false
+        "pass_on_raise": false,
+        "max-lifespan": 0
       },
       "BundleAudit": {
-        "pass_on_raise": false
+        "pass_on_raise": false,
+        "max-lifespan": 0
       },
       "CargoAudit": {
-        "pass_on_raise": false
+        "pass_on_raise": false,
+        "max-lifespan": 0
       },
       "Gosec": {
-        "pass_on_raise": false
+        "pass_on_raise": false,
+        "max-lifespan": 0
       },
       "NPMAudit": {
-        "pass_on_raise": false
+        "pass_on_raise": false,
+        "max-lifespan": 0
       },
       "PatternSearch": {
-        "pass_on_raise": false
+        "pass_on_raise": false,
+        "max-lifespan": 0
       },
       "RepoNotEmpty": {
-        "pass_on_raise": false
+        "pass_on_raise": false,
+        "max-lifespan": 0
       },
       "ReportGoDep": {
-        "pass_on_raise": false
+        "pass_on_raise": false,
+        "max-lifespan": 0
       },
       "ReportNodeModules": {
-        "pass_on_raise": false
+        "pass_on_raise": false,
+        "max-lifespan": 0
       },
       "ReportPythonModules": {
-        "pass_on_raise": false
+        "pass_on_raise": false,
+        "max-lifespan": 0
       },
       "ReportRubyGems": {
-        "pass_on_raise": false
+        "pass_on_raise": false,
+        "max-lifespan": 0
       },
       "ReportRustCrates": {
-        "pass_on_raise": false
+        "pass_on_raise": false,
+        "max-lifespan": 0
       },
       "Semgrep": {
-        "pass_on_raise": false
+        "pass_on_raise": false,
+        "max-lifespan": 0
       },
       "YarnAudit": {
-        "pass_on_raise": false
+        "pass_on_raise": false,
+        "max-lifespan": 0
       },
       "NodeAudit": {
-        "pass_on_raise": false
+        "pass_on_raise": false,
+        "max-lifespan": 0
       }
     },
     "report_uris": [

--- a/spec/fixtures/processor/local_uri/expected_report.json
+++ b/spec/fixtures/processor/local_uri/expected_report.json
@@ -90,67 +90,67 @@
     "scanner_configs": {
       "Bandit": {
         "pass_on_raise": false,
-        "scanner-timeout-s": 0
+        "scanner_timeout_s": 0
       },
       "Brakeman": {
         "pass_on_raise": false,
-        "scanner-timeout-s": 0
+        "scanner_timeout_s": 0
       },
       "BundleAudit": {
         "pass_on_raise": false,
-        "scanner-timeout-s": 0
+        "scanner_timeout_s": 0
       },
       "CargoAudit": {
         "pass_on_raise": false,
-        "scanner-timeout-s": 0
+        "scanner_timeout_s": 0
       },
       "Gosec": {
         "pass_on_raise": false,
-        "scanner-timeout-s": 0
+        "scanner_timeout_s": 0
       },
       "NPMAudit": {
         "pass_on_raise": false,
-        "scanner-timeout-s": 0
+        "scanner_timeout_s": 0
       },
       "PatternSearch": {
         "pass_on_raise": false,
-        "scanner-timeout-s": 0
+        "scanner_timeout_s": 0
       },
       "RepoNotEmpty": {
         "pass_on_raise": false,
-        "scanner-timeout-s": 0
+        "scanner_timeout_s": 0
       },
       "ReportGoDep": {
         "pass_on_raise": false,
-        "scanner-timeout-s": 0
+        "scanner_timeout_s": 0
       },
       "ReportNodeModules": {
         "pass_on_raise": false,
-        "scanner-timeout-s": 0
+        "scanner_timeout_s": 0
       },
       "ReportPythonModules": {
         "pass_on_raise": false,
-        "scanner-timeout-s": 0
+        "scanner_timeout_s": 0
       },
       "ReportRubyGems": {
         "pass_on_raise": false,
-        "scanner-timeout-s": 0
+        "scanner_timeout_s": 0
       },
       "ReportRustCrates": {
         "pass_on_raise": false,
-        "scanner-timeout-s": 0
+        "scanner_timeout_s": 0
       },
       "Semgrep": {
         "pass_on_raise": false,
-        "scanner-timeout-s": 0
+        "scanner_timeout_s": 0
       },
       "YarnAudit": {
         "pass_on_raise": false,
-        "scanner-timeout-s": 0
+        "scanner_timeout_s": 0
       },
       "NodeAudit": {
         "pass_on_raise": false,
-        "scanner-timeout-s": 0
+        "scanner_timeout_s": 0
       }
     },
     "report_uris": [

--- a/spec/fixtures/processor/remote_uri/expected_report.json
+++ b/spec/fixtures/processor/remote_uri/expected_report.json
@@ -90,67 +90,67 @@
     "scanner_configs": {
       "Bandit": {
         "pass_on_raise": false,
-        "scanner-timeout-ms": 0
+        "scanner-timeout-s": 0
       },
       "Brakeman": {
         "pass_on_raise": false,
-        "scanner-timeout-ms": 0
+        "scanner-timeout-s": 0
       },
       "BundleAudit": {
         "pass_on_raise": false,
-        "scanner-timeout-ms": 0
+        "scanner-timeout-s": 0
       },
       "CargoAudit": {
         "pass_on_raise": false,
-        "scanner-timeout-ms": 0
+        "scanner-timeout-s": 0
       },
       "Gosec": {
         "pass_on_raise": false,
-        "scanner-timeout-ms": 0
+        "scanner-timeout-s": 0
       },
       "NPMAudit": {
         "pass_on_raise": false,
-        "scanner-timeout-ms": 0
+        "scanner-timeout-s": 0
       },
       "PatternSearch": {
         "pass_on_raise": false,
-        "scanner-timeout-ms": 0
+        "scanner-timeout-s": 0
       },
       "RepoNotEmpty": {
         "pass_on_raise": false,
-        "scanner-timeout-ms": 0
+        "scanner-timeout-s": 0
       },
       "ReportGoDep": {
         "pass_on_raise": false,
-        "scanner-timeout-ms": 0
+        "scanner-timeout-s": 0
       },
       "ReportNodeModules": {
         "pass_on_raise": false,
-        "scanner-timeout-ms": 0
+        "scanner-timeout-s": 0
       },
       "ReportPythonModules": {
         "pass_on_raise": false,
-        "scanner-timeout-ms": 0
+        "scanner-timeout-s": 0
       },
       "ReportRubyGems": {
         "pass_on_raise": false,
-        "scanner-timeout-ms": 0
+        "scanner-timeout-s": 0
       },
       "ReportRustCrates": {
         "pass_on_raise": false,
-        "scanner-timeout-ms": 0
+        "scanner-timeout-s": 0
       },
       "Semgrep": {
         "pass_on_raise": false,
-        "scanner-timeout-ms": 0
+        "scanner-timeout-s": 0
       },
       "YarnAudit": {
         "pass_on_raise": false,
-        "scanner-timeout-ms": 0
+        "scanner-timeout-s": 0
       },
       "NodeAudit": {
         "pass_on_raise": false,
-        "scanner-timeout-ms": 0
+        "scanner-timeout-s": 0
       }
     },
     "report_uris": [

--- a/spec/fixtures/processor/remote_uri/expected_report.json
+++ b/spec/fixtures/processor/remote_uri/expected_report.json
@@ -90,67 +90,67 @@
     "scanner_configs": {
       "Bandit": {
         "pass_on_raise": false,
-        "max-lifespan": 0
+        "scanner-timeout-ms": 0
       },
       "Brakeman": {
         "pass_on_raise": false,
-        "max-lifespan": 0
+        "scanner-timeout-ms": 0
       },
       "BundleAudit": {
         "pass_on_raise": false,
-        "max-lifespan": 0
+        "scanner-timeout-ms": 0
       },
       "CargoAudit": {
         "pass_on_raise": false,
-        "max-lifespan": 0
+        "scanner-timeout-ms": 0
       },
       "Gosec": {
         "pass_on_raise": false,
-        "max-lifespan": 0
+        "scanner-timeout-ms": 0
       },
       "NPMAudit": {
         "pass_on_raise": false,
-        "max-lifespan": 0
+        "scanner-timeout-ms": 0
       },
       "PatternSearch": {
         "pass_on_raise": false,
-        "max-lifespan": 0
+        "scanner-timeout-ms": 0
       },
       "RepoNotEmpty": {
         "pass_on_raise": false,
-        "max-lifespan": 0
+        "scanner-timeout-ms": 0
       },
       "ReportGoDep": {
         "pass_on_raise": false,
-        "max-lifespan": 0
+        "scanner-timeout-ms": 0
       },
       "ReportNodeModules": {
         "pass_on_raise": false,
-        "max-lifespan": 0
+        "scanner-timeout-ms": 0
       },
       "ReportPythonModules": {
         "pass_on_raise": false,
-        "max-lifespan": 0
+        "scanner-timeout-ms": 0
       },
       "ReportRubyGems": {
         "pass_on_raise": false,
-        "max-lifespan": 0
+        "scanner-timeout-ms": 0
       },
       "ReportRustCrates": {
         "pass_on_raise": false,
-        "max-lifespan": 0
+        "scanner-timeout-ms": 0
       },
       "Semgrep": {
         "pass_on_raise": false,
-        "max-lifespan": 0
+        "scanner-timeout-ms": 0
       },
       "YarnAudit": {
         "pass_on_raise": false,
-        "max-lifespan": 0
+        "scanner-timeout-ms": 0
       },
       "NodeAudit": {
         "pass_on_raise": false,
-        "max-lifespan": 0
+        "scanner-timeout-ms": 0
       }
     },
     "report_uris": [

--- a/spec/fixtures/processor/remote_uri/expected_report.json
+++ b/spec/fixtures/processor/remote_uri/expected_report.json
@@ -89,52 +89,68 @@
     ],
     "scanner_configs": {
       "Bandit": {
-        "pass_on_raise": false
+        "pass_on_raise": false,
+        "max-lifespan": 0
       },
       "Brakeman": {
-        "pass_on_raise": false
+        "pass_on_raise": false,
+        "max-lifespan": 0
       },
       "BundleAudit": {
-        "pass_on_raise": false
+        "pass_on_raise": false,
+        "max-lifespan": 0
       },
       "CargoAudit": {
-        "pass_on_raise": false
+        "pass_on_raise": false,
+        "max-lifespan": 0
       },
       "Gosec": {
-        "pass_on_raise": false
+        "pass_on_raise": false,
+        "max-lifespan": 0
       },
       "NPMAudit": {
-        "pass_on_raise": false
+        "pass_on_raise": false,
+        "max-lifespan": 0
       },
       "PatternSearch": {
-        "pass_on_raise": false
+        "pass_on_raise": false,
+        "max-lifespan": 0
       },
       "RepoNotEmpty": {
-        "pass_on_raise": false
+        "pass_on_raise": false,
+        "max-lifespan": 0
       },
       "ReportGoDep": {
-        "pass_on_raise": false
+        "pass_on_raise": false,
+        "max-lifespan": 0
       },
       "ReportNodeModules": {
-        "pass_on_raise": false
+        "pass_on_raise": false,
+        "max-lifespan": 0
       },
       "ReportPythonModules": {
-        "pass_on_raise": false
+        "pass_on_raise": false,
+        "max-lifespan": 0
       },
       "ReportRubyGems": {
-        "pass_on_raise": false
+        "pass_on_raise": false,
+        "max-lifespan": 0
       },
       "ReportRustCrates": {
-        "pass_on_raise": false
+        "pass_on_raise": false,
+        "max-lifespan": 0
       },
       "Semgrep": {
-        "pass_on_raise": false
+        "pass_on_raise": false,
+        "max-lifespan": 0
       },
       "YarnAudit": {
-        "pass_on_raise": false
+        "pass_on_raise": false,
+        "max-lifespan": 0
       },
       "NodeAudit": {
-        "pass_on_raise": false
+        "pass_on_raise": false,
+        "max-lifespan": 0
       }
     },
     "report_uris": [

--- a/spec/fixtures/processor/remote_uri/expected_report.json
+++ b/spec/fixtures/processor/remote_uri/expected_report.json
@@ -90,67 +90,67 @@
     "scanner_configs": {
       "Bandit": {
         "pass_on_raise": false,
-        "scanner-timeout-s": 0
+        "scanner_timeout_s": 0
       },
       "Brakeman": {
         "pass_on_raise": false,
-        "scanner-timeout-s": 0
+        "scanner_timeout_s": 0
       },
       "BundleAudit": {
         "pass_on_raise": false,
-        "scanner-timeout-s": 0
+        "scanner_timeout_s": 0
       },
       "CargoAudit": {
         "pass_on_raise": false,
-        "scanner-timeout-s": 0
+        "scanner_timeout_s": 0
       },
       "Gosec": {
         "pass_on_raise": false,
-        "scanner-timeout-s": 0
+        "scanner_timeout_s": 0
       },
       "NPMAudit": {
         "pass_on_raise": false,
-        "scanner-timeout-s": 0
+        "scanner_timeout_s": 0
       },
       "PatternSearch": {
         "pass_on_raise": false,
-        "scanner-timeout-s": 0
+        "scanner_timeout_s": 0
       },
       "RepoNotEmpty": {
         "pass_on_raise": false,
-        "scanner-timeout-s": 0
+        "scanner_timeout_s": 0
       },
       "ReportGoDep": {
         "pass_on_raise": false,
-        "scanner-timeout-s": 0
+        "scanner_timeout_s": 0
       },
       "ReportNodeModules": {
         "pass_on_raise": false,
-        "scanner-timeout-s": 0
+        "scanner_timeout_s": 0
       },
       "ReportPythonModules": {
         "pass_on_raise": false,
-        "scanner-timeout-s": 0
+        "scanner_timeout_s": 0
       },
       "ReportRubyGems": {
         "pass_on_raise": false,
-        "scanner-timeout-s": 0
+        "scanner_timeout_s": 0
       },
       "ReportRustCrates": {
         "pass_on_raise": false,
-        "scanner-timeout-s": 0
+        "scanner_timeout_s": 0
       },
       "Semgrep": {
         "pass_on_raise": false,
-        "scanner-timeout-s": 0
+        "scanner_timeout_s": 0
       },
       "YarnAudit": {
         "pass_on_raise": false,
-        "scanner-timeout-s": 0
+        "scanner_timeout_s": 0
       },
       "NodeAudit": {
         "pass_on_raise": false,
-        "scanner-timeout-s": 0
+        "scanner_timeout_s": 0
       }
     },
     "report_uris": [

--- a/spec/lib/salus/processor_spec.rb
+++ b/spec/lib/salus/processor_spec.rb
@@ -154,7 +154,6 @@ describe Salus::Processor do
           headers: { 'Content-Type' => 'application/json' },
           times: 1
         ) do |req|
-          puts req.body
           expect(req.body).to match_report_json(expected_report)
         end
       end

--- a/spec/lib/salus/processor_spec.rb
+++ b/spec/lib/salus/processor_spec.rb
@@ -154,6 +154,7 @@ describe Salus::Processor do
           headers: { 'Content-Type' => 'application/json' },
           times: 1
         ) do |req|
+          puts req.body
           expect(req.body).to match_report_json(expected_report)
         end
       end

--- a/spec/lib/salus/scanners/base_spec.rb
+++ b/spec/lib/salus/scanners/base_spec.rb
@@ -9,7 +9,7 @@ describe Salus::Scanners::Base do
     let(:scanner) do
       Salus::Scanners::BundleAudit.new(
         repository: repository,
-        config: { 'scanner-timeout-ms' => 0 }
+        config: { 'scanner-timeout-s' => 0 }
       )
     end
     before do

--- a/spec/lib/salus/scanners/base_spec.rb
+++ b/spec/lib/salus/scanners/base_spec.rb
@@ -7,7 +7,10 @@ describe Salus::Scanners::Base do
   describe 'run!' do
     let(:salus_report) { Salus::Report.new }
     let(:scanner) do
-      Salus::Scanners::BundleAudit.new(repository: repository, config: { 'max-lifespan' => 0 })
+      Salus::Scanners::BundleAudit.new(
+        repository: repository,
+        config: { 'scanner-timeout-ms' => 0 }
+      )
     end
     before do
       allow(scanner).to receive(:run).and_raise(RuntimeError, 'bundle audit failed')

--- a/spec/lib/salus/scanners/base_spec.rb
+++ b/spec/lib/salus/scanners/base_spec.rb
@@ -30,7 +30,7 @@ describe Salus::Scanners::Base do
       )
     end
 
-    it 'should catch excepetions and fail the build if pass_on_raise false' do
+    it 'should catch exceptions and fail the build if pass_on_raise false' do
       expect do
         scanner.run!(
           salus_report: salus_report,
@@ -43,7 +43,7 @@ describe Salus::Scanners::Base do
       expect(salus_report.passed?).to eq(false)
     end
 
-    it 'should catch excepetions and fail the build if pass_on_raise false' do
+    it 'should catch exceptions and fail the build if pass_on_raise false' do
       expect do
         scanner.run!(
           salus_report: salus_report,

--- a/spec/lib/salus/scanners/base_spec.rb
+++ b/spec/lib/salus/scanners/base_spec.rb
@@ -62,9 +62,10 @@ describe Salus::Scanners::Base do
     end
 
     it 'should time out when execution time exceeds configured timeout' do
+      timeout_s = 2
       sleeping_scanner = Salus::Scanners::BundleAudit.new(
         repository: repository,
-        config: { 'scanner_timeout_s' => 2 }
+        config: { 'scanner_timeout_s' => timeout_s }
       )
       allow(sleeping_scanner).to receive(:run) { sleep(5) }
       expect do
@@ -76,9 +77,7 @@ describe Salus::Scanners::Base do
         )
       end.to raise_error(
         Salus::Scanners::Base::ScannerTimeoutError,
-        # Using regex to match the message irrespective of the exact execution duration.
-        # Here, we expect a "2" before the "." and 1 or 2 digits of any number after it
-        /Scanner BundleAudit timed out after 2.\d{1,2} seconds/
+        "Scanner BundleAudit timed out after #{timeout_s} seconds"
       )
     end
   end

--- a/spec/lib/salus/scanners/base_spec.rb
+++ b/spec/lib/salus/scanners/base_spec.rb
@@ -6,7 +6,9 @@ describe Salus::Scanners::Base do
 
   describe 'run!' do
     let(:salus_report) { Salus::Report.new }
-    let(:scanner) { Salus::Scanners::BundleAudit.new(repository: repository, config: { 'max-lifespan' => 0 }) }
+    let(:scanner) do
+      Salus::Scanners::BundleAudit.new(repository: repository, config: { 'max-lifespan' => 0 })
+    end
     before do
       allow(scanner).to receive(:run).and_raise(RuntimeError, 'bundle audit failed')
     end

--- a/spec/lib/salus/scanners/base_spec.rb
+++ b/spec/lib/salus/scanners/base_spec.rb
@@ -9,7 +9,7 @@ describe Salus::Scanners::Base do
     let(:scanner) do
       Salus::Scanners::BundleAudit.new(
         repository: repository,
-        config: { 'scanner-timeout-s' => 0 }
+        config: { 'scanner_timeout_s' => 0 }
       )
     end
     before do

--- a/spec/lib/salus/scanners/base_spec.rb
+++ b/spec/lib/salus/scanners/base_spec.rb
@@ -61,7 +61,7 @@ describe Salus::Scanners::Base do
       expect(salus_report.passed?).to eq(true)
     end
 
-    it 'should time out whene execution time exceeds configure timeout' do
+    it 'should time out when execution time exceeds configured timeout' do
       sleeping_scanner = Salus::Scanners::BundleAudit.new(
         repository: repository,
         config: { 'scanner_timeout_s' => 2 }

--- a/spec/lib/salus/scanners/base_spec.rb
+++ b/spec/lib/salus/scanners/base_spec.rb
@@ -6,7 +6,7 @@ describe Salus::Scanners::Base do
 
   describe 'run!' do
     let(:salus_report) { Salus::Report.new }
-    let(:scanner) { Salus::Scanners::BundleAudit.new(repository: repository, config: {}) }
+    let(:scanner) { Salus::Scanners::BundleAudit.new(repository: repository, config: { 'max-lifespan' => 0 }) }
     before do
       allow(scanner).to receive(:run).and_raise(RuntimeError, 'bundle audit failed')
     end


### PR DESCRIPTION
This lets developers define a `scanner_timeout_s` key in scanner configurations. If a scanner is scanning for longer than `scanner_timeout_s` seconds, the scan times out and an error is reported accordingly. If no `scanner_timeout_s` is provided, the scan is allowed to run indefinitely. Also fixed some typos in `base_spec.rb`.