### PR TITLE
CycloneDX Node Modules Support With Purl Percentage Encoding

### DIFF
--- a/lib/cyclonedx/base.rb
+++ b/lib/cyclonedx/base.rb
@@ -79,9 +79,11 @@ module Cyclonedx
 
     # Return version string to be used in purl or component
     def version_string(dependency, is_purl_version = false)
-      # If the dependency is specified in a unlocked dependency file and an absolute version is needed for
-      # the purl return empty
-      return "" if dependency[:dependency_file] == self.class::UNLOCKED_DEPENDENCY_FILE && is_purl_version
+      # If the dependency is specified in a unlocked dependency file and an absolute version
+      # is needed for the purl return empty
+      if dependency[:dependency_file] == self.class::UNLOCKED_DEPENDENCY_FILE && is_purl_version
+        return ""
+      end
 
       dependency[:version]
     end

--- a/lib/cyclonedx/base.rb
+++ b/lib/cyclonedx/base.rb
@@ -1,6 +1,8 @@
 module Cyclonedx
   class Base
     DEFAULT_DEP_COMPONENT_TYPE = "library".freeze
+    TYPE = "N/A".freeze
+
     class CycloneDXInvalidVersionError < StandardError; end
 
     attr_accessor :config
@@ -66,6 +68,12 @@ module Cyclonedx
           "value": dependency[:dependency_file]
         }
       ]
+    end
+
+    def package_url(dependency)
+      PackageUrl.new(type: self.class::TYPE,
+                     namespace: dependency[:name],
+                     version: version_string(dependency, true)).to_string
     end
   end
 end

--- a/lib/cyclonedx/base.rb
+++ b/lib/cyclonedx/base.rb
@@ -2,6 +2,7 @@ module Cyclonedx
   class Base
     DEFAULT_DEP_COMPONENT_TYPE = "library".freeze
     TYPE = "N/A".freeze
+    UNLOCKED_DEPENDENCY_FILE = "N/A".freeze
 
     class CycloneDXInvalidVersionError < StandardError; end
 
@@ -74,6 +75,15 @@ module Cyclonedx
       PackageUrl.new(type: self.class::TYPE,
                      namespace: dependency[:name],
                      version: version_string(dependency, true)).to_string
+    end
+
+    # Return version string to be used in purl or component
+    def version_string(dependency, is_purl_version = false)
+      # If the dependency is specified in a unlocked dependency file and an absolute version is needed for
+      # the purl return empty
+      return "" if dependency[:dependency_file] == self.class::UNLOCKED_DEPENDENCY_FILE && is_purl_version
+
+      dependency[:version]
     end
   end
 end

--- a/lib/cyclonedx/package_url.rb
+++ b/lib/cyclonedx/package_url.rb
@@ -1,0 +1,30 @@
+module Cyclonedx
+  class PackageUrl
+    def initialize(type:, namespace:, version:)
+      @type = type
+      @namespace = namespace
+      @version = version
+    end
+
+    # TODO: Add support for qualifiers and subpaths
+    # https://github.com/package-url/purl-spec/blob/master/PURL-SPECIFICATION.rst#how-to-build-purl-string-from-its-components
+    def to_string
+      # Start with type and a colon
+      purl = "pkg:#{@type}/"
+
+      # Add the required namespace
+      if @namespace.present?
+        # Remove leading and trailing /
+        namespace = @namespace.delete_prefix("/").delete_suffix("/")
+
+        ns = namespace.split("/").map { |s| CGI.escape(s) }
+        purl += ns.join("/")
+      end
+
+      # If a version is provided, add it after the @ symbol
+      purl += "@#{CGI.escape(@version)}" if @version.present?
+
+      purl
+    end
+  end
+end

--- a/lib/cyclonedx/report.rb
+++ b/lib/cyclonedx/report.rb
@@ -2,6 +2,7 @@ require 'securerandom'
 require 'json'
 require 'json-schema'
 require_relative './base'
+require_relative './package_url'
 
 Dir.entries(File.expand_path('./', __dir__)).sort.each do |filename|
   next unless /_cyclonedx.rb\z/.match?(filename) && !filename.eql?('base_cyclonedx.rb')

