### PR TITLE
[Sect-933] Raw severity in Sarif

### DIFF
--- a/lib/salus/report.rb
+++ b/lib/salus/report.rb
@@ -141,7 +141,7 @@ module Salus
     end
 
     def to_sarif(config = {})
-      sarif_json = Sarif::SarifReport.new(@scan_reports, @repo_path, config).to_sarif
+      sarif_json = Sarif::SarifReport.new(@scan_reports, config, @repo_path).to_sarif
       # We will validate to ensure the applied filter
       # doesn't produce any invalid SARIF
       Sarif::SarifReport.validate_sarif(apply_report_sarif_filters(sarif_json))

--- a/lib/salus/report.rb
+++ b/lib/salus/report.rb
@@ -141,7 +141,7 @@ module Salus
     end
 
     def to_sarif(config = {})
-      sarif_json = Sarif::SarifReport.new(@scan_reports, config).to_sarif
+      sarif_json = Sarif::SarifReport.new(@scan_reports, @repo_path, config).to_sarif
       # We will validate to ensure the applied filter
       # doesn't produce any invalid SARIF
       Sarif::SarifReport.validate_sarif(apply_report_sarif_filters(sarif_json))

--- a/lib/salus/scanners/base.rb
+++ b/lib/salus/scanners/base.rb
@@ -50,7 +50,6 @@ module Salus::Scanners
 
     def version_valid?(version)
       return false if !version.is_a?(String)
-
       !/^\d+\.\d+(.\d+)*$/.match(version).nil?
     end
 

--- a/lib/salus/scanners/base.rb
+++ b/lib/salus/scanners/base.rb
@@ -50,6 +50,7 @@ module Salus::Scanners
 
     def version_valid?(version)
       return false if !version.is_a?(String)
+
       !/^\d+\.\d+(.\d+)*$/.match(version).nil?
     end
 

--- a/lib/sarif/bandit_sarif.rb
+++ b/lib/sarif/bandit_sarif.rb
@@ -51,7 +51,7 @@ module Sarif
         details: (issue['issue_text']).to_s,
         messageStrings: { "confidence": { "text": (issue['issue_severity']).to_s },
                          "severity": { "text": (issue['issue_severity']).to_s } },
-        properties: { 'severity': issue['confidence'].to_s },
+        properties: { 'severity': issue['issue_severity'].to_s },
         start_line: issue["line_number"].to_i,
         end_line: endline,
         start_column: 1,

--- a/lib/sarif/bandit_sarif.rb
+++ b/lib/sarif/bandit_sarif.rb
@@ -51,6 +51,7 @@ module Sarif
         details: (issue['issue_text']).to_s,
         messageStrings: { "confidence": { "text": (issue['issue_severity']).to_s },
                          "severity": { "text": (issue['issue_severity']).to_s } },
+        properties: { 'severity': issue['confidence'].to_s },
         start_line: issue["line_number"].to_i,
         end_line: endline,
         start_column: 1,

--- a/lib/sarif/bandit_sarif.rb
+++ b/lib/sarif/bandit_sarif.rb
@@ -5,7 +5,7 @@ module Sarif
     BANDIT_URI = 'https://github.com/PyCQA/bandit'.freeze
 
     def initialize(scan_report, repo_path = nil)
-      super(scan_report, repo_path)
+      super(scan_report, {}, repo_path)
       @uri = BANDIT_URI
       @logs = parse_scan_report!
     end

--- a/lib/sarif/bandit_sarif.rb
+++ b/lib/sarif/bandit_sarif.rb
@@ -4,8 +4,8 @@ module Sarif
 
     BANDIT_URI = 'https://github.com/PyCQA/bandit'.freeze
 
-    def initialize(scan_report)
-      super(scan_report)
+    def initialize(scan_report, repo_path)
+      super(scan_report, repo_path)
       @uri = BANDIT_URI
       @logs = parse_scan_report!
     end

--- a/lib/sarif/bandit_sarif.rb
+++ b/lib/sarif/bandit_sarif.rb
@@ -4,7 +4,7 @@ module Sarif
 
     BANDIT_URI = 'https://github.com/PyCQA/bandit'.freeze
 
-    def initialize(scan_report, repo_path)
+    def initialize(scan_report, repo_path = nil)
       super(scan_report, repo_path)
       @uri = BANDIT_URI
       @logs = parse_scan_report!

--- a/lib/sarif/base_sarif.rb
+++ b/lib/sarif/base_sarif.rb
@@ -102,8 +102,11 @@ module Sarif
         parsed_issue = parse_issue(issue)
 
         next if !parsed_issue
+
         next if parsed_issue[:suppressed] && @config['include_suppressed'] == false
+
         next if @required == false && @config['include_suppressed'] == false
+
         rule = build_rule(parsed_issue)
         rules << rule if rule
         result = build_result(parsed_issue)

--- a/lib/sarif/base_sarif.rb
+++ b/lib/sarif/base_sarif.rb
@@ -14,7 +14,7 @@ module Sarif
 
     attr_accessor :config, :required # sarif_options
 
-    def initialize(scan_report, repo_path, config = {})
+    def initialize(scan_report, config = {}, repo_path = nil)
       @scan_report = scan_report
       @mapped_rules = {} # map each rule to an index
       @rule_index = 0

--- a/lib/sarif/base_sarif.rb
+++ b/lib/sarif/base_sarif.rb
@@ -127,7 +127,7 @@ module Sarif
       end
 
       # unique-ify the results
-      results = results.inject([]) { |result,h| result << h unless result.include?(h); result }
+      results = results.each_with_object([]) { |h, result| result << h unless result.include?(h); }
 
       invocation = build_invocations(@scan_report, supported)
       {

--- a/lib/sarif/base_sarif.rb
+++ b/lib/sarif/base_sarif.rb
@@ -67,7 +67,7 @@ module Sarif
       end
 
       location[:region][:snippet] = { "text": parsed_issue[:code] } if !parsed_issue[:code].nil?
-      result["properties"] = parsed_issue[:properties] if parsed_issue[:properties]
+      result[:properties] = parsed_issue[:properties] if parsed_issue[:properties]
       result
     end
 
@@ -98,11 +98,12 @@ module Sarif
       results = []
       rules = []
       @logs.each do |issue|
+        # {:type=>"Syntax error", :message=>"", :level=>"warn", :spans=>[]}
         parsed_issue = parse_issue(issue)
+
         next if !parsed_issue
         next if parsed_issue[:suppressed] && @config['include_suppressed'] == false
         next if @required == false && @config['include_suppressed'] == false
-
         rule = build_rule(parsed_issue)
         rules << rule if rule
         result = build_result(parsed_issue)
@@ -115,7 +116,6 @@ module Sarif
         end
         results << result
       end
-
       invocation = build_invocations(@scan_report, supported)
       {
         "tool" => build_tool(rules: rules),

--- a/lib/sarif/base_sarif.rb
+++ b/lib/sarif/base_sarif.rb
@@ -1,4 +1,5 @@
 require 'sarif/shared_objects'
+
 module Sarif
   class BaseSarif
     include Sarif::SharedObjects
@@ -13,7 +14,7 @@ module Sarif
 
     attr_accessor :config, :required # sarif_options
 
-    def initialize(scan_report, config = {})
+    def initialize(scan_report, repo_path, config = {})
       @scan_report = scan_report
       @mapped_rules = {} # map each rule to an index
       @rule_index = 0
@@ -21,6 +22,11 @@ module Sarif
       @uri = DEFAULT_URI
       @issues = Set.new
       @config = config
+      @repo_path = repo_path
+    end
+
+    def base_path
+      @base_path ||= File.expand_path(@repo_path)
     end
 
     # Retrieve tool section for sarif report

--- a/lib/sarif/brakeman_sarif.rb
+++ b/lib/sarif/brakeman_sarif.rb
@@ -49,6 +49,7 @@ module Sarif
                           "warning_code": { "text": (issue['warning_code']).to_s } },
         properties: { 'fingerprint': issue['fingerprint'].to_s,
                       'confidence': issue['confidence'].to_s,
+                      'severity': issue['confidence'].to_s,
                       'render_path': issue['render_path'].to_s,
                       'user_input': issue['user_input'].to_s,
                       'location_type': issue.dig('location', 'type').to_s,

--- a/lib/sarif/brakeman_sarif.rb
+++ b/lib/sarif/brakeman_sarif.rb
@@ -4,8 +4,8 @@ module Sarif
 
     BRAKEMAN_URI = 'https://github.com/presidentbeef/brakeman'.freeze
 
-    def initialize(scan_report, repo_path)
-      super(scan_report, repo_path)
+    def initialize(scan_report, repo_path = nil)
+      super(scan_report, {}, repo_path)
       @uri = BRAKEMAN_URI
       @logs = parse_scan_report!
     end

--- a/lib/sarif/brakeman_sarif.rb
+++ b/lib/sarif/brakeman_sarif.rb
@@ -4,8 +4,8 @@ module Sarif
 
     BRAKEMAN_URI = 'https://github.com/presidentbeef/brakeman'.freeze
 
-    def initialize(scan_report)
-      super(scan_report)
+    def initialize(scan_report, repo_path)
+      super(scan_report, repo_path)
       @uri = BRAKEMAN_URI
       @logs = parse_scan_report!
     end

--- a/lib/sarif/bundle_audit_sarif.rb
+++ b/lib/sarif/bundle_audit_sarif.rb
@@ -22,6 +22,7 @@ module Sarif
                          "osvdb": { "text": (issue[:osdvb]).to_s },
                          "type": { "text": (issue[:type]).to_s },
                          "version": { "text": (issue[:version]).to_s } },
+        properties: { 'severity': (issue[:cvss]).to_s },
         uri: 'Gemfile.lock',
         help_url: issue[:url]
       }

--- a/lib/sarif/bundle_audit_sarif.rb
+++ b/lib/sarif/bundle_audit_sarif.rb
@@ -2,8 +2,8 @@ module Sarif
   class BundleAuditSarif < BaseSarif
     BUNDLEAUDIT_URI = 'https://github.com/rubysec/bundler-audit/'.freeze
 
-    def initialize(scan_report, repo_path)
-      super(scan_report, repo_path)
+    def initialize(scan_report, repo_path = nil)
+      super(scan_report, {}, repo_path)
       @logs = @scan_report.to_h.dig(:info, :vulnerabilities) || []
       @uri = BUNDLEAUDIT_URI
     end

--- a/lib/sarif/bundle_audit_sarif.rb
+++ b/lib/sarif/bundle_audit_sarif.rb
@@ -2,8 +2,8 @@ module Sarif
   class BundleAuditSarif < BaseSarif
     BUNDLEAUDIT_URI = 'https://github.com/rubysec/bundler-audit/'.freeze
 
