### PR TITLE
support sending sarif_diff_full to uris

### DIFF
--- a/lib/salus/report_request.rb
+++ b/lib/salus/report_request.rb
@@ -8,11 +8,13 @@ module Salus
       'txt'  => 'text/plain',
       'sarif' => 'application/json',
       'sarif_diff' => 'application/json',
+      'sarif_diff_full' => 'application/json',
       'cyclonedx-json' => 'application/json'
     }.freeze
 
     FORMAT_SARIF_DIFF = "sarif_diff".freeze
     FORMAT_SARIF = "sarif".freeze
+    FORMAT_SARIF_DIFF_FULL = "sarif_diff_full".freeze
     SCANNER_TYPE_SARIF_DIFF = "salus_sarif_diff".freeze
     SCANNER_TYPE_SARIF = "salus_sarif".freeze
     SCANNER_TYPE_SALUS = "salus".freeze
@@ -43,7 +45,7 @@ module Salus
 
       def x_scanner_type(format)
         return SCANNER_TYPE_SARIF_DIFF if format == FORMAT_SARIF_DIFF
-        return SCANNER_TYPE_SARIF if format == FORMAT_SARIF
+        return SCANNER_TYPE_SARIF if [FORMAT_SARIF, FORMAT_SARIF_DIFF_FULL].include?(format)
 
         SCANNER_TYPE_SALUS
       end

--- a/spec/lib/salus/report_spec.rb
+++ b/spec/lib/salus/report_spec.rb
@@ -275,6 +275,7 @@ describe Salus::Report do
           'X-Scanner' => 'salus' }).to_return(status: 200, body: "", headers: {})
         expect { report.export_report }.not_to raise_error
       end
+
       it 'should make a call to send the sarif report for http URI' do
         url = 'https://nerv.tk3/salus-report'
         params = { 'salus_report_param_name' => 'report',
@@ -297,6 +298,36 @@ describe Salus::Report do
         ).to_return(status: 200, body: "", headers: {})
 
         expect(report).to receive(:to_sarif).with(options).and_call_original.twice
+        expect { report.export_report }.not_to raise_error
+      end
+
+      it 'should make a call to send the sarif_diff_full report for http URI' do
+        url = 'https://nerv.tk3/salus-report'
+        params = { 'salus_report_param_name' => 'report',
+          'additional_params' => { "foo" => "bar", "abc" => "def" } }
+        options = { 'foo' => 'bar' }
+        directive = { 'uri' => url, 'format' => 'sarif_diff_full', 'post' => params,
+                      'verbose': false, 'sarif_options' => options }
+        report = build_report(directive)
+        report.instance_variable_set(:@scan_reports, [])
+        content = { "version": "2.1.0",
+                    "$schema": "https://docs.oasis-open.org/sarif/sarif/v2.1.0/csprd01/" \
+                               "schemas/sarif-schema-2.1.0",
+                "runs": [] }
+        report.instance_variable_set(:@full_diff_sarif, content)
+
+        stub_request(:post, "https://nerv.tk3/salus-report").with(
+          body: "{\n  \"foo\": \"bar\",\n  \"abc\": \"def\",\n  \"report\": {\n    \"version\": "\
+          "\"2.1.0\",\n    \"$schema\": \"https://docs.oasis-open.org/sarif/sarif/v2.1.0/csprd01/"\
+          "schemas/sarif-schema-2.1.0\",\n    \"runs\": [\n\n    ]\n  }\n}",
+          headers: { 'Accept' => '*/*',
+            'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+            'Content-Type' => 'application/json',
+            'User-Agent' => 'Faraday v1.3.0',
+            'X-Scanner' => 'salus_sarif' }
+        ).to_return(status: 200, body: "", headers: {})
+
+        expect(report).to receive(:to_full_sarif_diff).and_call_original.twice
         expect { report.export_report }.not_to raise_error
       end
     end
@@ -346,6 +377,8 @@ describe Salus::Report do
         expect(report.x_scanner_type('json')).to eq('salus')
         expect(report.x_scanner_type('yaml')).to eq('salus')
         expect(report.x_scanner_type('sarif_diff')).to eq('salus_sarif_diff')
+        expect(report.x_scanner_type('sarif')).to eq('salus_sarif')
+        expect(report.x_scanner_type('sarif_diff_full')).to eq('salus_sarif')
       end
     end
   end


### PR DESCRIPTION
Support sending full diff sarifs to uri's.  We only supported sending full diff sarifs to local files before.

Tested with new unit tests and sending full diff sarifs to internal uri's.