### PR TITLE
Add CycloneDX Spec Version to Options in Config

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -76,6 +76,10 @@ custom_info: "PR-123"
 # Additional options are also available for cyclonedx using the optional keyword: cyclonedx_options
 # The available options for the cyclonedx_options keyword are:
 # 1) `cyclonedx_project_name: string` -This option allows users to specify the cyclonedx report project name.
+# 2) `spec_version: string` -This option allows users to specify the cyclonedx report spec version.
+#     Currently only versions 1.2 and 1.3 are supported with 1.3 being the default version if the
+#     parameter is not specified.
+
 reports:
   - uri: file://tests/salus-report.txt
     format: txt
@@ -98,6 +102,7 @@ reports:
       X-API-Key: '{{RANDOM_API_KEY}}'
     cyclonedx_options:
       cyclonedx_project_name: '{{SALUS_BUILD_ORG}}/{{SALUS_BUILD_PROJECT}}'
+      spec_version: '1.3'
   - uri: file://tests/salus-report.sarif
     format: sarif
   - uri: file://tests/salus-report.sarif

--- a/lib/cyclonedx/base.rb
+++ b/lib/cyclonedx/base.rb
@@ -23,14 +23,23 @@ module Cyclonedx
     end
 
     def parse_dependency(dependency)
-      {
+      component = {
         "bom-ref": package_url(dependency),
         "type": DEFAULT_DEP_COMPONENT_TYPE,
         "group": "", # TODO: add group or domain name of the publisher
         "name": dependency[:name],
         "version": version_string(dependency),
-        "purl": package_url(dependency),
-        "properties": [
+        "purl": package_url(dependency)
+      }
+
+      unless @config['spec_version'].present? && @config['spec_version'] == "1.2"
+        component[:properties] = dependency_properties(dependency)
+      end
+      component
+    end
+
+    def dependency_properties(dependency)
+       [
           {
             "key": "source",
             # Varies between these two values by scanner
@@ -40,8 +49,7 @@ module Cyclonedx
             "key": "dependency_file",
             "value": dependency[:dependency_file]
           }
-        ]
-      }
+       ]
     end
   end
 end

--- a/lib/cyclonedx/base.rb
+++ b/lib/cyclonedx/base.rb
@@ -1,6 +1,7 @@
 module Cyclonedx
   class Base
     DEFAULT_DEP_COMPONENT_TYPE = "library".freeze
+    class CycloneDXInvalidVersionError < StandardError; end
 
     attr_accessor :config
 
@@ -23,33 +24,48 @@ module Cyclonedx
     end
 
     def parse_dependency(dependency)
-      component = {
+      component = build_component(dependency)
+      component[:properties] = build_properties(dependency)
+
+      # Default to version 1.3 if no spec version is specified
+      return component unless @config['spec_version'].present?
+
+      case @config['spec_version']
+      when "1.2"
+        component.delete(:properties)
+        component
+      when "1.3"
+        component
+      else
+        raise CycloneDXInvalidVersionError,
+              "Incorrect Cyclone Version Specified: #{@config['spec_version']}." \
+              " Should be exactly 1.2 or 1.3"
+      end
+    end
+
+    def build_component(dependency)
+      {
         "bom-ref": package_url(dependency),
         "type": DEFAULT_DEP_COMPONENT_TYPE,
         "group": "", # TODO: add group or domain name of the publisher
         "name": dependency[:name],
         "version": version_string(dependency),
-        "purl": package_url(dependency)
+        "purl": package_url(dependency),
       }
-
-      unless @config['spec_version'].present? && @config['spec_version'] == "1.2"
-        component[:properties] = dependency_properties(dependency)
-      end
-      component
     end
 
-    def dependency_properties(dependency)
-       [
-          {
-            "key": "source",
-            # Varies between these two values by scanner
-            "value": dependency[:source] || dependency[:reference].to_s
-          },
-          {
-            "key": "dependency_file",
-            "value": dependency[:dependency_file]
-          }
-       ]
+    def build_properties(dependency)
+      [
+        {
+          "key": "source",
+          # Varies between these two values by scanner
+          "value": dependency[:source] || dependency[:reference].to_s
+        },
+        {
+          "key": "dependency_file",
+          "value": dependency[:dependency_file]
+        }
+      ]
     end
   end
 end

--- a/lib/cyclonedx/base.rb
+++ b/lib/cyclonedx/base.rb
@@ -50,7 +50,7 @@ module Cyclonedx
         "group": "", # TODO: add group or domain name of the publisher
         "name": dependency[:name],
         "version": version_string(dependency),
-        "purl": package_url(dependency),
+        "purl": package_url(dependency)
       }
     end
 

--- a/lib/cyclonedx/report.rb
+++ b/lib/cyclonedx/report.rb
@@ -19,7 +19,7 @@ module Cyclonedx
       @config = config
     end
 
-    CYCLONEDX_SPEC_VERSION = "1.3".freeze
+    CYCLONEDX_DEFAULT_SPEC_VERSION = "1.3".freeze
     CYCLONEDX_VERSION = 1
     CYCLONEDX_FORMAT = "CycloneDX".freeze
 