-    def initialize(scan_report)
-      super(scan_report)
+    def initialize(scan_report, repo_path)
+      super(scan_report, repo_path)
       @logs = @scan_report.to_h.dig(:info, :vulnerabilities) || []
       @uri = BUNDLEAUDIT_URI
     end

--- a/lib/sarif/cargo_audit_sarif.rb
+++ b/lib/sarif/cargo_audit_sarif.rb
@@ -4,8 +4,8 @@ module Sarif
 
     CARGO_AUDIT_URI = 'https://github.com/RustSec/cargo-audit/'.freeze
 
-    def initialize(scan_report, repo_path)
-      super(scan_report, repo_path)
+    def initialize(scan_report, repo_path = nil)
+      super(scan_report, {}, repo_path)
       @uri = CARGO_AUDIT_URI
       @logs = parse_scan_report!
     end

--- a/lib/sarif/cargo_audit_sarif.rb
+++ b/lib/sarif/cargo_audit_sarif.rb
@@ -4,8 +4,8 @@ module Sarif
 
     CARGO_AUDIT_URI = 'https://github.com/RustSec/cargo-audit/'.freeze
 
-    def initialize(scan_report)
-      super(scan_report)
+    def initialize(scan_report, repo_path)
+      super(scan_report, repo_path)
       @uri = CARGO_AUDIT_URI
       @logs = parse_scan_report!
     end

--- a/lib/sarif/cargo_audit_sarif.rb
+++ b/lib/sarif/cargo_audit_sarif.rb
@@ -57,6 +57,7 @@ module Sarif
                          "patched_versions": { "text": issue.dig('versions', 'patched').to_s },
                          "unaffected_versions": { "text": issue.dig('versions',
                                                                     'unaffected').to_s } },
+        properties: { 'severity': (advisory['cvss']).to_s },
         uri: 'Cargo.lock',
         help_url: issue['advisory']['url']
       }

--- a/lib/sarif/gosec_sarif.rb
+++ b/lib/sarif/gosec_sarif.rb
@@ -67,6 +67,13 @@ module Sarif
         url = issue['cwe']['URL'] || issue['cwe']['url']
         id = issue['cwe']['ID'] || issue['cwe']['id']
         filepath = Pathname.new(issue['file'])
+
+        uri = if filepath.relative? || base_path.nil?
+                filepath.to_s
+              else
+                filepath.relative_path_from(base_path).to_s
+              end
+
         @issues.add(id)
         {
           id: issue['rule_id'],
@@ -80,7 +87,7 @@ module Sarif
           properties: { 'severity': (issue['severity']).to_s },
           start_line: issue['line'].to_i,
           start_column: issue['column'].to_i,
-          uri: filepath.relative? || base_path.nil? ? filepath.to_s : filepath.relative_path_from(base_path).to_s,
+          uri: uri,
           help_url: url,
           code: issue['code']
         }

--- a/lib/sarif/gosec_sarif.rb
+++ b/lib/sarif/gosec_sarif.rb
@@ -79,7 +79,7 @@ module Sarif
           properties: { 'severity': (issue['severity']).to_s },
           start_line: issue['line'].to_i,
           start_column: issue['column'].to_i,
-          uri: filepath.relative? ? filepath.to_s : filepath.relative_path_from(base_path).to_s,
+          uri: filepath.relative? || base_path.nil? ? filepath.to_s : filepath.relative_path_from(base_path).to_s,
           help_url: url,
           code: issue['code']
         }

--- a/lib/sarif/gosec_sarif.rb
+++ b/lib/sarif/gosec_sarif.rb
@@ -1,4 +1,5 @@
 require 'salus/bugsnag'
+require 'pathname'
 
 module Sarif
   class GosecSarif < BaseSarif
@@ -6,8 +7,8 @@ module Sarif
 
     GOSEC_URI = 'https://github.com/securego/gosec'.freeze
 
-    def initialize(scan_report)
-      super(scan_report)
+    def initialize(scan_report, repo_path)
+      super(scan_report, repo_path)
       @uri = GOSEC_URI
       @logs = parse_scan_report!(scan_report)
     end
@@ -62,22 +63,24 @@ module Sarif
       else
         id = issue['details'] + ' ' + issue['file'] + ' ' + issue['line']
         return nil if @issues.include?(id)
-
+        url = issue['cwe']['URL'] || issue['cwe']['url']
+        id = issue['cwe']['ID'] || issue['cwe']['id']
+        filepath = Pathname.new(issue['file'])
         @issues.add(id)
         {
           id: issue['rule_id'],
-          name: "CWE-#{issue['cwe']['ID']}",
+          name: "CWE-#{id}",
           level: issue['severity'],
           details: "#{issue['details']} \nSeverity: #{issue['severity']}\nConfidence:"\
-          " #{issue['confidence']}\nCWE: #{issue['cwe']['URL']}",
+          " #{issue['confidence']}\nCWE: #{url}",
           messageStrings: { "severity": { "text": (issue['severity']).to_s },
                            "confidence": { "text": (issue['confidence']).to_s },
-                           "cwe": { "text": (issue['cwe']['URL']).to_s } },
+                           "cwe": { "text": url.to_s } },
           properties: { 'severity': (issue['severity']).to_s },
           start_line: issue['line'].to_i,
           start_column: issue['column'].to_i,
-          uri: issue['file'],
-          help_url: issue['cwe']['URL'],
+          uri: filepath.relative? ? filepath.to_s : filepath.relative_path_from(base_path).to_s,
+          help_url: url,
           code: issue['code']
         }
       end

--- a/lib/sarif/gosec_sarif.rb
+++ b/lib/sarif/gosec_sarif.rb
@@ -63,6 +63,7 @@ module Sarif
       else
         id = issue['details'] + ' ' + issue['file'] + ' ' + issue['line']
         return nil if @issues.include?(id)
+
         url = issue['cwe']['URL'] || issue['cwe']['url']
         id = issue['cwe']['ID'] || issue['cwe']['id']
         filepath = Pathname.new(issue['file'])

--- a/lib/sarif/gosec_sarif.rb
+++ b/lib/sarif/gosec_sarif.rb
@@ -7,8 +7,8 @@ module Sarif
 
     GOSEC_URI = 'https://github.com/securego/gosec'.freeze
 
-    def initialize(scan_report, repo_path)
-      super(scan_report, repo_path)
+    def initialize(scan_report, repo_path = nil)
+      super(scan_report, {}, repo_path)
       @uri = GOSEC_URI
       @logs = parse_scan_report!(scan_report)
     end

--- a/lib/sarif/gosec_sarif.rb
+++ b/lib/sarif/gosec_sarif.rb
@@ -64,6 +64,8 @@ module Sarif
         id = issue['details'] + ' ' + issue['file'] + ' ' + issue['line']
         return nil if @issues.include?(id)
 
+        # Newer gosecs have changed case to lower. Preparing to upgrade,
+        # we'll support both
         url = issue['cwe']['URL'] || issue['cwe']['url']
         id = issue['cwe']['ID'] || issue['cwe']['id']
         filepath = Pathname.new(issue['file'])

--- a/lib/sarif/gosec_sarif.rb
+++ b/lib/sarif/gosec_sarif.rb
@@ -73,6 +73,7 @@ module Sarif
           messageStrings: { "severity": { "text": (issue['severity']).to_s },
                            "confidence": { "text": (issue['confidence']).to_s },
                            "cwe": { "text": (issue['cwe']['URL']).to_s } },
+          properties: { 'severity': (issue['severity']).to_s },
           start_line: issue['line'].to_i,
           start_column: issue['column'].to_i,
           uri: issue['file'],

--- a/lib/sarif/npm_audit_sarif.rb
+++ b/lib/sarif/npm_audit_sarif.rb
@@ -2,8 +2,8 @@ module Sarif
   class NPMAuditSarif < BaseSarif
     NPM_URI = 'https://docs.npmjs.com/cli/v7/commands/npm-audit'.freeze
 
-    def initialize(scan_report, repo_path)
-      super(scan_report, repo_path)
+    def initialize(scan_report, repo_path = nil)
+      super(scan_report, {}, repo_path)
       @uri = NPM_URI
       @logs = parse_scan_report!
       @exceptions = Set.new(@scan_report.to_h.dig(:info, :exceptions))

--- a/lib/sarif/npm_audit_sarif.rb
+++ b/lib/sarif/npm_audit_sarif.rb
@@ -2,8 +2,8 @@ module Sarif
   class NPMAuditSarif < BaseSarif
     NPM_URI = 'https://docs.npmjs.com/cli/v7/commands/npm-audit'.freeze
 
-    def initialize(scan_report)
-      super(scan_report)
+    def initialize(scan_report, repo_path)
+      super(scan_report, repo_path)
       @uri = NPM_URI
       @logs = parse_scan_report!
       @exceptions = Set.new(@scan_report.to_h.dig(:info, :exceptions))

--- a/lib/sarif/npm_audit_sarif.rb
+++ b/lib/sarif/npm_audit_sarif.rb
@@ -34,6 +34,7 @@ module Sarif
                          "cwe": { "text": (issue[:cwe]).to_s },
                          "recommendation": { "text": (issue[:recommendation]).to_s },
                          "vulnerable_versions": { "text": (issue[:vulnerable_versions]).to_s } },
+        properties: { 'severity': (issue[:severity]).to_s },
         uri: "package-lock.json",
         help_url: issue[:url],
         suppressed: @exceptions.include?(id)

--- a/lib/sarif/pattern_search_sarif.rb
+++ b/lib/sarif/pattern_search_sarif.rb
@@ -8,8 +8,8 @@ module Sarif
     PATTERN_SEARCH_URI = "https://github.com/coinbase/salus/blob/master/docs/scanners/"\
     "pattern_search.md".freeze
 
-    def initialize(scan_report, repo_path)
-      super(scan_report, repo_path)
+    def initialize(scan_report, repo_path = nil)
+      super(scan_report, {}, repo_path)
       @uri = PATTERN_SEARCH_URI
       @logs = parse_scan_report!
     end

--- a/lib/sarif/pattern_search_sarif.rb
+++ b/lib/sarif/pattern_search_sarif.rb
@@ -83,7 +83,7 @@ module Sarif
         uri: url_info[0],
         help_url: PATTERN_SEARCH_URI,
         code: issue[:hit],
-        properties: { 'severity': "HIGH" }
+        properties: { severity: "HIGH" }
       }
     end
   end

