### PR TITLE
Remove unique check property from SARIF Schema

### DIFF
--- a/lib/sarif/schema/sarif-schema.json
+++ b/lib/sarif/schema/sarif-schema.json
@@ -2172,7 +2172,6 @@
           "description": "The set of results contained in an SARIF log. The results array can be omitted when a run is solely exporting rules metadata. It must be present (but may be empty) if a log file represents an actual scan.",
           "type": "array",
           "minItems": 0,
-          "uniqueItems": false,
           "items": {
             "$ref": "#/definitions/result"
           }


### PR DESCRIPTION
Having the "uniqueItems" property inside of a schema definition whether true or false appears to trigger a uniqueness constraint during validation. 

In this pr the uniqueItems field was remove from #/run/results definition