@@ -27,7 +27,7 @@ module Cyclonedx
     def to_cyclonedx
       cyclonedx_report = {
         bomFormat: CYCLONEDX_FORMAT,
-        specVersion: CYCLONEDX_SPEC_VERSION,
+        specVersion: spec_version,
         serialNumber: random_urn_uuid,
         version: CYCLONEDX_VERSION,
         metadata: {},
@@ -43,7 +43,7 @@ module Cyclonedx
 
     def self.validate_cyclonedx(cyclonedx_report)
       cyclonedx_string = JSON.pretty_generate(cyclonedx_report)
-      path = File.expand_path('schema/bom-1.3.schema.json', __dir__)
+      path = File.expand_path("schema/bom-#{cyclonedx_report[:specVersion]}.schema.json", __dir__)
       schema = JSON.parse(File.read(path))
       return cyclonedx_report if JSON::Validator.validate(schema, cyclonedx_string)
 
@@ -65,6 +65,10 @@ module Cyclonedx
 
     def random_urn_uuid
       "urn:uuid:#{SecureRandom.uuid}"
+    end
+
+    def spec_version
+      @config['spec_version'] || CYCLONEDX_DEFAULT_SPEC_VERSION
     end
   end
 end

--- a/lib/cyclonedx/report_ruby_gems_cyclonedx.rb
+++ b/lib/cyclonedx/report_ruby_gems_cyclonedx.rb
@@ -1,7 +1,7 @@
 module Cyclonedx
   class ReportRubyGems < Base
-    def initialize(scan_report)
-      super(scan_report)
+    def initialize(scan_report, config = {})
+      super(scan_report, config)
     end
 
     def package_url(dependency)

--- a/lib/cyclonedx/schema/bom-1.2.schema.json
+++ b/lib/cyclonedx/schema/bom-1.2.schema.json
@@ -1,0 +1,997 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$id": "http://cyclonedx.org/schema/bom-1.2a.schema.json",
+  "type": "object",
+  "title": "CycloneDX Software Bill-of-Material Specification",
+  "$comment" : "CycloneDX JSON schema is published under the terms of the Apache License 2.0.",
+  "required": [
+    "bomFormat",
+    "specVersion",
+    "version"
+  ],
+  "properties": {
+    "bomFormat": {
+      "$id": "#/properties/bomFormat",
+      "type": "string",
+      "title": "BOM Format",
+      "description": "Specifies the format of the BOM. This helps to identify the file as CycloneDX since BOMs do not have a filename convention nor does JSON schema support namespaces.",
+      "enum": [
+        "CycloneDX"
+      ]
+    },
+    "specVersion": {
+      "$id": "#/properties/specVersion",
+      "type": "string",
+      "title": "CycloneDX Specification Version",
+      "description": "The version of the CycloneDX specification a BOM is written to (starting at version 1.2)",
+      "examples": ["1.2"]
+    },
+    "serialNumber": {
+      "$id": "#/properties/serialNumber",
+      "type": "string",
+      "title": "BOM Serial Number",
+      "description": "Every BOM generated should have a unique serial number, even if the contents of the BOM being generated have not changed over time. The process or tool responsible for creating the BOM should create random UUID's for every BOM generated.",
+      "default": "",
+      "examples": ["urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79"],
+      "pattern": "^urn:uuid:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+    },
+    "version": {
+      "$id": "#/properties/version",
+      "type": "integer",
+      "title": "BOM Version",
+      "description": "The version allows component publishers/authors to make changes to existing BOMs to update various aspects of the document such as description or licenses. When a system is presented with multiple BOMs for the same component, the system should use the most recent version of the BOM. The default version is '1' and should be incremented for each version of the BOM that is published. Each version of a component should have a unique BOM and if no changes are made to the BOMs, then each BOM will have a version of '1'.",
+      "default": 1,
+      "examples": [1]
+    },
+    "metadata": {
+      "$id": "#/properties/metadata",
+      "$ref": "#/definitions/metadata",
+      "title": "BOM Metadata",
+      "description": "Provides additional information about a BOM."
+    },
+    "components": {
+      "$id": "#/properties/components",
+      "type": "array",
+      "items": {"$ref": "#/definitions/component"},
+      "uniqueItems": true,
+      "title": "Components"
+    },
+    "services": {
+      "$id": "#/properties/services",
+      "type": "array",
+      "items": {"$ref": "#/definitions/service"},
+      "uniqueItems": true,
+      "title": "Services"
+    },
+    "externalReferences": {
+      "$id": "#/properties/externalReferences",
+      "type": "array",
+      "items": {"$ref": "#/definitions/externalReference"},
+      "title": "External References",
+      "description": "External references provide a way to document systems, sites, and information that may be relevant but which are not included with the BOM."
+    },
+    "dependencies": {
+      "$id": "#/properties/dependencies",
+      "type": "array",
+      "items": {"$ref": "#/definitions/dependency"},
+      "uniqueItems": true,
+      "title": "Dependencies",
+      "description": "Provides the ability to document dependency relationships."
+    }
+  },
+  "definitions": {
+    "metadata": {
+      "type": "object",
+      "title": "BOM Metadata Object",
+      "properties": {
+        "timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "title": "Timestamp",
+          "description": "The date and time (timestamp) when the document was created."
+        },
+        "tools": {
+          "type": "array",
+          "title": "Creation Tools",
+          "description": "The tool(s) used in the creation of the BOM.",
+          "items": {"$ref": "#/definitions/tool"}
+        },
+        "authors" :{
+          "type": "array",
+          "title": "Authors",
+          "description": "The person(s) who created the BOM. Authors are common in BOMs created through manual processes. BOMs created through automated means may not have authors.",
+          "items": {"$ref": "#/definitions/organizationalContact"}
+        },
+        "component": {
+          "title": "Component",
+          "description": "The component that the BOM describes.",
+          "$ref": "#/definitions/component"
+        },
+        "manufacture": {
+          "title": "Manufacture",
+          "description": "The organization that manufactured the component that the BOM describes.",
+          "$ref": "#/definitions/organizationalEntity"
+        },
+        "supplier": {
+          "title": "Supplier",
+          "description": " The organization that supplied the component that the BOM describes. The supplier may often be the manufacture, but may also be a distributor or repackager.",
+          "$ref": "#/definitions/organizationalEntity"
+        }
+      }
+    },
+    "tool": {
+      "type": "object",
+      "title": "Tool",
+      "description": "The tool used to create the BOM.",
+      "properties": {
+        "vendor": {
+          "type": "string",
+          "format": "string",
+          "title": "Tool Vendor",
+          "description": "The date and time (timestamp) when the document was created."
+        },
+        "name": {
+          "type": "string",
+          "format": "string",
+          "title": "Tool Name",
+          "description": "The date and time (timestamp) when the document was created."
+        },
+        "version": {
+          "type": "string",
+          "format": "string",
+          "title": "Tool Version",
+          "description": "The date and time (timestamp) when the document was created."
+        },
+        "hashes": {
+          "$id": "#/properties/hashes",
+          "type": "array",
+          "items": {"$ref": "#/definitions/hash"},
+          "title": "Hashes",
+          "description": "The hashes of the tool (if applicable)."
+        }
+      }
+    },
+    "organizationalEntity": {
+      "type": "object",
+      "title": "Organizational Entity Object",
+      "description": "",
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the organization",
+          "default": "",
+          "examples": [
+            "Example Inc."
+          ],
+          "pattern": "^(.*)$"
+        },
+        "url": {
+          "type": "array",
+          "title": "URL",
+          "description": "The URL of the organization. Multiple URLs are allowed.",
+          "default": "",
+          "examples": ["https://example.com"],
+          "pattern": "^(.*)$"
+        },
+        "contact": {
+          "type": "array",
+          "title": "Contact",
+          "description": "A contact at the organization. Multiple contacts are allowed.",
+          "items": {"$ref": "#/definitions/organizationalContact"}
+        }
+      }
+    },
+    "organizationalContact": {
+      "type": "object",
+      "title": "Organizational Contact Object",
+      "description": "",
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of a contact",
+          "default": "",
+          "examples": ["Contact name"],
+          "pattern": "^(.*)$"
+        },
+        "email": {
+          "type": "string",
+          "title": "Email Address",
+          "description": "The email address of the contact. Multiple email addresses are allowed.",
+          "default": "",
+          "examples": ["firstname.lastname@example.com"],
+          "pattern": "^(.*)$"
+        },
+        "phone": {
+          "type": "string",
+          "title": "Phone",
+          "description": "The phone number of the contact. Multiple phone numbers are allowed.",
+          "default": "",
+          "examples": ["800-555-1212"],
+          "pattern": "^(.*)$"
+        }
+      }
+    },
+    "component": {
+      "type": "object",
+      "title": "Component Object",
+      "required": [
+        "type",
+        "name",
+        "version"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "application",
+            "framework",
+            "library",
+            "container",
+            "operating-system",
+            "device",
+            "firmware",
+            "file"
+          ],
+          "title": "Component Type",
+          "description": "Specifies the type of component. For software components, classify as application if no more specific appropriate classification is available or cannot be determined for the component.",
+          "default": "",
+          "examples": ["library"],
+          "pattern": "^(.*)$"
+        },
+        "mime-type": {
+          "type": "string",
+          "title": "Mime-Type",
+          "description": "The optional mime-type of the component. When used on file components, the mime-type can provide additional context about the kind of file being represented such as an image, font, or executable. Some library or framework components may also have an associated mime-type.",
+          "default": "",
+          "examples": ["image/jpeg"],
+          "pattern": "^[-+a-z0-9.]+/[-+a-z0-9.]+$"
+        },
+        "bom-ref": {
+          "type": "string",
+          "title": "BOM Reference",
+          "description": "An optional identifier which can be used to reference the component elsewhere in the BOM. Every bom-ref should be unique.",
+          "default": "",
+          "pattern": "^(.*)$"
+        },
+        "supplier": {
+          "title": "Component Supplier",
+          "description": " The organization that supplied the component. The supplier may often be the manufacture, but may also be a distributor or repackager.",
+          "$ref": "#/definitions/organizationalEntity"
+        },
+        "author": {
+          "type": "string",
+          "title": "Component Author",
+          "description": "The person(s) or organization(s) that authored the component",
+          "default": "",
+          "examples": ["Acme Inc"],
+          "pattern": "^(.*)$"
+        },
+        "publisher": {
+          "type": "string",
+          "title": "Component Publisher",
+          "description": "The person(s) or organization(s) that published the component",
+          "default": "",
+          "examples": ["Acme Inc"],
+          "pattern": "^(.*)$"
+        },
+        "group": {
+          "type": "string",
+          "title": "Component Group",
+          "description": "The grouping name or identifier. This will often be a shortened, single name of the company or project that produced the component, or the source package or domain name. Whitespace and special characters should be avoided. Examples include: apache, org.apache.commons, and apache.org.",
+          "default": "",
+          "examples": ["com.acme"],
+          "pattern": "^(.*)$"
+        },
+        "name": {
+          "type": "string",
+          "title": "Component Name",
+          "description": "The name of the component. This will often be a shortened, single name of the component. Examples: commons-lang3 and jquery",
+          "default": "",
+          "examples": ["tomcat-catalina"],
+          "pattern": "^(.*)$"
+        },
+        "version": {
+          "type": "string",
+          "title": "Component Version",
+          "description": "The component version. The version should ideally comply with semantic versioning but is not enforced.",
+          "default": "",
+          "examples": ["9.0.14"],
+          "pattern": "^(.*)$"
+        },
+        "description": {
+          "type": "string",
+          "title": "Component Description",
+          "description": "Specifies a description for the component",
+          "default": "",
+          "pattern": "^(.*)$"
+        },
+        "scope": {
+          "type": "string",
+          "enum": [
+            "required",
+            "optional",
+            "excluded"
+          ],
+          "title": "Component Scope",
+          "description": "Specifies the scope of the component. If scope is not specified, 'required' scope should be assumed by the consumer of the BOM",
+          "default": "required",
+          "pattern": "^(.*)$"
+        },
+        "hashes": {
+          "type": "array",
+          "title": "Component Hashes",
+          "items": {"$ref": "#/definitions/hash"}
+        },
+        "licenses": {
+          "type": "array",
+          "title": "Component License(s)",
+          "items": {
+            "properties": {
+              "license": {
+                "$ref": "#/definitions/license"
+              },
+              "expression": {
+                "type": "string",
+                "title": "SPDX License Expression",
+                "examples": [
+                  "Apache-2.0 AND (MIT OR GPL-2.0-only)",
+                  "GPL-3.0-only WITH Classpath-exception-2.0"
+                ],
+                "pattern": "^(.*)$"
+              }
+            },
+            "oneOf":[
+              {
+                "required": ["license"]
+              },
+              {
+                "required": ["expression"]
+              }
+            ]
+          }
+        },
+        "copyright": {
+          "type": "string",
+          "title": "Component Copyright",
+          "description": "An optional copyright notice informing users of the underlying claims to copyright ownership in a published work.",
+          "examples": ["Acme Inc"],
+          "pattern": "^(.*)$"
+        },
+        "cpe": {
+          "type": "string",
+          "title": "Component Common Platform Enumeration (CPE)",
+          "description": "DEPRECATED - DO NOT USE. This will be removed in a future version. Specifies a well-formed CPE name. See https://nvd.nist.gov/products/cpe",
+          "examples": ["cpe:2.3:a:acme:component_framework:-:*:*:*:*:*:*:*"],
+          "pattern": "^(.*)$"
+        },
+        "purl": {
+          "type": "string",
+          "title": "Component Package URL (purl)",
+          "default": "",
+          "examples": ["pkg:maven/com.acme/tomcat-catalina@9.0.14?packaging=jar"],
+          "pattern": "^(.*)$"
+        },
+        "swid": {
+          "$ref": "#/definitions/swid",
+          "title": "SWID Tag",
+          "description": "Specifies metadata and content for ISO-IEC 19770-2 Software Identification (SWID) Tags."
+        },
+        "modified": {
+          "type": "boolean",
+          "title": "Component Modified From Original",
+          "description": "DEPRECATED - DO NOT USE. This will be removed in a future version. Use the pedigree element instead to supply information on exactly how the component was modified. A boolean value indicating is the component has been modified from the original. A value of true indicates the component is a derivative of the original. A value of false indicates the component has not been modified from the original."
+        },
+        "pedigree": {
+          "type": "object",
+          "title": "Component Pedigree",
+          "description": "Component pedigree is a way to document complex supply chain scenarios where components are created, distributed, modified, redistributed, combined with other components, etc. Pedigree supports viewing this complex chain from the beginning, the end, or anywhere in the middle. It also provides a way to document variants where the exact relation may not be known.",
+          "properties": {
+            "ancestors": {
+              "type": "array",
+              "title": "Ancestors",
+              "description": "Describes zero or more components in which a component is derived from. This is commonly used to describe forks from existing projects where the forked version contains a ancestor node containing the original component it was forked from. For example, Component A is the original component. Component B is the component being used and documented in the BOM. However, Component B contains a pedigree node with a single ancestor documenting Component A - the original component from which Component B is derived from.",
+              "items": {"$ref": "#/definitions/component"}
+            },
+            "descendants": {
+              "type": "array",
+              "title": "Descendants",
+              "description": "Descendants are the exact opposite of ancestors. This provides a way to document all forks (and their forks) of an original or root component.",
+              "items": {"$ref": "#/definitions/component"}
+            },
+            "variants": {
+              "type": "array",
+              "title": "Variants",
+              "description": "Variants describe relations where the relationship between the components are not known. For example, if Component A contains nearly identical code to Component B. They are both related, but it is unclear if one is derived from the other, or if they share a common ancestor.",
+              "items": {"$ref": "#/definitions/component"}
+            },
+            "commits": {
+              "type": "array",
+              "title": "Commits",
+              "description": "A list of zero or more commits which provide a trail describing how the component deviates from an ancestor, descendant, or variant.",
+              "items": {"$ref": "#/definitions/commit"}
+            },
+            "patches": {
+              "type": "array",
+              "title": "Patches",
+              "description": ">A list of zero or more patches describing how the component deviates from an ancestor, descendant, or variant. Patches may be complimentary to commits or may be used in place of commits.",
+              "items": {"$ref": "#/definitions/patch"}
+            },
+            "notes": {
+              "type": "string",
+              "title": "Notes",
+              "description": "Notes, observations, and other non-structured commentary describing the components pedigree.",
+              "pattern": "^(.*)$"
+            }
+          }
+        },
+        "externalReferences": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/externalReference"},
+          "title": "External References"
+        },
+        "components": {
+          "$id": "#/properties/components",
+          "type": "array",
+          "items": {"$ref": "#/definitions/component"},
+          "uniqueItems": true,
+          "title": "Components"
+        }
+      }
+    },
+    "swid": {
+      "type": "object",
+      "title": "SWID Tag",
+      "description": "Specifies metadata and content for ISO-IEC 19770-2 Software Identification (SWID) Tags.",
+      "required": [
+        "tagId",
+        "name"
+      ],
+      "properties": {
+        "tagId": {
+          "type": "string",
+          "title": "Tag ID",
+          "description": "Maps to the tagId of a SoftwareIdentity."
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "Maps to the name of a SoftwareIdentity."
+        },
+        "version": {
+          "type": "string",
+          "title": "Version",
+          "default": "0.0",
+          "description": "Maps to the version of a SoftwareIdentity."
+        },
+        "tagVersion": {
+          "type": "integer",
+          "title": "Tag Version",
+          "default": 0,
+          "description": "Maps to the tagVersion of a SoftwareIdentity."
+        },
+        "patch": {
+          "type": "boolean",
+          "title": "Patch",
+          "default": false,
+          "description": "Maps to the patch of a SoftwareIdentity."
+        },
+        "text": {
+          "title": "Attachment text",
+          "description": "Specifies the metadata and content of the SWID tag.",
+          "$ref": "#/definitions/attachment"
+        },
+        "url": {
+          "type": "string",
+          "title": "URL",
+          "default": "The URL to the SWID file.",
+          "pattern": "^(.*)$"
+        }
+      }
+    },
+    "attachment": {
+      "type": "object",
+      "title": "Attachment",
+      "description": "Specifies the metadata and content for an attachment.",
+      "required": [
+        "content"
+      ],
+      "properties": {
+        "contentType": {
+          "type": "string",
+          "title": "Content-Type",
+          "description": "Specifies the content type of the text. Defaults to text/plain if not specified.",
+          "default": "text/plain"
+        },
+        "encoding": {
+          "type": "string",
+          "title": "Encoding",
+          "description": "Specifies the optional encoding the text is represented in.",
+          "enum": [
+            "base64"
+          ],
+          "default": "",
+          "pattern": "^(.*)$"
+        },
+        "content": {
+          "type": "string",
+          "title": "Attachment Text",
+          "description": "The attachment data"
+        }
+      }
+    },
+    "hash": {
+      "type": "object",
+      "title": "Hash Objects",
+      "required": [
+        "alg",
+        "content"
+      ],
+      "properties": {
+        "alg": {
+          "$ref": "#/definitions/hash-alg"
+        },
+        "content": {
+          "$ref": "#/definitions/hash-content"
+        }
+      }
+    },
+    "hash-alg": {
+      "type": "string",
+      "enum": [
+        "MD5",
+        "SHA-1",
+        "SHA-256",
+        "SHA-384",
+        "SHA-512",
+        "SHA3-256",
+        "SHA3-384",
+        "SHA3-512",
+        "BLAKE2b-256",
+        "BLAKE2b-384",
+        "BLAKE2b-512",
+        "BLAKE3"
+      ],
+      "title": "Hash Algorithm",
+      "default": "",
+      "pattern": "^(.*)$"
+    },
+    "hash-content": {
+      "type": "string",
+      "title": "Hash Content (value)",
+      "default": "",
+      "examples": ["3942447fac867ae5cdb3229b658f4d48"],
+      "pattern": "^([a-fA-F0-9]{32}|[a-fA-F0-9]{40}|[a-fA-F0-9]{64}|[a-fA-F0-9]{96}|[a-fA-F0-9]{128})$"
+    },
+    "license": {
+      "type": "object",
+      "title": "License Object",
+      "oneOf": [
+        {
+          "required": ["id"]
+        },
+        {
+          "required": ["name"]
+        }
+      ],
+      "properties": {
+        "id": {
+          "$ref": "lib/cyclonedx/schema/spdx.schema.json",
+          "title": "License ID (SPDX)",
+          "description": "A valid SPDX license ID",
+          "examples": ["Apache-2.0"]
+        },
+        "name": {
+          "type": "string",
+          "title": "License Name",
+          "description": "If SPDX does not define the license used, this field may be used to provide the license name",
+          "default": "",
+          "examples": ["Acme Software License"],
+          "pattern": "^(.*)$"
+        },
+        "text": {
+          "title": "License text",
+          "description": "An optional way to include the textual content of a license.",
+          "$ref": "#/definitions/attachment"
+        },
+        "url": {
+          "type": "string",
+          "title": "License URL",
+          "description": "The URL to the license file. If specified, a 'license' externalReference should also be specified for completeness",
+          "examples": ["https://www.apache.org/licenses/LICENSE-2.0.txt"],
+          "pattern": "^(.*)$"
+        }
+      }
+    },
+    "commit": {
+      "type": "object",
+      "title": "Commit",
+      "description": "Specifies an individual commit",
+      "properties": {
+        "uid": {
+          "type": "string",
+          "title": "UID",
+          "description": "A unique identifier of the commit. This may be version control specific. For example, Subversion uses revision numbers whereas git uses commit hashes.",
+          "pattern": "^(.*)$"
+        },
+        "url": {
+          "type": "string",
+          "title": "URL",
+          "description": "The URL to the commit. This URL will typically point to a commit in a version control system.",
+          "format": "iri-reference"
+        },
+        "author": {
+          "title": "Author",
+          "description": "The author who created the changes in the commit",
+          "$ref": "#/definitions/identifiableAction"
+        },
+        "committer": {
+          "title": "Committer",
+          "description": "The person who committed or pushed the commit",
+          "$ref": "#/definitions/identifiableAction"
+        },
+        "message": {
+          "type": "string",
+          "title": "Message",
+          "description": "The text description of the contents of the commit",
+          "pattern": "^(.*)$"
+        }
+      }
+    },
+    "patch": {
+      "type": "object",
+      "title": "Patch",
+      "description": "Specifies an individual patch",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "unofficial",
+            "monkey",
+            "backport",
+            "cherry-pick"
+          ],
+          "title": "Type",
+          "description": "Specifies the purpose for the patch including the resolution of defects, security issues, or new behavior or functionality"
+        },
+        "diff": {
+          "title": "Diff",
+          "description": "The patch file (or diff) that show changes. Refer to https://en.wikipedia.org/wiki/Diff",
+          "$ref": "#/definitions/diff"
+        },
+        "resolves": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/issue"},
+          "title": "Resolves",
+          "description": "A collection of issues the patch resolves"
+        }
+      }
+    },
+    "diff": {
+      "type": "object",
+      "title": "Diff",
+      "description": "The patch file (or diff) that show changes. Refer to https://en.wikipedia.org/wiki/Diff",
+      "properties": {
+        "text": {
+          "title": "Diff text",
+          "description": "Specifies the optional text of the diff",
+          "$ref": "#/definitions/attachment"
+        },
+        "url": {
+          "type": "string",
+          "title": "URL",
+          "description": "Specifies the URL to the diff",
+          "pattern": "^(.*)$"
+        }
+      }
+    },
+    "issue": {
+      "type": "object",
+      "title": "Diff",
+      "description": "The patch file (or diff) that show changes. Refer to https://en.wikipedia.org/wiki/Diff",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "defect",
+            "enhancement",
+            "security"
+          ],
+          "title": "Type",
+          "description": "Specifies the type of issue"
+        },
+        "id": {
+          "type": "string",
+          "title": "ID",
+          "description": "The identifier of the issue assigned by the source of the issue",
+          "pattern": "^(.*)$"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the issue",
+          "pattern": "^(.*)$"
+        },
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "A description of the issue",
+          "pattern": "^(.*)$"
+        },
+        "source": {
+          "type": "object",
+          "title": "Source",
+          "description": "The source of the issue where it is documented",
+          "properties": {
+            "name": {
+              "type": "string",
+              "title": "Name",
+              "description": "The name of the source. For example 'National Vulnerability Database', 'NVD', and 'Apache'",
+              "pattern": "^(.*)$"
+            },
+            "url": {
+              "type": "string",
+              "title": "URL",
+              "description": "The url of the issue documentation as provided by the source",
+              "pattern": "^(.*)$"
+            }
+          }
+        },
+        "references": {
+          "type": "array",
+          "title": "References",
+          "description": "A collection of URL's for reference. Multiple URLs are allowed.",
+          "default": "",
+          "examples": ["https://example.com"],
+          "pattern": "^(.*)$"
+        }
+      }
+    },
+    "identifiableAction": {
+      "type": "object",
+      "title": "Identifiable Action",
+      "description": "Specifies an individual commit",
+      "properties": {
+        "timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "title": "Timestamp",
+          "description": "The timestamp in which the action occurred"
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the individual who performed the action",
+          "pattern": "^(.*)$"
+        },
+        "email": {
+          "type": "string",
+          "format": "idn-email",
+          "title": "E-mail",
+          "description": "The email address of the individual who performed the action"
+        }
+      }
+    },
+    "externalReference": {
+      "type": "object",
+      "title": "External Reference",
+      "description": "Specifies an individual external reference",
+      "required": [
+        "url",
+        "type"
+      ],
+      "properties": {
+        "url": {
+          "type": "string",
+          "title": "URL",
+          "description": "The URL to the external reference",
+          "pattern": "^(.*)$"
+        },
+        "comment": {
+          "type": "string",
+          "title": "Comment",
+          "description": "An optional comment describing the external reference",
+          "pattern": "^(.*)$"
+        },
+        "type": {
+          "type": "string",
+          "title": "Type",
+          "description": "Specifies the type of external reference. There are built-in types to describe common references. If a type does not exist for the reference being referred to, use the \"other\" type.",
+          "enum": [
+            "vcs",
+            "issue-tracker",
+            "website",
+            "advisories",
+            "bom",
+            "mailing-list",
+            "social",
+            "chat",
+            "documentation",
+            "support",
+            "distribution",
+            "license",
+            "build-meta",
+            "build-system",
+            "other"
+          ]
+        }
+      }
+    },
+    "dependency": {
+      "type": "object",
+      "title": "Dependency",
+      "description": "Defines the direct dependencies of a component. Components that do not have their own dependencies MUST be declared as empty elements within the graph. Components that are not represented in the dependency graph MAY have unknown dependencies. It is RECOMMENDED that implementations assume this to be opaque and not an indicator of a component being dependency-free.",
+      "required": [
+        "ref"
+      ],
+      "properties": {
+        "ref": {
+          "type": "string",
+          "format": "string",
+          "title": "Reference",
+          "description": "References a component by the components bom-ref attribute"
+        },
+        "dependsOn": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          },
+          "title": "Depends On",
+          "description": "The bom-ref identifiers of the components that are dependencies of this dependency object."
+        }
+      }
+    },
+    "service": {
+      "type": "object",
+      "title": "Service Object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "bom-ref": {
+          "type": "string",
+          "title": "BOM Reference",
+          "description": "An optional identifier which can be used to reference the service elsewhere in the BOM. Every bom-ref should be unique.",
+          "default": "",
+          "pattern": "^(.*)$"
+        },
+        "provider": {
+          "title": "Provider",
+          "description": "The organization that provides the service.",
+          "$ref": "#/definitions/organizationalEntity"
+        },
+        "group": {
+          "type": "string",
+          "title": "Service Group",
+          "description": "The grouping name, namespace, or identifier. This will often be a shortened, single name of the company or project that produced the service or domain name. Whitespace and special characters should be avoided.",
+          "default": "",
+          "examples": ["com.acme"],
+          "pattern": "^(.*)$"
+        },
+        "name": {
+          "type": "string",
+          "title": "Service Name",
+          "description": "The name of the service. This will often be a shortened, single name of the service.",
+          "default": "",
+          "examples": ["ticker-service"],
+          "pattern": "^(.*)$"
+        },
+        "version": {
+          "type": "string",
+          "title": "Service Version",
+          "description": "The service version.",
+          "default": "",
+          "examples": ["1.0.0"],
+          "pattern": "^(.*)$"
+        },
+        "description": {
+          "type": "string",
+          "title": "Service Description",
+          "description": "Specifies a description for the service",
+          "default": "",
+          "pattern": "^(.*)$"
+        },
+        "endpoints": {
+          "type": "array",
+          "title": "Endpoints",
+          "description": "The endpoint URIs of the service. Multiple endpoints are allowed.",
+          "default": "",
+          "examples": ["https://example.com/api/v1/ticker"],
+          "pattern": "^(.*)$"
+        },
+        "authenticated": {
+          "type": "boolean",
+          "title": "Authentication Required",
+          "description": "A boolean value indicating if the service requires authentication. A value of true indicates the service requires authentication prior to use. A value of false indicates the service does not require authentication."
+        },
+        "x-trust-boundary": {
+          "type": "boolean",
+          "title": "Crosses Trust Boundary",
+          "description": "A boolean value indicating if use of the service crosses a trust zone or boundary. A value of true indicates that by using the service, a trust boundary is crossed. A value of false indicates that by using the service, a trust boundary is not crossed."
+        },
+        "data": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/dataClassification"},
+          "title": "Data Classification",
+          "description": "Specifies the data classification."
+        },
+        "licenses": {
+          "type": "array",
+          "title": "Component License(s)",
+          "items": {
+            "properties": {
+              "license": {
+                "$ref": "#/definitions/license"
+              },
+              "expression": {
+                "type": "string",
+                "title": "SPDX License Expression",
+                "examples": [
+                  "Apache-2.0 AND (MIT OR GPL-2.0-only)",
+                  "GPL-3.0-only WITH Classpath-exception-2.0"
+                ],
+                "pattern": "^(.*)$"
+              }
+            },
+            "oneOf":[
+              {
+                "required": ["license"]
+              },
+              {
+                "required": ["expression"]
+              }
+            ]
+          }
+        },
+        "externalReferences": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/externalReference"},
+          "title": "External References"
+        },
+        "services": {
+          "$id": "#/properties/services",
+          "type": "array",
+          "items": {"$ref": "#/definitions/service"},
+          "uniqueItems": true,
+          "title": "Services"
+        }
+      }
+    },
+    "dataClassification": {
+      "type": "object",
+      "title": "Hash Objects",
+      "required": [
+        "flow",
+        "classification"
+      ],
+      "properties": {
+        "flow": {
+          "$ref": "#/definitions/dataFlow"
+        },
+        "classification": {
+          "type": "string"
+        }
+      }
+    },
+    "dataFlow": {
+      "type": "string",
+      "enum": [
+        "inbound",
+        "outbound",
+        "bi-directional",
+        "unknown"
+      ],
+      "title": "Data flow direction",
+      "default": "",
+      "pattern": "^(.*)$"
+    }
+  }
+}