--- a/lib/sarif/pattern_search_sarif.rb
+++ b/lib/sarif/pattern_search_sarif.rb
@@ -8,8 +8,8 @@ module Sarif
     PATTERN_SEARCH_URI = "https://github.com/coinbase/salus/blob/master/docs/scanners/"\
     "pattern_search.md".freeze
 
-    def initialize(scan_report)
-      super(scan_report)
+    def initialize(scan_report, repo_path)
+      super(scan_report, repo_path)
       @uri = PATTERN_SEARCH_URI
       @logs = parse_scan_report!
     end

--- a/lib/sarif/pattern_search_sarif.rb
+++ b/lib/sarif/pattern_search_sarif.rb
@@ -82,7 +82,8 @@ module Sarif
         start_column: 1,
         uri: url_info[0],
         help_url: PATTERN_SEARCH_URI,
-        code: issue[:hit]
+        code: issue[:hit],
+        properties: { 'severity': "HIGH" }
       }
     end
   end

--- a/lib/sarif/repo_not_empty_sarif.rb
+++ b/lib/sarif/repo_not_empty_sarif.rb
@@ -24,7 +24,8 @@ module Sarif
         details: issue[:message],
         level: "VERY LOW",
         uri: "",
-        help_url: REPO_NOT_EMPTY_URI
+        help_url: REPO_NOT_EMPTY_URI,
+        properties: { 'severity': "VERY LOW" }
       }
     end
   end

--- a/lib/sarif/repo_not_empty_sarif.rb
+++ b/lib/sarif/repo_not_empty_sarif.rb
@@ -25,7 +25,7 @@ module Sarif
         level: "VERY LOW",
         uri: "",
         help_url: REPO_NOT_EMPTY_URI,
-        properties: { 'severity': "VERY LOW" }
+        properties: { severity: "VERY LOW" }
       }
     end
   end

--- a/lib/sarif/repo_not_empty_sarif.rb
+++ b/lib/sarif/repo_not_empty_sarif.rb
@@ -7,8 +7,8 @@ module Sarif
     REPO_NOT_EMPTY_URI = "https://github.com/coinbase/salus/blob/master/docs/scanners/"\
     "repository_not_blank.md".freeze
 
-    def initialize(scan_report)
-      super(scan_report)
+    def initialize(scan_report, repo_path)
+      super(scan_report, repo_path)
       @uri = REPO_NOT_EMPTY_URI
       @logs = parse_scan_report!
     end

--- a/lib/sarif/repo_not_empty_sarif.rb
+++ b/lib/sarif/repo_not_empty_sarif.rb
@@ -7,8 +7,8 @@ module Sarif
     REPO_NOT_EMPTY_URI = "https://github.com/coinbase/salus/blob/master/docs/scanners/"\
     "repository_not_blank.md".freeze
 
-    def initialize(scan_report, repo_path)
-      super(scan_report, repo_path)
+    def initialize(scan_report, repo_path = nil)
+      super(scan_report, {}, repo_path)
       @uri = REPO_NOT_EMPTY_URI
       @logs = parse_scan_report!
     end

--- a/lib/sarif/sarif_report.rb
+++ b/lib/sarif/sarif_report.rb
@@ -18,9 +18,10 @@ module Sarif
     SARIF_SCHEMA = "https://docs.oasis-open.org/sarif/sarif/v#{SARIF_VERSION}/csprd01/schemas/"\
     "sarif-schema-#{SARIF_VERSION}".freeze
 
-    def initialize(scan_reports, config = {})
+    def initialize(scan_reports, repo_path, config = {})
       @scan_reports = scan_reports
       @config = config
+      @repo_path = repo_path
     end
 
     # Builds Sarif Report. Raises an SarifInvalidFormatError if generated SARIF report is invalid
@@ -32,6 +33,7 @@ module Sarif
         "$schema" => SARIF_SCHEMA,
         "runs" => []
       }
+
       # for each scanner report, run the appropriate converter
       @scan_reports.each do |scan_report|
         sarif_report["runs"] << converter(scan_report[0], scan_report[1])
@@ -57,12 +59,12 @@ module Sarif
     def converter(scan_report, required)
       adapter = "Sarif::#{scan_report.scanner_name}Sarif"
       begin
-        converter = Object.const_get(adapter).new(scan_report)
+        converter = Object.const_get(adapter).new(scan_report, @repo_path)
         converter.config = @config
         converter.required = required
         converter.build_runs_object(true)
       rescue NameError
-        converter = BaseSarif.new(scan_report, @config)
+        converter = BaseSarif.new(scan_report, @repo_path, @config)
         converter.required = required
         converter.build_runs_object(false)
       end

--- a/lib/sarif/sarif_report.rb
+++ b/lib/sarif/sarif_report.rb
@@ -33,7 +33,6 @@ module Sarif
         "$schema" => SARIF_SCHEMA,
         "runs" => []
       }
-
       # for each scanner report, run the appropriate converter
       @scan_reports.each do |scan_report|
         sarif_report["runs"] << converter(scan_report[0], scan_report[1])
@@ -63,7 +62,7 @@ module Sarif
         converter.config = @config
         converter.required = required
         converter.build_runs_object(true)
-      rescue NameError
+      rescue NameError # this is greedy and will catch NoMethodError's too
         converter = BaseSarif.new(scan_report, @repo_path, @config)
         converter.required = required
         converter.build_runs_object(false)

--- a/lib/sarif/sarif_report.rb
+++ b/lib/sarif/sarif_report.rb
@@ -18,7 +18,7 @@ module Sarif
     SARIF_SCHEMA = "https://docs.oasis-open.org/sarif/sarif/v#{SARIF_VERSION}/csprd01/schemas/"\
     "sarif-schema-#{SARIF_VERSION}".freeze
 
-    def initialize(scan_reports, repo_path, config = {})
+    def initialize(scan_reports, config = {}, repo_path = nil)
       @scan_reports = scan_reports
       @config = config
       @repo_path = repo_path
@@ -63,7 +63,7 @@ module Sarif
         converter.required = required
         converter.build_runs_object(true)
       rescue NameError # this is greedy and will catch NoMethodError's too
-        converter = BaseSarif.new(scan_report, @repo_path, @config)
+        converter = BaseSarif.new(scan_report, @config, @repo_path)
         converter.required = required
         converter.build_runs_object(false)
       end

--- a/lib/sarif/semgrep_sarif.rb
+++ b/lib/sarif/semgrep_sarif.rb
@@ -8,8 +8,8 @@ module Sarif
     SEMGREP_URI = "https://github.com/coinbase/salus/blob/master/docs/scanners/"\
                      "semgrep.md".freeze
 
-    def initialize(scan_report, repo_path)
-      super(scan_report, repo_path)
+    def initialize(scan_report, repo_path = nil)
+      super(scan_report, {}, repo_path)
       @uri = SEMGREP_URI
       @logs = parse_scan_report!
       @issues = Set.new

--- a/lib/sarif/semgrep_sarif.rb
+++ b/lib/sarif/semgrep_sarif.rb
@@ -101,6 +101,8 @@ module Sarif
         name: warning[:type],
         level: "HIGH",
         details: warning[:message],
+        # Default to line one if not provided as SARIF spec requires this value
+        # to be > 0
         start_line: warning[:spans].empty? ? 1 : warning[:spans][0][:start]["line"],
         start_column: warning[:spans].empty? ? 1 : warning[:spans][0][:start]["col"],
         uri: warning[:spans].empty? ? "" : warning[:spans][0][:file],

--- a/lib/sarif/semgrep_sarif.rb
+++ b/lib/sarif/semgrep_sarif.rb
@@ -8,8 +8,8 @@ module Sarif
     SEMGREP_URI = "https://github.com/coinbase/salus/blob/master/docs/scanners/"\
                      "semgrep.md".freeze
 
-    def initialize(scan_report)
-      super(scan_report)
+    def initialize(scan_report, repo_path)
+      super(scan_report, repo_path)
       @uri = SEMGREP_URI
       @logs = parse_scan_report!
       @issues = Set.new

--- a/lib/sarif/semgrep_sarif.rb
+++ b/lib/sarif/semgrep_sarif.rb
@@ -101,9 +101,9 @@ module Sarif
         name: warning[:type],
         level: "HIGH",
         details: warning[:message],
-        start_line: warning[:spans][0][:start]["line"],
-        start_column: warning[:spans][0][:start]["col"],
-        uri: warning[:spans][0][:file],
+        start_line: warning[:spans].empty? ? 1 : warning[:spans][0][:start]["line"],
+        start_column: warning[:spans].empty? ? 1 : warning[:spans][0][:start]["col"],
+        uri: warning[:spans].empty? ? "" : warning[:spans][0][:file],
         help_url: SEMGREP_URI
       }
     end

--- a/lib/sarif/semgrep_sarif.rb
+++ b/lib/sarif/semgrep_sarif.rb
@@ -85,7 +85,8 @@ module Sarif
         uri: location[0],
         help_url: SEMGREP_URI,
         code: location[2],
-        rule: "Pattern: #{hit[:pattern]}\nMessage: #{hit[:msg]}"
+        rule: "Pattern: #{hit[:pattern]}\nMessage: #{hit[:msg]}",
+        properties: { 'severity': "HIGH" }
       }
     rescue StandardError => e
       bugsnag_notify(e.message)

--- a/lib/sarif/yarn_audit_sarif.rb
+++ b/lib/sarif/yarn_audit_sarif.rb
@@ -4,8 +4,8 @@ module Sarif
     include Salus::SalusBugsnag
     YARN_URI = 'https://classic.yarnpkg.com/en/docs/cli/audit/'.freeze
 
-    def initialize(scan_report, repo_path)
-      super(scan_report, repo_path)
+    def initialize(scan_report, repo_path = nil)
+      super(scan_report, {}, repo_path)
       @uri = YARN_URI
       parse_scan_report!
     end

--- a/lib/sarif/yarn_audit_sarif.rb
+++ b/lib/sarif/yarn_audit_sarif.rb
@@ -31,6 +31,7 @@ module Sarif
                          "severity": { "text": (issue['Severity']).to_s },
                          "patched_versions": { "text": (issue['Patched in']).to_s },
                          "dependency_of": { "text": (issue['Dependency of']).to_s } },
+        properties: { 'severity': (issue['Severity']).to_s },
         uri: "yarn.lock",
         help_url: issue['More info']
       }

--- a/lib/sarif/yarn_audit_sarif.rb
+++ b/lib/sarif/yarn_audit_sarif.rb
@@ -4,8 +4,8 @@ module Sarif
     include Salus::SalusBugsnag
     YARN_URI = 'https://classic.yarnpkg.com/en/docs/cli/audit/'.freeze
 
