### PR TITLE
Update pattern_search.rb

### DIFF
--- a/lib/salus/scanners/pattern_search.rb
+++ b/lib/salus/scanners/pattern_search.rb
@@ -48,6 +48,9 @@ module Salus::Scanners
           ex_paths = match['exclude_filepaths'] || @config['exclude_filepaths']
           exclude_filepath_pattern = filepath_pattern(ex_paths)
 
+          # Setting default block size in kilobytes to 256KB
+          match['blocksize'] ||= '256K'
+          
           command_array = [
             "sift",
             "-n",
@@ -60,7 +63,9 @@ module Salus::Scanners
             ".",
             *(match_exclude_directory_flags || global_exclude_directory_flags),
             *(match_exclude_extension_flags || global_exclude_extension_flags),
-            *(match_include_extension_flags || global_include_extension_flags)
+            *(match_include_extension_flags || global_include_extension_flags),
+            "--blocksize",
+            match['blocksize']
           ].compact
 
           shell_return = run_shell(command_array)


### PR DESCRIPTION
Added in support to specify a blocksize attribute that will allow projects to increase the default size of Salus Pattern search scanner. Default is now set to 256KB

In order to increase we used 512KB to see if that allows the scanner to complete the processing or not. It worked with 512KB.