--- a/lib/cyclonedx/report_node_modules_cyclonedx.rb
+++ b/lib/cyclonedx/report_node_modules_cyclonedx.rb
@@ -1,18 +1,11 @@
 module Cyclonedx
   class ReportNodeModules < Base
     TYPE = "npm".freeze
+    UNLOCKED_DEPENDENCY_FILE = "package.json".freeze
 
     def initialize(scan_report)
       super(scan_report)
     end
 
-    # Return version string to be used in purl or component
-    def version_string(dependency, is_purl_version = false)
-      # If the dependency is specified in package.json and an absolute version is needed for
-      # the purl return empty
-      return "" if dependency[:dependency_file] == 'package.json' && is_purl_version
-
-      dependency[:version]
-    end
   end
 end

--- a/lib/cyclonedx/report_node_modules_cyclonedx.rb
+++ b/lib/cyclonedx/report_node_modules_cyclonedx.rb
@@ -3,5 +3,19 @@ module Cyclonedx
     def initialize(scan_report)
       super(scan_report)
     end
+
+    def package_url(dependency)
+      "pkg:npm/#{dependency[:name]}#{version_string(dependency, true)}"
+    end
+
+    # Return version string to be used in purl or component
+    def version_string(dependency, is_purl_version = false)
+      # If the dependency is specified in package.json and an absolute version is needed for
+      # the purl return empty
+      return "" if dependency[:dependency_file] == 'package.json' && is_purl_version
+
+      prefix = is_purl_version ? "@" : ""
+      "#{prefix}#{dependency[:version]}"
+    end
   end
 end

--- a/lib/cyclonedx/report_node_modules_cyclonedx.rb
+++ b/lib/cyclonedx/report_node_modules_cyclonedx.rb
@@ -1,11 +1,9 @@
 module Cyclonedx
   class ReportNodeModules < Base
+    TYPE = "npm".freeze
+
     def initialize(scan_report)
       super(scan_report)
-    end
-
-    def package_url(dependency)
-      "pkg:npm/#{dependency[:name]}#{version_string(dependency, true)}"
     end
 
     # Return version string to be used in purl or component
@@ -14,8 +12,7 @@ module Cyclonedx
       # the purl return empty
       return "" if dependency[:dependency_file] == 'package.json' && is_purl_version
 
-      prefix = is_purl_version ? "@" : ""
-      "#{prefix}#{dependency[:version]}"
+      dependency[:version]
     end
   end
 end

--- a/lib/cyclonedx/report_node_modules_cyclonedx.rb
+++ b/lib/cyclonedx/report_node_modules_cyclonedx.rb
@@ -6,6 +6,5 @@ module Cyclonedx
     def initialize(scan_report)
       super(scan_report)
     end
-
   end
 end

--- a/lib/cyclonedx/report_ruby_gems_cyclonedx.rb
+++ b/lib/cyclonedx/report_ruby_gems_cyclonedx.rb
@@ -1,11 +1,9 @@
 module Cyclonedx
   class ReportRubyGems < Base
+    TYPE = "gem".freeze
+
     def initialize(scan_report, config = {})
       super(scan_report, config)
-    end
-
-    def package_url(dependency)
-      "pkg:#{dependency[:type]}/#{dependency[:name]}#{version_string(dependency, true)}"
     end
 
     # Return version string to be used in purl or component
@@ -14,8 +12,7 @@ module Cyclonedx
       # the purl return empty
       return "" if dependency[:dependency_file] == 'Gemfile' && is_purl_version
 
-      prefix = is_purl_version ? "@" : ""
-      "#{prefix}#{dependency[:version]}"
+      dependency[:version]
     end
   end
 end

--- a/lib/cyclonedx/report_ruby_gems_cyclonedx.rb
+++ b/lib/cyclonedx/report_ruby_gems_cyclonedx.rb
@@ -6,6 +6,5 @@ module Cyclonedx
     def initialize(scan_report, config = {})
       super(scan_report, config)
     end
-
   end
 end

--- a/lib/cyclonedx/report_ruby_gems_cyclonedx.rb
+++ b/lib/cyclonedx/report_ruby_gems_cyclonedx.rb
@@ -1,18 +1,11 @@
 module Cyclonedx
   class ReportRubyGems < Base
     TYPE = "gem".freeze