-    def initialize(scan_report)
-      super(scan_report)
+    def initialize(scan_report, repo_path)
+      super(scan_report, repo_path)
       @uri = YARN_URI
       parse_scan_report!
     end

--- a/spec/fixtures/gosec/multiple_vulns2/filter.sarif
+++ b/spec/fixtures/gosec/multiple_vulns2/filter.sarif
@@ -80,7 +80,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/home/spec/fixtures/gosec/multiple_vulns2/hello.go",
+                  "uri": "hello.go",
                   "uriBaseId": "%SRCROOT%"
                 },
                 "region": {
@@ -92,7 +92,10 @@
                 }
               }
             }
-          ]
+          ],
+          "properties": {
+            "severity": "HIGH"
+          }
         },
         {
           "ruleId": "G104",
@@ -105,7 +108,7 @@
             {
               "physicalLocation": {
                 "artifactLocation": {
-                  "uri": "/home/spec/fixtures/gosec/multiple_vulns2/hello.go",
+                  "uri": "hello.go",
                   "uriBaseId": "%SRCROOT%"
                 },
                 "region": {
@@ -117,7 +120,10 @@
                 }
               }
             }
-          ]
+          ],
+          "properties": {
+            "severity": "LOW"
+          }
         }
       ],
       "invocations": [

--- a/spec/lib/salus_spec.rb
+++ b/spec/lib/salus_spec.rb
@@ -133,12 +133,12 @@ describe Salus::CLI do
           expect(rule_ids).to eq(%w[G101 G104 G401 G501])
 
           # filtered result file should include both new rules and project build info
-          data2 = JSON.parse(File.read(diff_file))
-          expect(data2['report_type']).to eq('salus_sarif_diff')
-          rule_ids2 = data2['filtered_results'].map { |r| r['ruleId'] }.sort
+          data = JSON.parse(File.read(diff_file))
+          expect(data['report_type']).to eq('salus_sarif_diff')
+          rule_ids = data['filtered_results'].map { |r| r['ruleId'] }.sort
 
-          expect(rule_ids2).to eq(%w[G401 G501])
-          builds = data2['builds']
+          expect(rule_ids).to eq(%w[G401 G501])
+          builds = data['builds']
           expect(builds['org']).to eq('my_org')
           expect(builds['project']).to eq('my_repo')
           expect(builds['url']).to eq('http://buildkite/builds/123456')

--- a/spec/lib/salus_spec.rb
+++ b/spec/lib/salus_spec.rb
@@ -133,15 +133,12 @@ describe Salus::CLI do
           expect(rule_ids).to eq(%w[G101 G104 G401 G501])
 
           # filtered result file should include both new rules and project build info
-          data = JSON.parse(File.read(diff_file))
+          data2 = JSON.parse(File.read(diff_file))
+          expect(data2['report_type']).to eq('salus_sarif_diff')
+          rule_ids2 = data2['filtered_results'].map { |r| r['ruleId'] }.sort
 
-          expect(data['report_type']).to eq('salus_sarif_diff')
-
-          rule_ids = data['filtered_results'].map { |r| r['ruleId'] }.sort
-
-          expect(rule_ids).to eq(%w[G401 G501])
-
-          builds = data['builds']
+          expect(rule_ids2).to eq(%w[G401 G501])
+          builds = data2['builds']
           expect(builds['org']).to eq('my_org')
           expect(builds['project']).to eq('my_repo')
           expect(builds['url']).to eq('http://buildkite/builds/123456')

--- a/spec/lib/sarif/bandit_sarif_spec.rb
+++ b/spec/lib/sarif/bandit_sarif_spec.rb
@@ -1,6 +1,6 @@
 require_relative '../../spec_helper'
 
-describe Sarif::BanditSarif do 
+describe Sarif::BanditSarif do
   describe '#parse_issue' do
     let(:py_dir) { 'spec/fixtures/python' }
     let(:scanner) { Salus::Scanners::Bandit.new(repository: repo, config: {}) }

--- a/spec/lib/sarif/bandit_sarif_spec.rb
+++ b/spec/lib/sarif/bandit_sarif_spec.rb
@@ -1,6 +1,6 @@
 require_relative '../../spec_helper'
 
-describe Sarif::BanditSarif do
+describe Sarif::BanditSarif do 
   describe '#parse_issue' do
     let(:py_dir) { 'spec/fixtures/python' }
     let(:scanner) { Salus::Scanners::Bandit.new(repository: repo, config: {}) }
@@ -20,6 +20,7 @@ describe Sarif::BanditSarif do
           details: "Consider possible security implications associated with cPickle module.",
           messageStrings: { "confidence": { "text": "LOW" },
                            "severity": { "text": "LOW" } },
+          properties: { "severity": "LOW" },
           start_line: 1,
           start_column: 1,
           help_url: "https://bandit.readthedocs.io/en/latest/blacklists/blacklist_imports.html"\

--- a/spec/lib/sarif/bandit_sarif_spec.rb
+++ b/spec/lib/sarif/bandit_sarif_spec.rb
@@ -7,9 +7,10 @@ describe Sarif::BanditSarif do
     before { scanner.run }
 
     context 'scan report with logged vulnerabilites' do
-      let(:repo) { Salus::Repo.new("#{py_dir}/python_project_with_insecure_code_practices") }
+      let(:path) { "#{py_dir}/python_project_with_insecure_code_practices" }
+      let(:repo) { Salus::Repo.new(path) }
       it 'parses information correctly' do
-        bandit_sarif = Sarif::BanditSarif.new(scanner.report)
+        bandit_sarif = Sarif::BanditSarif.new(scanner.report, path)
         issue = JSON.parse(scanner.log(''))['results'][0]
 
         expected = "1 import cPickle\n2 import pickle\n3 import StringIO\n"
@@ -31,7 +32,7 @@ describe Sarif::BanditSarif do
       end
 
       it 'dont have duplicate entries' do
-        bandit_sarif = Sarif::BanditSarif.new(scanner.report)
+        bandit_sarif = Sarif::BanditSarif.new(scanner.report, path)
         issue = JSON.parse(scanner.log(''))['results'][0]
 
         expect(bandit_sarif.parse_issue(issue).nil?).to eq(false)
@@ -43,12 +44,13 @@ describe Sarif::BanditSarif do
   describe '#sarif_level' do
     let(:scanner) { Salus::Scanners::Bandit.new(repository: repo, config: {}) }
     let(:py_dir) { 'spec/fixtures/python' }
+    let(:path) { "#{py_dir}/python_project_no_vulns" }
 
     context 'Bandit Severities' do
-      let(:repo) { Salus::Repo.new("#{py_dir}/python_project_no_vulns") }
+      let(:repo) { Salus::Repo.new(path) }
 
       it 'are mapped to the right sarif levels' do
-        adapter = Sarif::BanditSarif.new(scanner.report)
+        adapter = Sarif::BanditSarif.new(scanner.report, path)
         expect(adapter.sarif_level("HIGH")).to eq("error")
         expect(adapter.sarif_level("LOW")).to eq("warning")
         expect(adapter.sarif_level("MEDIUM")).to eq("error")

--- a/spec/lib/sarif/bandit_sarif_spec.rb
+++ b/spec/lib/sarif/bandit_sarif_spec.rb
@@ -13,6 +13,7 @@ describe Sarif::BanditSarif do
         issue = JSON.parse(scanner.log(''))['results'][0]
 
         expected = "1 import cPickle\n2 import pickle\n3 import StringIO\n"
+
         expect(bandit_sarif.parse_issue(issue)).to include(
           id: "B403",
           name: "blacklist",

--- a/spec/lib/sarif/base_sarif_spec.rb
+++ b/spec/lib/sarif/base_sarif_spec.rb
@@ -3,7 +3,7 @@ require 'json-schema'
 
 describe Sarif::BaseSarif do
   let(:scan_report) { Salus::ScanReport.new("Unsupported_Scanner") }
-  let(:base_sarif) { Sarif::BaseSarif.new(scan_report, "./") }
+  let(:base_sarif) { Sarif::BaseSarif.new(scan_report) }
   let(:report) { Salus::Report.new(project_name: 'Neon genesis') }
   before do
     scan_report.add_version('1.1.1')

--- a/spec/lib/sarif/base_sarif_spec.rb
+++ b/spec/lib/sarif/base_sarif_spec.rb
@@ -47,7 +47,7 @@ describe Sarif::BaseSarif do
 
   describe '#build_runs_object' do
     context 'results object' do
-      let (:path) { "./" }
+      let(:path) { "./" }
       it 'has suppressions objects for suppressed results' do
         parsed_issue = {
           id: 'SAL002',

--- a/spec/lib/sarif/base_sarif_spec.rb
+++ b/spec/lib/sarif/base_sarif_spec.rb
@@ -3,7 +3,7 @@ require 'json-schema'
 
 describe Sarif::BaseSarif do
   let(:scan_report) { Salus::ScanReport.new("Unsupported_Scanner") }
-  let(:base_sarif) { Sarif::BaseSarif.new(scan_report) }
+  let(:base_sarif) { Sarif::BaseSarif.new(scan_report, "./") }
   let(:report) { Salus::Report.new(project_name: 'Neon genesis') }
   before do
     scan_report.add_version('1.1.1')
@@ -47,6 +47,7 @@ describe Sarif::BaseSarif do
 
   describe '#build_runs_object' do
     context 'results object' do
+      let (:path) { "./" }
       it 'has suppressions objects for suppressed results' do
         parsed_issue = {
           id: 'SAL002',
@@ -60,7 +61,7 @@ describe Sarif::BaseSarif do
           code: "",
           suppressed: true
         }
-        adapter = Sarif::GosecSarif.new(scan_report)
+        adapter = Sarif::GosecSarif.new(scan_report, path)
         adapter.instance_variable_set(:@logs, [parsed_issue])
         runs_object = adapter.build_runs_object(true)
         expect(runs_object['results'][0]['suppressions'].nil?).to eq(false)
@@ -78,7 +79,7 @@ describe Sarif::BaseSarif do
           help_url: "https://github.com/coinbase/salus/blob/master/docs/salus_reports.md",
           code: ""
         }
-        adapter = Sarif::GosecSarif.new(scan_report)
+        adapter = Sarif::GosecSarif.new(scan_report, path)
         adapter.instance_variable_set(:@logs, [parsed_issue])
         runs_object = adapter.build_runs_object(true)
         expect(runs_object['results'][0]['suppressions'].nil?).to eq(true)
@@ -97,7 +98,7 @@ describe Sarif::BaseSarif do
           code: "",
           suppressed: true
         }
-        adapter = Sarif::GosecSarif.new(scan_report)
+        adapter = Sarif::GosecSarif.new(scan_report, path)
         adapter.instance_variable_set(:@logs, [parsed_issue])
         adapter.instance_variable_set(:@config, { "include_suppressed": false }.stringify_keys)
         runs_object = adapter.build_runs_object(true)
@@ -117,7 +118,7 @@ describe Sarif::BaseSarif do
           code: "",
           suppressed: true
         }
