### PR TITLE
Fix skips config name for Bandit

### DIFF
--- a/lib/salus/scanners/bandit.rb
+++ b/lib/salus/scanners/bandit.rb
@@ -83,7 +83,7 @@ module Salus::Scanners
                   configfile: { type: :file, keyword: 'c' },
                   profile: { type: :string, keyword: 'p' },
                   tests: { type: :list, keyword: 't', regex: /\AB\d{3}\z/i },
-                  skip: { type: :list, keyword: 's', regex: /\AB\d{3}\z/i },
+                  skips: { type: :list, keyword: 's', regex: /\AB\d{3}\z/i },
                   baseline: { type: :file, keyword: 'b' },
                   ini: { type: :file, prefix: '--' },
                   'ignore-nosec': { type: :flag, prefix: '--' },


### PR DESCRIPTION
The [Salus documentation](https://github.com/coinbase/salus/blob/master/docs/scanners/bandit.md) for the Bandit configuration specifies that rules to skip should be listed in YAML with `skips`,  which matches [Bandit's documentation](https://bandit.readthedocs.io/en/latest/config.html), but the code actually uses `skip`.  This commit fixes that.