+    UNLOCKED_DEPENDENCY_FILE = "Gemfile".freeze
 
     def initialize(scan_report, config = {})
       super(scan_report, config)
     end
 
-    # Return version string to be used in purl or component
-    def version_string(dependency, is_purl_version = false)
-      # If the dependency is specified in the Gemfile and an absolute version is needed for
-      # the purl return empty
-      return "" if dependency[:dependency_file] == 'Gemfile' && is_purl_version
-
-      dependency[:version]
-    end
   end
 end

--- a/lib/salus/scanners/report_node_modules.rb
+++ b/lib/salus/scanners/report_node_modules.rb
@@ -136,12 +136,10 @@ module Salus::Scanners
         # Resolve the source if possible from .npmrc
         source = if name.start_with?('@')
                    sections = name.split(%r{\/})
-                   name = sections[1]
                    sources[sections[0]]
                  else
                    '<package manager default>'
                  end
-
         record_node_module(
           name: name,
           version: version,

--- a/spec/lib/cyclonedx/package_url_spec.rb
+++ b/spec/lib/cyclonedx/package_url_spec.rb
@@ -1,0 +1,30 @@
+require_relative '../../spec_helper'
+
+describe Cyclonedx::PackageUrl do
+  describe "purl format matches expected" do
+    it 'purl format is correct with no special characters' do
+      purl = Cyclonedx::PackageUrl.new(type: "npm", namespace: "prediction", version: "1.2.0")
+        .to_string
+      expect(purl).to eq("pkg:npm/prediction@1.2.0")
+    end
+
+    it 'purl format is correct with no version' do
+      purl = Cyclonedx::PackageUrl.new(type: "npm", namespace: "prediction", version: "").to_string
+      expect(purl).to eq("pkg:npm/prediction")
+    end
+
+    it 'purl format is correct with percent encoded strings' do
+      purl = Cyclonedx::PackageUrl.new(type: "npm",
+                                       namespace: "@magi-core/prediction",
+                                       version: "1.2.0").to_string
+      expect(purl).to eq("pkg:npm/%40magi-core/prediction@1.2.0")
+    end
+
+    it 'purl format removes leading and trailing / from namespace' do
+      purl = Cyclonedx::PackageUrl.new(type: "npm",
+                                       namespace: "/@magi-core/prediction/",
+                                       version: "1.2.0").to_string
+      expect(purl).to eq("pkg:npm/%40magi-core/prediction@1.2.0")
+    end
+  end
+end

--- a/spec/lib/cyclonedx/report_node_modules_cyclonedx_spec.rb
+++ b/spec/lib/cyclonedx/report_node_modules_cyclonedx_spec.rb
@@ -97,12 +97,12 @@ describe Cyclonedx::ReportNodeModules do
       expect(node_cyclonedx.build_components_object).to match_array(
         [
           {
-            "bom-ref": "pkg:npm/@nerv-hq/control-system@1.2.3",
+            "bom-ref": "pkg:npm/%40nerv-hq/control-system@1.2.3",
             "type": "library",
             "group": "",
             "name": "@nerv-hq/control-system",
             "version": "1.2.3",
-            "purl": "pkg:npm/@nerv-hq/control-system@1.2.3",
+            "purl": "pkg:npm/%40nerv-hq/control-system@1.2.3",
             "properties": [
               {
                 "key": "source",
@@ -116,12 +116,12 @@ describe Cyclonedx::ReportNodeModules do
             ]
           },
           {
-            "bom-ref": "pkg:npm/@magi-core/prediction@0.0.1",
+            "bom-ref": "pkg:npm/%40magi-core/prediction@0.0.1",
             "type": "library",
             "group": "",
             "name": "@magi-core/prediction",
             "version": "0.0.1",
-            "purl": "pkg:npm/@magi-core/prediction@0.0.1",
+            "purl": "pkg:npm/%40magi-core/prediction@0.0.1",
             "properties": [
               {
                 "key": "source",
@@ -185,12 +185,12 @@ describe Cyclonedx::ReportNodeModules do
       expect(node_cyclonedx.build_components_object).to match_array(
         [
           {
-            "bom-ref": "pkg:npm/@nerv-hq/control-system@1.2.3",
+            "bom-ref": "pkg:npm/%40nerv-hq/control-system@1.2.3",
             "type": "library",
             "group": "",
             "name": "@nerv-hq/control-system",
             "version": "1.2.3",
-            "purl": "pkg:npm/@nerv-hq/control-system@1.2.3",
+            "purl": "pkg:npm/%40nerv-hq/control-system@1.2.3",
             "properties": [
               {
                 "key": "source",
@@ -204,12 +204,12 @@ describe Cyclonedx::ReportNodeModules do
             ]
           },
           {
-            "bom-ref": "pkg:npm/@magi-core/prediction@0.0.1",
+            "bom-ref": "pkg:npm/%40magi-core/prediction@0.0.1",
             "type": "library",
             "group": "",
             "name": "@magi-core/prediction",
             "version": "0.0.1",
-            "purl": "pkg:npm/@magi-core/prediction@0.0.1",
+            "purl": "pkg:npm/%40magi-core/prediction@0.0.1",
             "properties": [
               {
                 "key": "source",

--- a/spec/lib/cyclonedx/report_node_modules_cyclonedx_spec.rb
+++ b/spec/lib/cyclonedx/report_node_modules_cyclonedx_spec.rb
@@ -1,0 +1,285 @@
+require_relative '../../spec_helper'
+require 'json'
+
+describe Cyclonedx::ReportNodeModules do
+  describe "#run" do
+    it 'should report all the deps in the package.json if both\
+        package-lock.json and yarn.lock files do not exist' do
+      repo = Salus::Repo.new('spec/fixtures/report_node_modules/package_json_only')
+      scanner = Salus::Scanners::ReportNodeModules.new(repository: repo, config: {})
+      scanner.run
+
+      node_cyclonedx = Cyclonedx::ReportNodeModules.new(scanner.report)
+      expect(node_cyclonedx.build_components_object).to match_array(
+        [
+          {
+            "bom-ref": "pkg:npm/control-system",
+            "type": "library",
+            "group": "",
+            "name": "control-system",
+            "version": "1.2.3",
+            "purl": "pkg:npm/control-system",
+            "properties": [
+              {
+                "key": "source",
+                "value": "https://npm.hq.nerv.net"
+              },
+              {
+                "key": "dependency_file",
+                "value": "package.json"
+              }
+            ]
+          },
+          {
+            "bom-ref": "pkg:npm/prediction",
+            "type": "library",
+            "group": "",
+            "name": "prediction",
+            "version": "0.0.1",
+            "purl": "pkg:npm/prediction",
+            "properties": [
+              {
+                "key": "source",
+                "value": "https://npm.magi.nerv.net"
+              },
+              {
+                "key": "dependency_file",
+                "value": "package.json"
+              }
+            ]
+          },
+          {
+            "bom-ref": "pkg:npm/classnames",
+            "type": "library",
+            "group": "",
+            "name": "classnames",
+            "version": "^2.2.5",
+            "purl": "pkg:npm/classnames",
+            "properties": [
+              {
+                "key": "source",
+                "value": "<package manager default>"
+              },
+              {
+                "key": "dependency_file",
+                "value": "package.json"
+              }
+            ]
+          },
+          {
+            "bom-ref": "pkg:npm/mobx",
+            "type": "library",
+            "group": "",
+            "name": "mobx",
+            "version": "^3.2.1",
+            "purl": "pkg:npm/mobx",
+            "properties": [
+              {
+                "key": "source",
+                "value": "<package manager default>"
+              },
+              {
+                "key": "dependency_file",
+                "value": "package.json"
+              }
+            ]
+          }
+        ]
+      )
+    end
+
+    it 'should report all the deps in the package-lock.json if present' do
+      repo = Salus::Repo.new('spec/fixtures/report_node_modules/package_lock_json')
+      scanner = Salus::Scanners::ReportNodeModules.new(repository: repo, config: {})
+      scanner.run
+
+      node_cyclonedx = Cyclonedx::ReportNodeModules.new(scanner.report)
+      expect(node_cyclonedx.build_components_object).to match_array(
+        [
+          {
+            "bom-ref": "pkg:npm/@nerv-hq/control-system@1.2.3",
+            "type": "library",
+            "group": "",
+            "name": "@nerv-hq/control-system",
+            "version": "1.2.3",
+            "purl": "pkg:npm/@nerv-hq/control-system@1.2.3",
+            "properties": [
+              {
+                "key": "source",
+                "value": 'https://npm.hq.nerv.net/control-system/v1.2.3/'\
+              'tarball#sha1-ux/eKKZxz2ojD4icjhvReee++74='
+              },
+              {
+                "key": "dependency_file",
+                "value": "package-lock.json"
+              }
+            ]
+          },
+          {
+            "bom-ref": "pkg:npm/@magi-core/prediction@0.0.1",
+            "type": "library",
+            "group": "",
+            "name": "@magi-core/prediction",
+            "version": "0.0.1",
+            "purl": "pkg:npm/@magi-core/prediction@0.0.1",
+            "properties": [
+              {
+                "key": "source",
+                "value": 'https://npm.magi.nerv.net/prediction/v0.0.1/'\
+              'tarball#sha1-ux/EyKzTRzvejDFis90vRLj8++74='
+              },
+              {
+                "key": "dependency_file",
+                "value": "package-lock.json"
+              }
+            ]
+          },
+          {
+            "bom-ref": "pkg:npm/classnames@2.2.5",
+            "type": "library",
+            "group": "",
+            "name": "classnames",
+            "version": "2.2.5",
+            "purl": "pkg:npm/classnames@2.2.5",
+            "properties": [
+              {
+                "key": "source",
+                "value": 'https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz'\
+              '#sha1-+zgB1FNGdknvNgPH1hoCvRKb3m0='
+              },
+              {
+                "key": "dependency_file",
+                "value": "package-lock.json"
+              }
+            ]
+          },
+          {
+            "bom-ref": "pkg:npm/mobx@3.2.1",
+            "type": "library",
+            "group": "",
+            "name": "mobx",
+            "version": "3.2.1",
+            "purl": "pkg:npm/mobx@3.2.1",
+            "properties": [
+              {
+                "key": "source",
+                "value": 'https://registry.npmjs.org/mobx/-/mobx-3.2.1.tgz'\
+              '#sha1-aureASDMP3i6pXGVAxYwoK6PE88='
+              },
+              {
+                "key": "dependency_file",
+                "value": "package-lock.json"
+              }
+            ]
+          }
+        ]
+      )
+    end
+
+    it 'should report all the deps in the yarn.lock if present' do
+      repo = Salus::Repo.new('spec/fixtures/report_node_modules/yarn_lock')
+      scanner = Salus::Scanners::ReportNodeModules.new(repository: repo, config: {})
+      scanner.run
+
+      node_cyclonedx = Cyclonedx::ReportNodeModules.new(scanner.report)
+      expect(node_cyclonedx.build_components_object).to match_array(
+        [
+          {
+            "bom-ref": "pkg:npm/@nerv-hq/control-system@1.2.3",
+            "type": "library",
+            "group": "",
+            "name": "@nerv-hq/control-system",
+            "version": "1.2.3",
+            "purl": "pkg:npm/@nerv-hq/control-system@1.2.3",
+            "properties": [
+              {
+                "key": "source",
+                "value": 'https://npm.hq.nerv.net/control-system/v1.2.3/'\
+              'tarball#fb3801d453467639ef560fc7a61a02bd129bde6d'
+              },
+              {
+                "key": "dependency_file",
+                "value": "yarn.lock"
+              }
+            ]
+          },
+          {
+            "bom-ref": "pkg:npm/@magi-core/prediction@0.0.1",
+            "type": "library",
+            "group": "",
+            "name": "@magi-core/prediction",
+            "version": "0.0.1",
+            "purl": "pkg:npm/@magi-core/prediction@0.0.1",
+            "properties": [
+              {
+                "key": "source",
+                "value": 'https://npm.magi.nerv.net/prediction/v0.0.1/'\
+              'tarball#fb3801d453467639ef5602c7a51a02fd129bbbbd'
+              },
+              {
+                "key": "dependency_file",
+                "value": "yarn.lock"
+              }
+            ]
+          },
+          {
+            "bom-ref": "pkg:npm/classnames@2.2.5",
+            "type": "library",
+            "group": "",
+            "name": "classnames",
+            "version": "2.2.5",
+            "purl": "pkg:npm/classnames@2.2.5",
+            "properties": [
+              {
+                "key": "source",
+                "value": 'https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz'\
+              '#fb3801d453467649ef3603c7d61a02bd129bde6d'
+              },
+              {
+                "key": "dependency_file",
+                "value": "yarn.lock"
+              }
+            ]
+          },
+          {
+            "bom-ref": "pkg:npm/mobx@3.2.1",
+            "type": "library",
+            "group": "",
+            "name": "mobx",
+            "version": "3.2.1",
+            "purl": "pkg:npm/mobx@3.2.1",
+            "properties": [
+              {
+                "key": "source",
+                "value": 'https://registry.yarnpkg.com/mobx/-/mobx-3.2.1.tgz'\
+              '#6aeade0120cc3f78baa57195031630a0ae8f13cf'
+              },
+              {
+                "key": "dependency_file",
+                "value": "yarn.lock"
+              }
+            ]
+          },
+          {
+            "bom-ref": "pkg:npm/eslint-plugin-internal@0.0.0",
+            "type": "library",
+            "group": "",
+            "name": "eslint-plugin-internal",
+            "version": "0.0.0",
+            "purl": "pkg:npm/eslint-plugin-internal@0.0.0",
+            "properties": [
+              {
+                "key": "source",
+                "value": 'file:./lib/lint-rules'
+              },
+              {
+                "key": "dependency_file",
+                "value": "yarn.lock"
+              }
+            ]
+          }
+        ]
+      )
+    end
+  end
+end

--- a/spec/lib/cyclonedx/report_node_modules_cyclonedx_spec.rb
+++ b/spec/lib/cyclonedx/report_node_modules_cyclonedx_spec.rb
@@ -13,12 +13,12 @@ describe Cyclonedx::ReportNodeModules do
       expect(node_cyclonedx.build_components_object).to match_array(
         [
           {
-            "bom-ref": "pkg:npm/control-system",
+            "bom-ref": "pkg:npm/%40nerv-hq/control-system",
             "type": "library",
             "group": "",
-            "name": "control-system",
+            "name": "@nerv-hq/control-system",
             "version": "1.2.3",
-            "purl": "pkg:npm/control-system",
+            "purl": "pkg:npm/%40nerv-hq/control-system",
             "properties": [
               {
                 "key": "source",
@@ -31,12 +31,12 @@ describe Cyclonedx::ReportNodeModules do
             ]
           },
           {
-            "bom-ref": "pkg:npm/prediction",
+            "bom-ref": "pkg:npm/%40magi-core/prediction",
             "type": "library",
             "group": "",
-            "name": "prediction",
+            "name": "@magi-core/prediction",
             "version": "0.0.1",
-            "purl": "pkg:npm/prediction",
+            "purl": "pkg:npm/%40magi-core/prediction",
             "properties": [
               {
                 "key": "source",

--- a/spec/lib/salus/scanners/report_node_modules_spec.rb
+++ b/spec/lib/salus/scanners/report_node_modules_spec.rb
@@ -28,14 +28,14 @@ describe Salus::Scanners::ReportNodeModules do
           {
             dependency_file: 'package.json',
             type: 'node_module',
-            name: 'control-system',
+            name: '@nerv-hq/control-system',
             version: '1.2.3',
             source: 'https://npm.hq.nerv.net'
           },
           {
             dependency_file: 'package.json',
             type: 'node_module',
-            name: 'prediction',
+            name: '@magi-core/prediction',
             version: '0.0.1',
             source: 'https://npm.magi.nerv.net'
           },


### PR DESCRIPTION
**What changed?**
- Added in percentage encoding for purl following the [spec](https://github.com/package-url/purl-spec/blob/master/PURL-SPECIFICATION.rst#how-to-build-purl-string-from-its-components). Currently support type, namespace and version (not including qualifiers and subpaths). You can test if a purl can be recognized by using the search option for this vulnerability scanner https://ossindex.sonatype.org/
- Added in logic to parse node module dependencies and populate cyclonedx reports

**How was it tested?**
- Specs for purl encoding
- Testing valid purl's through https://ossindex.sonatype.org/
- Specs for node modules package.json, package-json.lock and yarn.lock as sources