--- a/spec/fixtures/processor/remote_uri_headers_verbs/expected_report_no_cyclonedx_options.json
+++ b/spec/fixtures/processor/remote_uri_headers_verbs/expected_report_no_cyclonedx_options.json
@@ -1,0 +1,6 @@
+{
+  "autoCreate": true,
+  "projectName": "",
+  "projectVersion": "1",
+  "bom": {"bomFormat":"CycloneDX","specVersion":"1.3","serialNumber":"urn:uuid:b75641bb-b8e8-4c87-90b3-3b294d47a89b","version":1,"metadata":{},"components":[]}
+}

--- a/spec/fixtures/processor/remote_uri_headers_verbs/expected_report_no_project_name.json
+++ b/spec/fixtures/processor/remote_uri_headers_verbs/expected_report_no_project_name.json
@@ -2,5 +2,5 @@
   "autoCreate": true,
   "projectName": "",
   "projectVersion": "1",
-  "bom": {"bomFormat":"CycloneDX","specVersion":"1.3","serialNumber":"urn:uuid:b75641bb-b8e8-4c87-90b3-3b294d47a89b","version":1,"metadata":{},"components":[]}
+  "bom": {"bomFormat":"CycloneDX","specVersion":"1.2","serialNumber":"urn:uuid:b75641bb-b8e8-4c87-90b3-3b294d47a89b","version":1,"metadata":{},"components":[]}
 }

