### PR TITLE
Update pattern_search.rb

### DIFF
--- a/lib/salus/scanners/pattern_search.rb
+++ b/lib/salus/scanners/pattern_search.rb
@@ -48,6 +48,9 @@ module Salus::Scanners
           ex_paths = match['exclude_filepaths'] || @config['exclude_filepaths']
           exclude_filepath_pattern = filepath_pattern(ex_paths)
 
+          # Setting default block size in kilobytes to 256KB
+          match['blocksize'] ||= '256K'
+          
           command_array = [
             "sift",
             "-n",
@@ -60,7 +63,9 @@ module Salus::Scanners
             ".",
             *(match_exclude_directory_flags || global_exclude_directory_flags),
             *(match_exclude_extension_flags || global_exclude_extension_flags),
-            *(match_include_extension_flags || global_include_extension_flags)
+            *(match_include_extension_flags || global_include_extension_flags),
+            "--blocksize ",
+            match['blocksize']
           ].compact
 
           shell_return = run_shell(command_array)


### PR DESCRIPTION
Fixing the Salus Pattern Search Error where the Pattern search parser is not able to process files with larger line than 256KB

Bug | https://jira.coinbase-corp.com/browse/SECT-760

Added in a new variable with default size of 256K which can be changed for applications where the parsing is not working over to 512K and then re-processed.