### PR TITLE
Sect 912 Normalize GoSec Exceptions

### DIFF
--- a/docs/scanners/gosec.md
+++ b/docs/scanners/gosec.md
@@ -13,7 +13,7 @@ The [Gosec Scanner](https://github.com/securego/gosec) is a static analysis tool
       include:                            # List of rules IDs to include
         - G104                            # Note only basic regex formatting is performed and does  
                                           # not check if this is a valid rule number
-      exclude:                            # List of rules IDs to exclude
+      exclude:                            # List of rules IDs to exclude, deprecated in favor of exceptions
         - G102
       sort: true                          # Sort issues by severity
       #tags:                              # Unsupported due to upstream bug. List of build tags
@@ -32,4 +32,12 @@ The [Gosec Scanner](https://github.com/securego/gosec) is a static analysis tool
       run_from_dirs:                     # run gosec from the specified subdirs only
         - subdir1                        # for now, any other gosec config will apply to all subdir runs
         - subdir2
+      exceptions:
+        - advisory_id: G101
+          changed_by: security-team
+          notes: Currently no patch exists and determined that this vulnerability is not exploitable.
+          expiration: "2021-04-27"
 ```
+## Exceptions
+
+The exclude configuration is supported for backwards compatibility and will be deprecated in the future.  Salus exceptions are being normalized to the new exceptions configuration

--- a/lib/salus/scanners/gosec.rb
+++ b/lib/salus/scanners/gosec.rb
@@ -190,8 +190,13 @@ module Salus::Scanners
           # exlude the folders from scan
           # can be files or directories
           'exclude-dir': :file
-        }
+        },
+        config_overrides: { 'exclude' => excluded_ids }
       )
+    end
+
+    def excluded_ids
+      (fetch_exception_ids + @config.fetch('exclude', [])).uniq
     end
 
     def should_run?

--- a/spec/lib/salus/scanners/gosec_spec.rb
+++ b/spec/lib/salus/scanners/gosec_spec.rb
@@ -255,6 +255,44 @@ describe Salus::Scanners::Gosec do
       end
     end
 
+    context 'active exceptions' do
+      let(:repo) { Salus::Repo.new('spec/fixtures/gosec/gosec_rules') }
+      let(:exceptions) do
+        [{'advisory_id' => "G101",
+          'expiration' => '2022-12-31',
+          'changed_by' => 'appsec' ,
+          'notes' => 'foo'}]
+      end
+      let(:config) { { "exceptions" => exceptions, "nosec" => "true" } }
+
+      before(:each) do
+        allow(Date).to receive(:today).and_return Date.new(2021,12,31)
+      end
+
+      it 'should honor active exceptions' do
+         expect(config_scanner.report.passed?).to eq(true)
+      end
+    end
+
+    context 'expired exceptions' do
+      let(:repo) { Salus::Repo.new('spec/fixtures/gosec/gosec_rules') }
+      let(:exceptions) do
+        [{'advisory_id' => "G101",
+          'expiration' => '2020-12-31',
+          'changed_by' => 'appsec' ,
+          'notes' => 'foo'}]
+      end
+      let(:config) { { "exceptions" => exceptions, "nosec" => "true" } }
+
+      before(:each) do
+        allow(Date).to receive(:today).and_return Date.new(2021,12,31)
+      end
+
+      it 'should ignore expired exceptions' do
+        expect(config_scanner.report.passed?).to eq(false)
+      end
+    end
+
     context 'when sorting by severity' do
       require 'json'
       let(:repo) { Salus::Repo.new('spec/fixtures/gosec/multiple_vulns') }

--- a/spec/lib/salus/scanners/gosec_spec.rb
+++ b/spec/lib/salus/scanners/gosec_spec.rb
@@ -258,34 +258,34 @@ describe Salus::Scanners::Gosec do
     context 'active exceptions' do
       let(:repo) { Salus::Repo.new('spec/fixtures/gosec/gosec_rules') }
       let(:exceptions) do
-        [{'advisory_id' => "G101",
+        [{ 'advisory_id' => "G101",
           'expiration' => '2022-12-31',
-          'changed_by' => 'appsec' ,
-          'notes' => 'foo'}]
+          'changed_by' => 'appsec',
+          'notes' => 'foo' }]
       end
       let(:config) { { "exceptions" => exceptions, "nosec" => "true" } }
 
       before(:each) do
-        allow(Date).to receive(:today).and_return Date.new(2021,12,31)
+        allow(Date).to receive(:today).and_return Date.new(2021, 12, 31)
       end
 
       it 'should honor active exceptions' do
-         expect(config_scanner.report.passed?).to eq(true)
+        expect(config_scanner.report.passed?).to eq(true)
       end
     end
 
     context 'expired exceptions' do
       let(:repo) { Salus::Repo.new('spec/fixtures/gosec/gosec_rules') }
       let(:exceptions) do
-        [{'advisory_id' => "G101",
+        [{ 'advisory_id' => "G101",
           'expiration' => '2020-12-31',
-          'changed_by' => 'appsec' ,
-          'notes' => 'foo'}]
+          'changed_by' => 'appsec',
+          'notes' => 'foo' }]
       end
       let(:config) { { "exceptions" => exceptions, "nosec" => "true" } }
 
       before(:each) do
-        allow(Date).to receive(:today).and_return Date.new(2021,12,31)
+        allow(Date).to receive(:today).and_return Date.new(2021, 12, 31)
       end
 
       it 'should ignore expired exceptions' do


### PR DESCRIPTION
Update gosec exception config to support the normalized exception format.  This will enable timeboxing as well.