### PR TITLE
Bump to 2.13.2

### DIFF
--- a/lib/salus.rb
+++ b/lib/salus.rb
@@ -13,7 +13,7 @@ require 'cyclonedx/report'
 require 'salus/report_request'
 
 module Salus
-  VERSION = '2.13.2'.freeze
+  VERSION = '2.13.3'.freeze
   DEFAULT_REPO_PATH = './repo'.freeze # This is inside the docker container at /home/repo.
 
   SafeYAML::OPTIONS[:default_mode] = :safe

--- a/spec/fixtures/integration/expected_report.json
+++ b/spec/fixtures/integration/expected_report.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.13.2",
+  "version": "2.13.3",
   "passed": true,
   "running_time": 0.0,
   "scans": {

--- a/spec/fixtures/processor/local_uri/expected_report.json
+++ b/spec/fixtures/processor/local_uri/expected_report.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.13.2",
+  "version": "2.13.3",
   "passed": true,
   "running_time": 0.0,
   "scans": {

--- a/spec/fixtures/processor/multiple_endpoints/expected_report.json
+++ b/spec/fixtures/processor/multiple_endpoints/expected_report.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.13.2",
+  "version": "2.13.3",
   "passed": true,
   "running_time": 0.0,
   "scans": {

--- a/spec/fixtures/processor/remote_uri/expected_report.json
+++ b/spec/fixtures/processor/remote_uri/expected_report.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.13.2",
+  "version": "2.13.3",
   "passed": true,
   "running_time": 0.0,
   "scans": {

--- a/spec/lib/salus/report_spec.rb
+++ b/spec/lib/salus/report_spec.rb
@@ -209,7 +209,7 @@ describe Salus::Report do
         report = build_report(directive)
 
         stub_request(:post, "https://nerv.tk3/salus-report").with(body: "{\n  \"foo\": \"bar\",\n"\
-          "  \"abc\": \"def\",\n  \"report\": {\n    \"version\": \"2.13.2\",\n    \"project_nam"\
+          "  \"abc\": \"def\",\n  \"report\": {\n    \"version\": \"2.13.3\",\n    \"project_nam"\
           "e\": \"eva00\",\n    \"passed\": false,\n    \"scans\": {\n      \"DerpScanner\": {\n "\
           "       \"scanner_name\": \"DerpScanner\",\n        \"passed\": false,\n        \"warn"\
           "\": {\n        },\n        \"info\": {\n          \"asdf\": \"qwerty\"\n        },\n "\
@@ -235,7 +235,7 @@ describe Salus::Report do
         report = build_report(directive)
 
         stub_request(:post, "https://nerv.tk3/salus-report").with(body: "---\nfoo: bar\nabc: def\n"\
-          "report:\n  :version: 2.13.2\n  :project_name: eva00\n  :passed: false\n  :scans:\n    "\
+          "report:\n  :version: 2.13.3\n  :project_name: eva00\n  :passed: false\n  :scans:\n    "\
           "DerpScanner:\n      :scanner_name: DerpScanner\n      :passed: false\n      :warn: {}\n"\
           "      :info:\n        :asdf: qwerty\n      :errors: []\n  :errors:\n  - :message: derp"\
           "\n  - :message: derp\n  - :message: derp\n  - :message: derp\n  - :message: derp\n  "\
@@ -260,7 +260,7 @@ describe Salus::Report do
         report.instance_variable_set(:@config, config)
 
         stub_request(:post, "https://nerv.tk3/salus-report").with(body: "{\"foo\"=>\"bar\", \"abc"\
-          "\"=>\"def\", \"report\"=>\"==== Salus Scan v2.13.2 for eva00\\n\\n==== Salus "\
+          "\"=>\"def\", \"report\"=>\"==== Salus Scan v2.13.3 for eva00\\n\\n==== Salus "\
           "Configuration Files Used:\\n\\n  word\\n\\n\\n==== Salus Errors\\n\\n  [\\n    {\\n    "\
           "  \\\"message\\\": \\\"derp\\\"\\n    },\\n    {\\n      \\\"message\\\": \\\"derp\\"\
           "\"\\n    },\\n    {\\n      \\\"message\\\": \\\"derp\\\"\\n    },\\n    {\\n      "\


### PR DESCRIPTION
https://github.com/coinbase/salus/pull/458

Added:
Properties.severity in SARIF result entries.  This field contains the raw scanner severity.

Fixed:
SARIF location URIs are now properly relative.