### PR TITLE
fix wrong brakeman raw severity in sarif

### DIFF
--- a/lib/sarif/brakeman_sarif.rb
+++ b/lib/sarif/brakeman_sarif.rb
@@ -49,7 +49,7 @@ module Sarif
                           "warning_code": { "text": (issue['warning_code']).to_s } },
         properties: { 'fingerprint': issue['fingerprint'].to_s,
                       'confidence': issue['confidence'].to_s,
-                      'severity': issue['confidence'].to_s,
+                      'severity': "",
                       'render_path': issue['render_path'].to_s,
                       'user_input': issue['user_input'].to_s,
                       'location_type': issue.dig('location', 'type').to_s,

--- a/spec/lib/sarif/brakeman_sarif_spec.rb
+++ b/spec/lib/sarif/brakeman_sarif_spec.rb
@@ -32,7 +32,7 @@ describe Sarif::BrakemanSarif do
           properties: {
             fingerprint: "b16e1cd0d952433f80b0403b6a74aab0e98792ea015cc1b1fa5c003cbe7d56eb",
             confidence: "High",
-            severity: "High",
+            severity: "",
             render_path: "",
             user_input: "params[:evil]",
             location_type: "method",


### PR DESCRIPTION
Fix wrong brakeman raw severity in sarif.
The original code set the severity to the confidence level.
The new code sets it to empty string because brakeman does not currently output severity level.