### PR TITLE
Add more Python project detections

### DIFF
--- a/lib/salus/repo.rb
+++ b/lib/salus/repo.rb
@@ -24,6 +24,9 @@ module Salus
       # Python
       { handle: :requirements_txt, filename: 'requirements.txt' },
       { handle: :setup_cfg, filename: 'setup.cfg' },
+      { handle: :setup_py, filename: 'setup.py' },
+      { handle: :environment_yml, filename: 'environment.yml' },
+      { handle: :environment_yaml, filename: 'environment.yaml' },
       # Rust
       { handle: :cargo, filename: 'Cargo.toml' },
       { handle: :cargo_lock, filename: 'Cargo.lock' },

--- a/lib/salus/scanners/bandit.rb
+++ b/lib/salus/scanners/bandit.rb
@@ -59,7 +59,11 @@ module Salus::Scanners
     end
 
     def should_run?
-      @repository.requirements_txt_present? || @repository.setup_cfg_present?
+      @repository.requirements_txt_present? ||
+      @repository.setup_cfg_present? ||
+      @repository.setup_py_present? ||
+      @repository.environment_yml_present? ||
+      @repository.environment_yaml_present?
     end
 
     def version


### PR DESCRIPTION
This adds `setup.py` (for packages), `environment.yml` and `environment.yaml` (for Conda) as indicators that Bandit should run.