### PR TITLE
Added support for defining blocksize for Pattern search

### DIFF
--- a/lib/salus/scanners/pattern_search.rb
+++ b/lib/salus/scanners/pattern_search.rb
@@ -47,7 +47,8 @@ module Salus::Scanners
           # if both are specified, they should be joined
           ex_paths = match['exclude_filepaths'] || @config['exclude_filepaths']
           exclude_filepath_pattern = filepath_pattern(ex_paths)
-
+          # Setting default block size in kilobytes to 256KB
+          match['blocksize'] ||= '256K'
           command_array = [
             "sift",
             "-n",
@@ -60,7 +61,9 @@ module Salus::Scanners
             ".",
             *(match_exclude_directory_flags || global_exclude_directory_flags),
             *(match_exclude_extension_flags || global_exclude_extension_flags),
-            *(match_include_extension_flags || global_include_extension_flags)
+            *(match_include_extension_flags || global_include_extension_flags),
+            "--blocksize",
+            match['blocksize']
           ].compact
 
           shell_return = run_shell(command_array)

--- a/spec/fixtures/integration/expected_report.json
+++ b/spec/fixtures/integration/expected_report.json
@@ -48,6 +48,7 @@
         "matches": [
           {
             "regex": "placeholder",
+            "blocksize": "256K",
             "forbidden": false,
             "required": false,
             "message": ""


### PR DESCRIPTION
Added in support to specify a blocksize attribute that will allow projects to increase the default size of Salus Pattern search scanner. Default is now set to 256KBIn order to increase we used 512KB to see if that allows the scanner to complete the processing or not. It worked with 512KB.