### PR TITLE
Replace toml with toml-rb

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,6 @@ gem 'parser', '~> 3.0.0'
 gem 'rgl', '~> 0.5.7'
 gem 'safe_yaml', '~> 1.0'
 gem 'thor', '~> 1.1.0'
-gem 'toml', '~> 0.2.0'
 
 group :scanners do
   gem 'brakeman', '4.10.0'
@@ -32,3 +31,5 @@ group :test do
 end
 
 gem "json-schema", "~> 2.8"
+
+gem "toml-rb", "~> 2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,6 +18,7 @@ GEM
       thor (~> 1.0)
     byebug (11.1.3)
     charlock_holmes (0.7.7)
+    citrus (3.0.2)
     coderay (1.1.2)
     concurrent-ruby (1.1.8)
     crack (0.4.5)
@@ -49,7 +50,6 @@ GEM
     parallel (1.19.2)
     parser (3.0.0.0)
       ast (~> 2.4.1)
-    parslet (1.8.2)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -102,8 +102,8 @@ GEM
     stream (0.5.3)
       generator
     thor (1.1.0)
-    toml (0.2.0)
-      parslet (~> 1.8.0)
+    toml-rb (2.0.1)
+      citrus (~> 3.0, > 3.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unicode-display_width (1.7.0)
@@ -135,7 +135,7 @@ DEPENDENCIES
   safe_yaml (~> 1.0)
   simplecov (~> 0.21.2)
   thor (~> 1.1.0)
-  toml (~> 0.2.0)
+  toml-rb (~> 2.0)
   webmock (~> 3.12)
 
 RUBY VERSION

--- a/lib/salus/scanners/report_go_dep.rb
+++ b/lib/salus/scanners/report_go_dep.rb
@@ -1,4 +1,4 @@
-require 'toml'
+require 'toml-rb'
 require 'salus/scanners/base'
 
 # Report the use of Go packages captured in a Gopkg.lock files.
@@ -13,7 +13,7 @@ module Salus::Scanners
           'Cannot report on Go dependencies without a Gopkg.lock file.'
         )
       end
-      dep_lock = TOML::Parser.new(@repository.dep_lock).parsed
+      dep_lock = TomlRB::Parser.new(@repository.dep_lock).hash
 
       # Report dependencies
       dep_lock['projects'].each do |dependency|

--- a/lib/salus/scanners/report_rust_crates.rb
+++ b/lib/salus/scanners/report_rust_crates.rb
@@ -1,4 +1,4 @@
-require 'toml'
+require 'toml-rb'
 require 'salus/scanners/base'
 
 # Report the use of any Rust Crates.  Reports the
@@ -62,7 +62,7 @@ module Salus::Scanners
           "Check write premissions and Cargo version is at least 1.44"
       end
 
-      deps = TOML::Parser.new(@repository.cargo_lock).parsed
+      deps = TomlRB::Parser.new(@repository.cargo_lock).hash
 
       # Sample Package
       # { "name"=>"autocfg",


### PR DESCRIPTION
What Changed?
Added toml-rb to replace the use of toml in go and rust dep report.

How was it tested?
Verified that no regressions were introduced by running unit and integration tests.

Notes:
toml-rb is pending security and legal review

will be leaving this pr in draft mode