-        adapter = Sarif::GosecSarif.new(scan_report)
+        adapter = Sarif::GosecSarif.new(scan_report, path)
         adapter.instance_variable_set(:@logs, [parsed_issue])
         adapter.instance_variable_set(:@config, { "include_suppressed": true }.stringify_keys)
         runs_object = adapter.build_runs_object(true)
@@ -136,7 +137,7 @@ describe Sarif::BaseSarif do
           help_url: "https://github.com/coinbase/salus/blob/master/docs/salus_reports.md",
           code: ""
         }
-        adapter = Sarif::GosecSarif.new(scan_report)
+        adapter = Sarif::GosecSarif.new(scan_report, path)
         adapter.instance_variable_set(:@logs, [parsed_issue])
         adapter.instance_variable_set(:@config, { "include_suppressed": true }.stringify_keys)
         adapter.instance_variable_set(:@required, false)
@@ -157,7 +158,7 @@ describe Sarif::BaseSarif do
           help_url: "https://github.com/coinbase/salus/blob/master/docs/salus_reports.md",
           code: ""
         }
-        adapter = Sarif::GosecSarif.new(scan_report)
+        adapter = Sarif::GosecSarif.new(scan_report, path)
         adapter.instance_variable_set(:@logs, [parsed_issue])
         adapter.instance_variable_set(:@config, { "include_suppressed": true }.stringify_keys)
         adapter.instance_variable_set(:@required, false)
@@ -177,7 +178,7 @@ describe Sarif::BaseSarif do
           help_url: "https://github.com/coinbase/salus/blob/master/docs/salus_reports.md",
           code: ""
         }
-        adapter = Sarif::GosecSarif.new(scan_report)
+        adapter = Sarif::GosecSarif.new(scan_report, path)
         adapter.instance_variable_set(:@logs, [parsed_issue])
         adapter.instance_variable_set(:@config, { "include_suppressed": false }.stringify_keys)
         adapter.instance_variable_set(:@required, true)
@@ -197,7 +198,7 @@ describe Sarif::BaseSarif do
           help_url: "https://github.com/coinbase/salus/blob/master/docs/salus_reports.md",
           code: ""
         }
-        adapter = Sarif::GosecSarif.new(scan_report)
+        adapter = Sarif::GosecSarif.new(scan_report, path)
         adapter.instance_variable_set(:@logs, [parsed_issue])
         adapter.instance_variable_set(:@config, { "include_suppressed": false }.stringify_keys)
         adapter.instance_variable_set(:@required, false)

--- a/spec/lib/sarif/brakeman_sarif_spec.rb
+++ b/spec/lib/sarif/brakeman_sarif_spec.rb
@@ -11,7 +11,7 @@ describe Sarif::BrakemanSarif do
       let(:repo) { Salus::Repo.new('spec/fixtures') }
       let(:path) { File.join(basedir, "fixtures/brakeman/vulnerable_rails_app") }
       it 'parses information correctly' do
-        brakeman_sarif = Sarif::BrakemanSarif.new(scanner.report)
+        brakeman_sarif = Sarif::BrakemanSarif.new(scanner.report, path)
 
         issue = JSON.parse(scanner.log(''))['warnings'][0]
 
@@ -43,7 +43,7 @@ describe Sarif::BrakemanSarif do
       end
 
       it 'should parse brakeman errors' do
-        brakeman_sarif = Sarif::BrakemanSarif.new(scanner.report)
+        brakeman_sarif = Sarif::BrakemanSarif.new(scanner.report, path)
         error = { 'error' => 'foo', 'location' => 'fooclass' }.stringify_keys
         parsed_error = brakeman_sarif.parse_issue(error)
         expect(parsed_error[:id]).to eq('SAL002')
@@ -57,10 +57,11 @@ describe Sarif::BrakemanSarif do
 
   describe '#build_result' do
     context 'rails project with vulnerabilities' do
+      let(:path) { "./" }
       it 'should generate valid result for a brakeman warning with no code snippets' do
         scan_report = Salus::ScanReport.new('Brakeman')
         scan_report.add_version('0.1')
