### PR TITLE
Allow CVEs entered as ints to continue to function

### DIFF
--- a/lib/salus/scanners/base.rb
+++ b/lib/salus/scanners/base.rb
@@ -344,7 +344,7 @@ module Salus::Scanners
           )
           next
         end
-        ids << except.id if except.active?
+        ids << except.id.to_s if except.active?
       end
       ids
     end

--- a/spec/fixtures/npm_audit/success_with_exceptions/salus-integer-ids.yaml
+++ b/spec/fixtures/npm_audit/success_with_exceptions/salus-integer-ids.yaml
@@ -1,0 +1,13 @@
+scanner_configs:
+  NPMAudit:
+    exceptions:
+    - advisory_id: 39
+      changed_by: commerce-team
+      notes: Low Sev. Prototype Pollution from lodash <=4.17.18. Need to upgrade to bitcore-lib-cash@8.25.7, which is a breaking change. Requires extensive testing.
+    - advisory_id: 48
+      changed_by: commerce-team
+      notes: High Sev. Prototype Pollution from lodash <=4.17.18. Need to upgrade to bitcore-lib-cash@8.25.7, which is a breaking change. Requires extensive testing.
+    exclude_groups:
+    - devDependencies # dev only dependencies
+enforced_scanners:
+  - NPMAudit

--- a/spec/fixtures/yarn_audit/success_with_exceptions/salus-integer-ids.yaml
+++ b/spec/fixtures/yarn_audit/success_with_exceptions/salus-integer-ids.yaml
@@ -1,0 +1,13 @@
+scanner_configs:
+  YarnAudit:
+    exceptions:
+    - advisory_id: 39
+      changed_by: commerce-team
+      notes: Low Sev. Prototype Pollution from lodash <=4.17.18. Need to upgrade to bitcore-lib-cash@8.25.7, which is a breaking change. Requires extensive testing.
+    - advisory_id: 48
+      changed_by: commerce-team
+      notes: High Sev. Prototype Pollution from lodash <=4.17.18. Need to upgrade to bitcore-lib-cash@8.25.7, which is a breaking change. Requires extensive testing.
+    exclude_groups:
+    - devDependencies # dev only dependencies
+enforced_scanners:
+  - NPMAudit

--- a/spec/lib/salus/scanners/node_audit_spec.rb
+++ b/spec/lib/salus/scanners/node_audit_spec.rb
@@ -159,6 +159,18 @@ describe Salus::Scanners::NodeAudit do
 
           expect(scanner.report.passed?).to eq(false)
         end
+
+        it 'should support integer ids' do
+          repo = Salus::Repo.new("spec/fixtures/#{klass_snake_str}/success_with_exceptions")
+          config_file = YAML.load_file(
+            "spec/fixtures/#{klass_snake_str}/success_with_exceptions/salus-integer-ids.yaml"
+          )
+          scanner = klass_obj.new(
+            repository: repo, config: config_file['scanner_configs'][klass_str]
+          )
+          scanner.run
+          expect(scanner.report.passed?).to eq(true)
+        end
       end
     end
   end


### PR DESCRIPTION
Bug fix.  Some advisory ids are entered as integers.  These were not being honored, causing some exceptions to be ignored.