--- a/spec/fixtures/processor/remote_uri_headers_verbs/salus.yaml
+++ b/spec/fixtures/processor/remote_uri_headers_verbs/salus.yaml
@@ -15,6 +15,8 @@ reports:
     headers:
       repo: 'Random Repo'
       X-API-Key: '{{DUMMY_API_KEY}}'
+    cyclonedx_options:
+      spec_version: '1.2'
 builds:
   org: "random_org"
   project: "random_project"

--- a/spec/fixtures/processor/remote_uri_headers_verbs/salus.yaml
+++ b/spec/fixtures/processor/remote_uri_headers_verbs/salus.yaml
@@ -17,6 +17,13 @@ reports:
       X-API-Key: '{{DUMMY_API_KEY}}'
     cyclonedx_options:
       spec_version: '1.2'
+  - uri: https://nerv.tk5/salus-report
+    format: cyclonedx-json
+    put:
+    headers:
+      repo: 'Random Repo'
+      X-API-Key: '{{DUMMY_API_KEY}}'
+
 builds:
   org: "random_org"
   project: "random_project"

--- a/spec/lib/cyclonedx/cyclonedx_report_spec.rb
+++ b/spec/lib/cyclonedx/cyclonedx_report_spec.rb
@@ -72,6 +72,71 @@ describe Cyclonedx::ReportRubyGems do
       expect(ruby_cyclonedx.build_components_object).to include(*expected)
     end
 