-        brakeman_sarif = Sarif::BrakemanSarif.new(scan_report)
+        brakeman_sarif = Sarif::BrakemanSarif.new(scan_report, path)
         issue = {
           "warning_type": "Cross-Site Request Forgery",
           "warning_code": 116,
@@ -86,7 +87,7 @@ describe Sarif::BrakemanSarif do
       it 'should generate valid result for a brakeman warning with code snippets' do
         scan_report = Salus::ScanReport.new('Brakeman')
         scan_report.add_version('0.1')
-        brakeman_sarif = Sarif::BrakemanSarif.new(scan_report)
+        brakeman_sarif = Sarif::BrakemanSarif.new(scan_report, path)
         issue = {
           "warning_type": "Cross-Site Request Forgery",
           "warning_code": 116,
@@ -114,7 +115,7 @@ describe Sarif::BrakemanSarif do
     it 'should map brakeman severity/confidence levels to sarif_levels' do
       scan_report = Salus::ScanReport.new('Brakeman')
       scan_report.add_version('0.1')
-      brakeman_adapter = Sarif::BrakemanSarif.new(scan_report)
+      brakeman_adapter = Sarif::BrakemanSarif.new(scan_report, "./")
       expect(brakeman_adapter.sarif_level('HIGH')).to eq('error')
       expect(brakeman_adapter.sarif_level('MEDIUM')).to eq('error')
       expect(brakeman_adapter.sarif_level('LOW')).to eq('warning')
@@ -139,6 +140,7 @@ describe Sarif::BrakemanSarif do
     end
 
     context 'rails project with no vulnerabilities' do
+      let(:basedir) { File.expand_path("../../../spec/", __dir__) }
       let(:repo) { Salus::Repo.new(File.join(basedir, "/fixtures/brakeman/bundler_2")) }
       it 'should generate an empty sarif report' do
         report = Salus::Report.new(project_name: "Neon Genesis")
@@ -150,6 +152,7 @@ describe Sarif::BrakemanSarif do
     end
 
     context 'python project with empty report containing whitespace' do
+      let(:basedir) { File.expand_path("../../../spec/", __dir__) }
       let(:repo) { Salus::Repo.new(File.join(basedir, "fixtures/brakeman/bundler_2")) }
       it 'should handle empty reports with whitespace' do
         report = Salus::Report.new(project_name: "Neon Genesis")
@@ -164,6 +167,7 @@ describe Sarif::BrakemanSarif do
     end
 
     context 'rails project with vulnerabilities' do
+      let(:basedir) { File.expand_path("../../../spec/", __dir__) }
       let(:repo) { Salus::Repo.new(File.join(basedir, "fixtures/brakeman/vulnerable_rails_app")) }
       it 'should generate the right results and rules' do
         report = Salus::Report.new(project_name: "Neon Genesis")

--- a/spec/lib/sarif/brakeman_sarif_spec.rb
+++ b/spec/lib/sarif/brakeman_sarif_spec.rb
@@ -115,7 +115,7 @@ describe Sarif::BrakemanSarif do
     it 'should map brakeman severity/confidence levels to sarif_levels' do
       scan_report = Salus::ScanReport.new('Brakeman')
       scan_report.add_version('0.1')
-      brakeman_adapter = Sarif::BrakemanSarif.new(scan_report, "./")
+      brakeman_adapter = Sarif::BrakemanSarif.new(scan_report)
       expect(brakeman_adapter.sarif_level('HIGH')).to eq('error')
       expect(brakeman_adapter.sarif_level('MEDIUM')).to eq('error')
       expect(brakeman_adapter.sarif_level('LOW')).to eq('warning')

--- a/spec/lib/sarif/brakeman_sarif_spec.rb
+++ b/spec/lib/sarif/brakeman_sarif_spec.rb
@@ -4,12 +4,12 @@ require 'json'
 describe Sarif::BrakemanSarif do
   describe '#parse_issue' do
     let(:scanner) { Salus::Scanners::Brakeman.new(repository: repo, config: { 'path' => path }) }
-    let(:basedir) { File.expand_path("../../../spec/", __dir__)}
+    let(:basedir) { File.expand_path("../../../spec/", __dir__) }
     before { scanner.run }
 
     context 'scan report with logged vulnerabilites' do
       let(:repo) { Salus::Repo.new('spec/fixtures') }
-      let(:path) { File.join(basedir, "fixtures/brakeman/vulnerable_rails_app")}
+      let(:path) { File.join(basedir, "fixtures/brakeman/vulnerable_rails_app") }
       it 'parses information correctly' do
         brakeman_sarif = Sarif::BrakemanSarif.new(scanner.report)
 

--- a/spec/lib/sarif/brakeman_sarif_spec.rb
+++ b/spec/lib/sarif/brakeman_sarif_spec.rb
@@ -4,13 +4,15 @@ require 'json'
 describe Sarif::BrakemanSarif do
   describe '#parse_issue' do
     let(:scanner) { Salus::Scanners::Brakeman.new(repository: repo, config: { 'path' => path }) }
+    let(:basedir) { File.expand_path("../../../spec/", __dir__)}
     before { scanner.run }
 
     context 'scan report with logged vulnerabilites' do
       let(:repo) { Salus::Repo.new('spec/fixtures') }
-      let(:path) { '/home/spec/fixtures/brakeman/vulnerable_rails_app' }
+      let(:path) { File.join(basedir, "fixtures/brakeman/vulnerable_rails_app")}
       it 'parses information correctly' do
         brakeman_sarif = Sarif::BrakemanSarif.new(scanner.report)
+
         issue = JSON.parse(scanner.log(''))['warnings'][0]
 
         brakeman_sarif.build_runs_object(true)
@@ -30,6 +32,7 @@ describe Sarif::BrakemanSarif do
           properties: {
             fingerprint: "b16e1cd0d952433f80b0403b6a74aab0e98792ea015cc1b1fa5c003cbe7d56eb",
             confidence: "High",
+            severity: "High",
             render_path: "",
             user_input: "params[:evil]",
             location_type: "method",
@@ -136,7 +139,7 @@ describe Sarif::BrakemanSarif do
     end
 
     context 'rails project with no vulnerabilities' do
-      let(:repo) { Salus::Repo.new('/home/spec/fixtures/brakeman/bundler_2') }
+      let(:repo) { Salus::Repo.new(File.join(basedir, "/fixtures/brakeman/bundler_2")) }
       it 'should generate an empty sarif report' do
         report = Salus::Report.new(project_name: "Neon Genesis")
         report.add_scan_report(scanner.report, required: false)
@@ -147,7 +150,7 @@ describe Sarif::BrakemanSarif do
     end
 
     context 'python project with empty report containing whitespace' do
-      let(:repo) { Salus::Repo.new('/home/spec/fixtures/brakeman/bundler_2') }
+      let(:repo) { Salus::Repo.new(File.join(basedir, "fixtures/brakeman/bundler_2")) }
       it 'should handle empty reports with whitespace' do
         report = Salus::Report.new(project_name: "Neon Genesis")
         # Override the report.log() to return "\n"
@@ -161,7 +164,7 @@ describe Sarif::BrakemanSarif do
     end
 
     context 'rails project with vulnerabilities' do
-      let(:repo) { Salus::Repo.new('/home/spec/fixtures/brakeman/vulnerable_rails_app') }
+      let(:repo) { Salus::Repo.new(File.join(basedir, "fixtures/brakeman/vulnerable_rails_app")) }
       it 'should generate the right results and rules' do
         report = Salus::Report.new(project_name: "Neon Genesis")
         report.add_scan_report(scanner.report, required: false)

--- a/spec/lib/sarif/bundle_audit_spec.rb
+++ b/spec/lib/sarif/bundle_audit_spec.rb
@@ -6,10 +6,11 @@ describe Sarif::BundleAuditSarif do
     before { scanner.run }
 
     context 'scan report with logged vulnerabilities' do
-      let(:repo) { Salus::Repo.new('spec/fixtures/bundle_audit/cves_found') }
+      let(:path) { 'spec/fixtures/bundle_audit/cves_found' }
+      let(:repo) { Salus::Repo.new(path) }
 
       it 'updates ids accordingly' do
-        bundle_audit_sarif = Sarif::BundleAuditSarif.new(scanner.report)
+        bundle_audit_sarif = Sarif::BundleAuditSarif.new(scanner.report, path)
         issue = { "type": "InsecureSource",
           "source": "http://rubygems.org/" }
 
@@ -31,7 +32,7 @@ describe Sarif::BundleAuditSarif do
       end
 
       it 'parses information correctly' do
-        bundle_audit_sarif = Sarif::BundleAuditSarif.new(scanner.report)
+        bundle_audit_sarif = Sarif::BundleAuditSarif.new(scanner.report, path)
         issue = scanner.report.to_h[:info][:vulnerabilities]
         issue = issue.detect { |i| i[:cve] == 'CVE-2021-22885' }
 
@@ -113,7 +114,7 @@ describe Sarif::BundleAuditSarif do
   describe '#sarif_level' do
     context 'Bundler audit severities' do
       it 'should be mapped to the right sarif level' do
-        adapter = Sarif::BundleAuditSarif.new([])
+        adapter = Sarif::BundleAuditSarif.new([], './')
         expect(adapter.sarif_level(0)).to eq("note")
         expect(adapter.sarif_level(5.6)).to eq("warning")
         expect(adapter.sarif_level(9.7)).to eq("error")

--- a/spec/lib/sarif/bundle_audit_spec.rb
+++ b/spec/lib/sarif/bundle_audit_spec.rb
@@ -114,7 +114,7 @@ describe Sarif::BundleAuditSarif do
   describe '#sarif_level' do
     context 'Bundler audit severities' do
       it 'should be mapped to the right sarif level' do
-        adapter = Sarif::BundleAuditSarif.new([], './')
+        adapter = Sarif::BundleAuditSarif.new([])
         expect(adapter.sarif_level(0)).to eq("note")
         expect(adapter.sarif_level(5.6)).to eq("warning")
         expect(adapter.sarif_level(9.7)).to eq("error")

--- a/spec/lib/sarif/cargo_audit_sarif_spec.rb
+++ b/spec/lib/sarif/cargo_audit_sarif_spec.rb
@@ -120,7 +120,7 @@ describe Sarif::CargoAuditSarif do
     it 'parses cargo severity levels to sarif levels' do
       scan_report = Salus::ScanReport.new('CargoAudit')
       scan_report.add_version('0.0.1')
-      cargo_sarif = Sarif::CargoAuditSarif.new(scan_report, './')
+      cargo_sarif = Sarif::CargoAuditSarif.new(scan_report)
       expect(cargo_sarif.sarif_level('HIGH')).to eq('error')
       expect(cargo_sarif.sarif_level('MEDIUM')).to eq('error')
       expect(cargo_sarif.sarif_level('LOW')).to eq('warning')

--- a/spec/lib/sarif/cargo_audit_sarif_spec.rb
+++ b/spec/lib/sarif/cargo_audit_sarif_spec.rb
@@ -4,13 +4,14 @@ require 'json'
 describe Sarif::CargoAuditSarif do
   describe '#parse_issue' do
     let(:scanner) { Salus::Scanners::CargoAudit.new(repository: repo, config: {}) }
+    let(:path) { 'spec/fixtures/cargo_audit/failure-vulnerability-present' }
     before { scanner.run }
 
     context 'scan report with logged vulnerabilites' do
-      let(:repo) { Salus::Repo.new('spec/fixtures/cargo_audit/failure-vulnerability-present') }
+      let(:repo) { Salus::Repo.new(path) }
       it 'parses information correctly' do
         x = JSON.parse(scanner.report.to_h.fetch(:logs))
-        cargo_sarif = Sarif::CargoAuditSarif.new(scanner.report)
+        cargo_sarif = Sarif::CargoAuditSarif.new(scanner.report, path)
 
         issue = x['vulnerabilities']['list'][0]
 
@@ -60,7 +61,7 @@ describe Sarif::CargoAuditSarif do
     end
 
     context 'rust project with no vulnerabilities' do
-      let(:repo) { Salus::Repo.new('/home/spec/fixtures/cargo_audit/success') }
+      let(:repo) { Salus::Repo.new('spec/fixtures/cargo_audit/success') }
       it 'should generate an empty sarif report' do
         report = Salus::Report.new(project_name: "Neon Genesis")
         report.add_scan_report(scanner.report, required: false)
@@ -71,7 +72,7 @@ describe Sarif::CargoAuditSarif do
     end
 
     context 'rust project with empty report containing whitespace' do
-      let(:repo) { Salus::Repo.new('/home/spec/fixtures/cargo_audit/success') }
+      let(:repo) { Salus::Repo.new('spec/fixtures/cargo_audit/success') }
       it 'should handle empty reports with whitespace' do
         report = Salus::Report.new(project_name: "Neon Genesis")
         # Override the report.log() to return "\n"
@@ -119,7 +120,7 @@ describe Sarif::CargoAuditSarif do
     it 'parses cargo severity levels to sarif levels' do
       scan_report = Salus::ScanReport.new('CargoAudit')
       scan_report.add_version('0.0.1')
-      cargo_sarif = Sarif::CargoAuditSarif.new(scan_report)
+      cargo_sarif = Sarif::CargoAuditSarif.new(scan_report, './')
       expect(cargo_sarif.sarif_level('HIGH')).to eq('error')
       expect(cargo_sarif.sarif_level('MEDIUM')).to eq('error')
       expect(cargo_sarif.sarif_level('LOW')).to eq('warning')

--- a/spec/lib/sarif/gosec_sarif_spec.rb
+++ b/spec/lib/sarif/gosec_sarif_spec.rb
@@ -5,15 +5,17 @@ require 'json-schema'
 describe Sarif::GosecSarif do
   describe '#parse_issue' do
     let(:scanner) { Salus::Scanners::Gosec.new(repository: repo, config: {}) }
+    let(:path) { 'spec/fixtures/gosec/safe_goapp' }
     before { scanner.run }
 
     context 'scan report with duplicate vulnerabilities' do
-      let(:repo) { Salus::Repo.new('spec/fixtures/gosec/safe_goapp') }
+      let(:repo) { Salus::Repo.new(path) }
+      let(:path) { 'spec/fixtures/gosec/duplicate_entries' }
       it 'should not include duplicate result entries' do
         scan_report = Salus::ScanReport.new(scanner_name: "Gosec")
-        f = File.read('spec/fixtures/gosec/duplicate_entries/report.json')
+        f = File.read("#{path}/report.json")
         scan_report.log(f.to_s)
-        adapter = Sarif::GosecSarif.new(scan_report)
+        adapter = Sarif::GosecSarif.new(scan_report, path)
         results = adapter.build_runs_object(true)["results"]
 
         expect(results.size).to eq(3)
@@ -28,7 +30,7 @@ describe Sarif::GosecSarif do
         scan_report = Salus::ScanReport.new(scanner_name: "Gosec")
         f = File.read('spec/fixtures/gosec/duplicate_entries/report.json')
         scan_report.log(f.to_s)
-        adapter = Sarif::GosecSarif.new(scan_report)
+        adapter = Sarif::GosecSarif.new(scan_report, 'spec/fixtures/gosec/duplicate_entries' )
         rules = adapter.build_runs_object(true)["tool"][:driver]["rules"]
         expect(rules.size).to eq(2)
         unique_rules = Set.new
@@ -41,10 +43,11 @@ describe Sarif::GosecSarif do
 
     describe '#sarif_level' do
       context 'gosec severities' do
-        let(:repo) { Salus::Repo.new('spec/fixtures/gosec/safe_goapp') }
+        let(:path) { 'spec/fixtures/gosec/safe_goapp' }
+        let(:repo) { Salus::Repo.new(path) }
         it 'are mapped to sarif levels' do
           scan_report = Salus::ScanReport.new(scanner_name: "Gosec")
-          adapter = Sarif::GosecSarif.new(scan_report)
+          adapter = Sarif::GosecSarif.new(scan_report, path )
           expect(adapter.sarif_level("MEDIUM")).to eq("error")
           expect(adapter.sarif_level("HIGH")).to eq("error")
           expect(adapter.sarif_level("LOW")).to eq("warning")
@@ -53,9 +56,10 @@ describe Sarif::GosecSarif do
     end
 
     context 'scan report with logged vulnerabilites' do
-      let(:repo) { Salus::Repo.new('spec/fixtures/gosec/vulnerable_goapp') }
+      let(:path) { 'spec/fixtures/gosec/vulnerable_goapp' }
+      let(:repo) { Salus::Repo.new(path) }
       it 'parses information correctly' do
-        gosec_sarif = Sarif::GosecSarif.new(scanner.report)
+        gosec_sarif = Sarif::GosecSarif.new(scanner.report, path)
         issue = JSON.parse(scanner.log(''))['Issues'][0]
 
         # should Parse and fill out hash
@@ -73,6 +77,8 @@ describe Sarif::GosecSarif do
           start_line: 8,
           start_column: 2,
           help_url: "https://cwe.mitre.org/data/definitions/798.html",
+          uri: "hello.go",
+          properties: {severity: "HIGH"},
           code: expected
         )
       end

--- a/spec/lib/sarif/gosec_sarif_spec.rb
+++ b/spec/lib/sarif/gosec_sarif_spec.rb
@@ -29,7 +29,7 @@ describe Sarif::GosecSarif do
         scan_report = Salus::ScanReport.new(scanner_name: "Gosec")
         f = File.read('spec/fixtures/gosec/duplicate_entries/report.json')
         scan_report.log(f.to_s)
-        adapter = Sarif::GosecSarif.new(scan_report, 'spec/fixtures/gosec/duplicate_entries' )
+        adapter = Sarif::GosecSarif.new(scan_report, 'spec/fixtures/gosec/duplicate_entries')
         rules = adapter.build_runs_object(true)["tool"][:driver]["rules"]
         expect(rules.size).to eq(2)
         unique_rules = Set.new
@@ -46,7 +46,7 @@ describe Sarif::GosecSarif do
         let(:repo) { Salus::Repo.new(path) }
         it 'are mapped to sarif levels' do
           scan_report = Salus::ScanReport.new(scanner_name: "Gosec")
-          adapter = Sarif::GosecSarif.new(scan_report, path )
+          adapter = Sarif::GosecSarif.new(scan_report, path)
           expect(adapter.sarif_level("MEDIUM")).to eq("error")
           expect(adapter.sarif_level("HIGH")).to eq("error")
           expect(adapter.sarif_level("LOW")).to eq("warning")
@@ -77,7 +77,7 @@ describe Sarif::GosecSarif do
           start_column: 2,
           help_url: "https://cwe.mitre.org/data/definitions/798.html",
           uri: "hello.go",
-          properties: {severity: "HIGH"},
+          properties: { severity: "HIGH" },
           code: expected
         )
       end

--- a/spec/lib/sarif/gosec_sarif_spec.rb
+++ b/spec/lib/sarif/gosec_sarif_spec.rb
@@ -17,7 +17,6 @@ describe Sarif::GosecSarif do
         scan_report.log(f.to_s)
         adapter = Sarif::GosecSarif.new(scan_report, path)
         results = adapter.build_runs_object(true)["results"]
-
         expect(results.size).to eq(3)
         unique_results = Set.new
         results.each do |result|
@@ -149,11 +148,13 @@ describe Sarif::GosecSarif do
     end
 
     context 'go project with vulnerabilities' do
-      let(:repo) { Salus::Repo.new('spec/fixtures/gosec/recursive_vulnerable_goapp') }
+      let(:path) { 'spec/fixtures/gosec/recursive_vulnerable_goapp' }
+      let(:repo) { Salus::Repo.new(path) }
 
       it 'should generate the right results and rules' do
-        report = Salus::Report.new(project_name: "Neon Genesis")
+        report = Salus::Report.new(project_name: "Neon Genesis", repo_path: path)
         report.add_scan_report(scanner.report, required: false)
+
         result = JSON.parse(report.to_sarif)["runs"][0]["results"][0]
         rules = JSON.parse(report.to_sarif)["runs"][0]["tool"]["driver"]["rules"]
         # Check rule info

--- a/spec/lib/sarif/npm_audit_sarif_spec.rb
+++ b/spec/lib/sarif/npm_audit_sarif_spec.rb
@@ -10,7 +10,7 @@ describe Sarif::NPMAuditSarif do
       let(:repo) { Salus::Repo.new('spec/fixtures/npm_audit/failure-2') }
       it 'parses information correctly' do
         issue = scanner.report.to_h[:info][:stdout][:advisories].values[0]
-        npm_sarif = Sarif::NPMAuditSarif.new(scanner.report)
+        npm_sarif = Sarif::NPMAuditSarif.new(scanner.report, './')
 
         expect(npm_sarif.parse_issue(issue)).to include(
           id: "39",
@@ -32,11 +32,12 @@ describe Sarif::NPMAuditSarif do
     end
 
     context 'Duplicate advisories' do
-      let(:repo) { Salus::Repo.new('spec/fixtures/npm_audit/failure-2') }
+      let(:path) { 'spec/fixtures/npm_audit/failure-2' }
+      let(:repo) { Salus::Repo.new(path) }
       it 'should be parsed once' do
         issue = scanner.report.to_h[:info][:stdout][:advisories].values[0]
 
-        npm_sarif = Sarif::NPMAuditSarif.new(scanner.report)
+        npm_sarif = Sarif::NPMAuditSarif.new(scanner.report, path)
         expect(npm_sarif.parse_issue(issue).empty?).to eq(false)
         expect(npm_sarif.parse_issue(issue)).to eq(nil)
       end
@@ -47,10 +48,11 @@ describe Sarif::NPMAuditSarif do
     let(:scanner) { Salus::Scanners::NPMAudit.new(repository: repo, config: {}) }
     before { scanner.run }
     context 'NPM severities' do
-      let(:repo) { Salus::Repo.new('spec/fixtures/npm_audit/success') }
+      let(:path) { 'spec/fixtures/npm_audit/success' }
+      let(:repo) { Salus::Repo.new(path) }
       it 'should be mapped to the right sarif levels' do
         # NPM Severities: https://docs.npmjs.com/about-audit-reports#severity
-        adapter = Sarif::NPMAuditSarif.new(scanner.report)
+        adapter = Sarif::NPMAuditSarif.new(scanner.report, path)
 
         expect(adapter.sarif_level('CRITICAL')).to eq('error')
         expect(adapter.sarif_level('HIGH')).to eq('error')

--- a/spec/lib/sarif/pattern_search_sarif_spec.rb
+++ b/spec/lib/sarif/pattern_search_sarif_spec.rb
@@ -2,7 +2,7 @@ require_relative '../../spec_helper'
 
 describe Sarif::PatternSearchSarif do
   context '#parse_issue' do
-    let(:path){ 'spec/fixtures/pattern_search' }
+    let(:path) { 'spec/fixtures/pattern_search' }
     it 'doesnt add duplicates to the report' do
       repo = Salus::Repo.new(path)
       config = {
@@ -21,7 +21,7 @@ describe Sarif::PatternSearchSarif do
 
   describe '#build_runs_object' do
     context 'vulnerabilites found in project' do
-      let(:path) {'spec/fixtures/pattern_search' }
+      let(:path) { 'spec/fixtures/pattern_search' }
       it 'creates valid sarif report with results populated' do
         repo = Salus::Repo.new(path)
         config = {

--- a/spec/lib/sarif/pattern_search_sarif_spec.rb
+++ b/spec/lib/sarif/pattern_search_sarif_spec.rb
@@ -2,8 +2,9 @@ require_relative '../../spec_helper'
 
 describe Sarif::PatternSearchSarif do
   context '#parse_issue' do
+    let(:path){ 'spec/fixtures/pattern_search' }
     it 'doesnt add duplicates to the report' do
-      repo = Salus::Repo.new('spec/fixtures/pattern_search')
+      repo = Salus::Repo.new(path)
       config = {
         'matches' => [
           { 'regex' => 'Nerv', 'required' => true, 'message' => 'important string' }
@@ -11,7 +12,7 @@ describe Sarif::PatternSearchSarif do
       }
       scanner = Salus::Scanners::PatternSearch.new(repository: repo, config: config)
       scanner.run
-      adapter = Sarif::PatternSearchSarif.new(scanner.report)
+      adapter = Sarif::PatternSearchSarif.new(scanner.report, path)
       x = scanner.report.to_h.dig(:info, :hits)
       adapter.parse_issue(x[0])
       expect(adapter.parse_issue(x[0])).to eq(nil)
@@ -20,8 +21,9 @@ describe Sarif::PatternSearchSarif do
 
   describe '#build_runs_object' do
     context 'vulnerabilites found in project' do
+      let(:path) {'spec/fixtures/pattern_search' }
       it 'creates valid sarif report with results populated' do
-        repo = Salus::Repo.new('spec/fixtures/pattern_search')
+        repo = Salus::Repo.new(path)
         config = {
           'matches' => [
             { 'regex' => 'Nerv', 'forbidden' => true, 'message' => 'not important string' },
@@ -34,7 +36,7 @@ describe Sarif::PatternSearchSarif do
         report = Salus::Report.new(project_name: "Neon Genesis")
         report.add_scan_report(scanner.report, required: true)
 
-        adapter = Sarif::PatternSearchSarif.new(scanner.report)
+        adapter = Sarif::PatternSearchSarif.new(scanner.report, path)
         report = adapter.build_runs_object(true)
         rules = report['tool'][:driver]['rules']
         results = report['results']

--- a/spec/lib/sarif/pattern_search_sarif_spec.rb
+++ b/spec/lib/sarif/pattern_search_sarif_spec.rb
@@ -46,6 +46,7 @@ describe Sarif::PatternSearchSarif do
             "message": {
               "text": "not important string. Pattern Nerv is forbidden."
             },
+            "properties": { severity: "HIGH" },
             "locations": [
               {
                 "physicalLocation": {

--- a/spec/lib/sarif/repo_not_empty_sarif_spec.rb
+++ b/spec/lib/sarif/repo_not_empty_sarif_spec.rb
@@ -6,9 +6,10 @@ describe Sarif::RepoNotEmptySarif do
     before { scanner.run }
 
     context 'vulnerabilites found in project' do
-      let(:repo) { Salus::Repo.new('spec/fixtures/repo_not_empty/blank') }
+      let(:path) { 'spec/fixtures/repo_not_empty/blank' }
+      let(:repo) { Salus::Repo.new(path) }
       it 'creates valid sarif report with results populated' do
-        adapter = Sarif::RepoNotEmptySarif.new(scanner.report)
+        adapter = Sarif::RepoNotEmptySarif.new(scanner.report, path)
         report = adapter.build_runs_object(true)
         rules = report['tool'][:driver]['rules']
         results = report['results']
@@ -57,7 +58,7 @@ describe Sarif::RepoNotEmptySarif do
         scan_reports = [
           [scanner.report, false]
         ]
-        sarif_json = Sarif::SarifReport.new(scan_reports).to_sarif
+        sarif_json = Sarif::SarifReport.new(scan_reports, "./").to_sarif
         filtered_sarif = report.apply_report_sarif_filters(sarif_json)
         expect { Sarif::SarifReport.validate_sarif(filtered_sarif) }.not_to raise_error
       end
@@ -67,16 +68,17 @@ describe Sarif::RepoNotEmptySarif do
         scan_reports = [
           [scanner.report, false]
         ]
-        sarif_json = Sarif::SarifReport.new(scan_reports).to_sarif
+        sarif_json = Sarif::SarifReport.new(scan_reports, "./").to_sarif
         filtered_sarif = report.apply_report_sarif_filters(sarif_json)
         expect { Sarif::SarifReport.validate_sarif(filtered_sarif) }.not_to raise_error
       end
     end
 
     context 'no vulnerabilites found in project' do
-      let(:repo) { Salus::Repo.new('spec/fixtures/repo_not_empty/non_blank') }
+      let(:path) { 'spec/fixtures/repo_not_empty/non_blank' }
+      let(:repo) { Salus::Repo.new(path) }
       it 'does not create sarif report for non-empty repo' do
-        adapter = Sarif::RepoNotEmptySarif.new(scanner.report)
+        adapter = Sarif::RepoNotEmptySarif.new(scanner.report, path)
         report = adapter.build_runs_object(true)
         rules = report['tool'][:driver]['rules']
         results = report['results']
@@ -87,7 +89,7 @@ describe Sarif::RepoNotEmptySarif do
         scan_reports = [
           [scanner.report, false]
         ]
-        sarif_json = Sarif::SarifReport.new(scan_reports).to_sarif
+        sarif_json = Sarif::SarifReport.new(scan_reports, "./").to_sarif
         filtered_sarif = report.apply_report_sarif_filters(sarif_json)
         expect { Sarif::SarifReport.validate_sarif(filtered_sarif) }.not_to raise_error
       end

--- a/spec/lib/sarif/repo_not_empty_sarif_spec.rb
+++ b/spec/lib/sarif/repo_not_empty_sarif_spec.rb
@@ -58,7 +58,7 @@ describe Sarif::RepoNotEmptySarif do
         scan_reports = [
           [scanner.report, false]
         ]
-        sarif_json = Sarif::SarifReport.new(scan_reports, "./").to_sarif
+        sarif_json = Sarif::SarifReport.new(scan_reports).to_sarif
         filtered_sarif = report.apply_report_sarif_filters(sarif_json)
         expect { Sarif::SarifReport.validate_sarif(filtered_sarif) }.not_to raise_error
       end
@@ -68,7 +68,7 @@ describe Sarif::RepoNotEmptySarif do
         scan_reports = [
           [scanner.report, false]
         ]
-        sarif_json = Sarif::SarifReport.new(scan_reports, "./").to_sarif
+        sarif_json = Sarif::SarifReport.new(scan_reports).to_sarif
         filtered_sarif = report.apply_report_sarif_filters(sarif_json)
         expect { Sarif::SarifReport.validate_sarif(filtered_sarif) }.not_to raise_error
       end
@@ -89,7 +89,7 @@ describe Sarif::RepoNotEmptySarif do
         scan_reports = [
           [scanner.report, false]
         ]
-        sarif_json = Sarif::SarifReport.new(scan_reports, "./").to_sarif
+        sarif_json = Sarif::SarifReport.new(scan_reports).to_sarif
         filtered_sarif = report.apply_report_sarif_filters(sarif_json)
         expect { Sarif::SarifReport.validate_sarif(filtered_sarif) }.not_to raise_error
       end

--- a/spec/lib/sarif/repo_not_empty_sarif_spec.rb
+++ b/spec/lib/sarif/repo_not_empty_sarif_spec.rb
@@ -23,6 +23,7 @@ describe Sarif::RepoNotEmptySarif do
               "text": "Salus was run on a blank directory. This may indicate "\
                "misconfiguration such as not correctly voluming in the repository to be scanned."
             },
+            "properties": { "severity": "VERY LOW" },
             "locations": [
               {
                 "physicalLocation": {

--- a/spec/lib/sarif/semgrep_sarif_spec.rb
+++ b/spec/lib/sarif/semgrep_sarif_spec.rb
@@ -24,6 +24,7 @@ describe Sarif::SemgrepSarif do
         sarif_report = JSON.parse(report.to_sarif)
 
         result = sarif_report["runs"][0]["results"]
+
         expect(result).to include({
           "ruleId": "Forbidden Pattern Found",
           "ruleIndex": 0,

--- a/spec/lib/sarif/semgrep_sarif_spec.rb
+++ b/spec/lib/sarif/semgrep_sarif_spec.rb
@@ -22,6 +22,7 @@ describe Sarif::SemgrepSarif do
         report.add_scan_report(scanner.report, required: true)
 
         sarif_report = JSON.parse(report.to_sarif)
+
         result = sarif_report["runs"][0]["results"]
         expect(result).to include({
           "ruleId": "Forbidden Pattern Found",

--- a/spec/lib/sarif/semgrep_sarif_spec.rb
+++ b/spec/lib/sarif/semgrep_sarif_spec.rb
@@ -20,9 +20,7 @@ describe Sarif::SemgrepSarif do
         scanner.run
         report = Salus::Report.new(project_name: "Neon Genesis")
         report.add_scan_report(scanner.report, required: true)
-
         sarif_report = JSON.parse(report.to_sarif)
-
         result = sarif_report["runs"][0]["results"]
 
         expect(result).to include({
@@ -48,7 +46,8 @@ describe Sarif::SemgrepSarif do
                 }
               }
             }
-          ]
+          ],
+          "properties": {"severity": "HIGH"},
         }.deep_stringify_keys)
       end
 

--- a/spec/lib/sarif/semgrep_sarif_spec.rb
+++ b/spec/lib/sarif/semgrep_sarif_spec.rb
@@ -47,7 +47,7 @@ describe Sarif::SemgrepSarif do
               }
             }
           ],
-          "properties": {"severity": "HIGH"},
+          "properties": { "severity": "HIGH" }
         }.deep_stringify_keys)
       end
 

--- a/spec/lib/sarif/yarn_audit_sarif_spec.rb
+++ b/spec/lib/sarif/yarn_audit_sarif_spec.rb
@@ -7,10 +7,11 @@ describe Sarif::YarnAuditSarif do
     before { scanner.run }
 
     context 'scan report with logged vulnerabilites' do
-      let(:repo) { Salus::Repo.new('spec/fixtures/yarn_audit/failure-2') }
+      let(:path) { 'spec/fixtures/yarn_audit/failure-2' }
+      let(:repo) { Salus::Repo.new(path) }
       it 'parses information correctly' do
         issue = JSON.parse(scanner.report.to_h[:info][:stdout])[0]
-        yarn_sarif = Sarif::YarnAuditSarif.new(scanner.report)
+        yarn_sarif = Sarif::YarnAuditSarif.new(scanner.report, path)
 
         expect(yarn_sarif.parse_issue(issue)).to include(
           id: "39",
@@ -34,7 +35,8 @@ describe Sarif::YarnAuditSarif do
     before { scanner.run }
 
     context 'Yarn file with errors' do
-      let(:repo) { Salus::Repo.new('spec/fixtures/yarn_audit/failure-3') }
+      let(:path) { 'spec/fixtures/yarn_audit/failure-3' }
+      let(:repo) { Salus::Repo.new(path) }
       it 'should generate error in report' do
         report = Salus::Report.new(project_name: "Neon Genesis")
         report.add_scan_report(scanner.report, required: false)
@@ -82,10 +84,11 @@ describe Sarif::YarnAuditSarif do
     end
 
     context 'yarn.lock file with vulnerabilities having the same ID' do
-      let(:repo) { Salus::Repo.new('spec/fixtures/yarn_audit/failure-2') }
+      let(:path) { 'spec/fixtures/yarn_audit/failure-2' }
+      let(:repo) { Salus::Repo.new(path) }
       it 'should generate all identified vulnerabilities' do
         issue = JSON.parse(scanner.report.to_h[:info][:stdout])[0]
-        yarn_sarif = Sarif::YarnAuditSarif.new(scanner.report)
+        yarn_sarif = Sarif::YarnAuditSarif.new(scanner.report, path)
 
         issue2 = issue.clone
         issue2['Dependency of'] = 'random package'
@@ -100,7 +103,7 @@ describe Sarif::YarnAuditSarif do
   describe '#sarif_level' do
     it 'maps severities to the right sarif level' do
       scan_report = Salus::ScanReport.new('yarnaudit')
-      adapter = Sarif::YarnAuditSarif.new(scan_report)
+      adapter = Sarif::YarnAuditSarif.new(scan_report, './')
       expect(adapter.sarif_level("INFO")).to eq("note")
       expect(adapter.sarif_level("LOW")).to eq("note")
       expect(adapter.sarif_level("MODERATE")).to eq("warning")

--- a/spec/lib/sarif/yarn_audit_sarif_spec.rb
+++ b/spec/lib/sarif/yarn_audit_sarif_spec.rb
@@ -103,7 +103,7 @@ describe Sarif::YarnAuditSarif do
   describe '#sarif_level' do
     it 'maps severities to the right sarif level' do
       scan_report = Salus::ScanReport.new('yarnaudit')
-      adapter = Sarif::YarnAuditSarif.new(scan_report, './')
+      adapter = Sarif::YarnAuditSarif.new(scan_report)
       expect(adapter.sarif_level("INFO")).to eq("note")
       expect(adapter.sarif_level("LOW")).to eq("note")
       expect(adapter.sarif_level("MODERATE")).to eq("warning")


### PR DESCRIPTION
Added a properties bag with a severity entry to the SARIF results records:

```
    "results": [
        {
          "ruleId": "G101",
          "ruleIndex": 0,
          "level": "error",
          "message": {
            "text": "Potential hardcoded credentials \nSeverity: HIGH\nConfidence: LOW\nCWE: https://cwe.mitre.org/data/definitions/798.html"
          },
          "locations": [
            {
              "physicalLocation": {
                "artifactLocation": {
                  "uri": "hello.go",
                  "uriBaseId": "%SRCROOT%"
                },
                "region": {
                  "startLine": 11,
                  "startColumn": 2,
                  "snippet": {
                    "text": "10: \n11: \tpassword := \"hhend77dyyydbh&^psNSSZ)JSM--_%\"\n12: \n"
                  }
                }
              }
            }
          ],
          "properties": {
            "severity": "HIGH"
          }
        }]...
```

This will allow any downstream clients to have access to the raw (unmapped) scanner severity.

Also fixed an issue where the SARIF location values had the absolute (not relative) path to the offending files.

For example when scanning "/home/spec/fixtures/gosec/multiple_vulns2" for vulnerabilities the former URI of 
```
"uri": "/home/spec/fixtures/gosec/multiple_vulns2/hello.go"
```
will now be
```
"uri": "hello.go"
```
Which is correctly relative to the  
```
"uriBaseId": "%SRCROOT%"
```