+    it 'cylonedx spec version 1.3 does include properties field' do
+      repo = Salus::Repo.new('spec/fixtures/report_ruby_gems/lockfile')
+      scanner = Salus::Scanners::ReportRubyGems.new(repository: repo, config: {})
+      scanner.run
+
+      ruby_cyclonedx = Cyclonedx::ReportRubyGems.new(scanner.report, { "spec_version" => "1.3" })
+      expected = [
+        {
+          "bom-ref": "pkg:gem/actioncable@5.1.2",
+          "type": "library",
+          "group": "",
+          "name": "actioncable",
+          "version": "5.1.2",
+          "purl": "pkg:gem/actioncable@5.1.2",
+          "properties": [
+            {
+              "key": "source",
+              "value": "rubygems repository https://rubygems.org/ or installed locally"
+            },
+            {
+              "key": "dependency_file",
+              "value": "Gemfile.lock"
+            }
+          ]
+        },
+        {
+          "bom-ref": "pkg:gem/actionmailer@5.1.2",
+          "type": "library",
+          "group": "",
+          "name": "actionmailer",
+          "version": "5.1.2",
+          "purl": "pkg:gem/actionmailer@5.1.2",
+          "properties": [
+            {
+              "key": "source",
+              "value": "rubygems repository https://rubygems.org/ or installed locally"
+            },
+            {
+              "key": "dependency_file",
+              "value": "Gemfile.lock"
+            }
+          ]
+        },
+        {
+          "bom-ref": "pkg:gem/actionpack@5.1.2",
+          "type": "library",
+          "group": "",
+          "name": "actionpack",
+          "version": "5.1.2",
+          "purl": "pkg:gem/actionpack@5.1.2",
+          "properties": [
+            {
+              "key": "source",
+              "value": "rubygems repository https://rubygems.org/ or installed locally"
+            },
+            {
+              "key": "dependency_file",
+              "value": "Gemfile.lock"
+            }
+          ]
+        }
+      ]
+      expect(ruby_cyclonedx.build_components_object).to include(*expected)
+    end
+
     it 'fails if provided cylonedx spec version is unsupported' do
       scanner = Salus::Scanners::ReportRubyGems.new(repository: repo, config: {})
       scanner.run

--- a/spec/lib/cyclonedx/cyclonedx_report_spec.rb
+++ b/spec/lib/cyclonedx/cyclonedx_report_spec.rb
@@ -42,7 +42,7 @@ describe Cyclonedx::ReportRubyGems do
       scanner = Salus::Scanners::ReportRubyGems.new(repository: repo, config: {})
       scanner.run
 
-      ruby_cyclonedx = Cyclonedx::ReportRubyGems.new(scanner.report, {"spec_version" => "1.2"})
+      ruby_cyclonedx = Cyclonedx::ReportRubyGems.new(scanner.report, { "spec_version" => "1.2" })
       expected = [
         {
           "bom-ref": "pkg:gem/actioncable@5.1.2",
@@ -50,7 +50,7 @@ describe Cyclonedx::ReportRubyGems do
           "group": "",
           "name": "actioncable",
           "version": "5.1.2",
-          "purl": "pkg:gem/actioncable@5.1.2",
+          "purl": "pkg:gem/actioncable@5.1.2"
         },
         {
           "bom-ref": "pkg:gem/actionmailer@5.1.2",
@@ -58,7 +58,7 @@ describe Cyclonedx::ReportRubyGems do
           "group": "",
           "name": "actionmailer",
           "version": "5.1.2",
-          "purl": "pkg:gem/actionmailer@5.1.2",
+          "purl": "pkg:gem/actionmailer@5.1.2"
         },
         {
           "bom-ref": "pkg:gem/actionpack@5.1.2",
@@ -66,7 +66,7 @@ describe Cyclonedx::ReportRubyGems do
           "group": "",
           "name": "actionpack",
           "version": "5.1.2",
-          "purl": "pkg:gem/actionpack@5.1.2",
+          "purl": "pkg:gem/actionpack@5.1.2"
         }
       ]
       expect(ruby_cyclonedx.build_components_object).to include(*expected)
@@ -77,8 +77,9 @@ describe Cyclonedx::ReportRubyGems do
       scanner.run
 
       error = Cyclonedx::Base::CycloneDXInvalidVersionError
-      cyclonedx_reports = Cyclonedx::Report.new([[scanner.report, false]], {"spec_version" => "1.0"})
-      expect { cyclonedx_reports.to_cyclonedx}.to raise_error(error)
+      cyclonedx_reports = Cyclonedx::Report.new([[scanner.report, false]],
+                                                { "spec_version" => "1.0" })
+      expect { cyclonedx_reports.to_cyclonedx }.to raise_error(error)
     end
   end
 end


### PR DESCRIPTION
**What Changed?**
Added support for CycloneDX spec version option in the config file. Currently the only options are `1.2` and `1.3` and we default the spec version to the latest `1.3` if the parameter is not specified. The difference between the two is the properties field that's not present in version `1.2`. See the documentation for more details and an example. 

**How was it tested?**
Wrote specs to test changes in salus.yaml file and the cyclonedx output
