### PR TITLE
Allow production option to npm audit command

### DIFF
--- a/lib/salus/scanners/npm_audit.rb
+++ b/lib/salus/scanners/npm_audit.rb
@@ -25,8 +25,14 @@ module Salus::Scanners
 
     private
 
+    def audit_command_with_options
+      command = AUDIT_COMMAND
+      command += " --production" if @config["production"] == true
+      command
+    end
+
     def scan_for_cves
-      raw = run_shell(AUDIT_COMMAND).stdout
+      raw = run_shell(audit_command_with_options).stdout
       json = JSON.parse(raw, symbolize_names: true)
 
       if json.key?(:error)
@@ -34,7 +40,7 @@ module Salus::Scanners
         summary = json[:error][:summary] || '<none>'
 
         message =
-          "`#{AUDIT_COMMAND}` failed unexpectedly (error code #{code}):\n" \
+          "`#{audit_command_with_options}` failed unexpectedly (error code #{code}):\n" \
           "```\n#{summary}\n```"
 
         raise message

--- a/spec/lib/salus/scanners/npm_audit_spec.rb
+++ b/spec/lib/salus/scanners/npm_audit_spec.rb
@@ -29,6 +29,20 @@ describe Salus::Scanners::NPMAudit do
     end
   end
 
+  describe '#audit_command_with_options' do
+    it 'should return default audit command if no options have been provided' do
+      repo = Salus::Repo.new("dir")
+      scanner = Salus::Scanners::NPMAudit.new(repository: repo, config: {})
+      expect(scanner.send(:audit_command_with_options)).to eql("npm audit --json")
+    end
+
+    it 'should return audit command with configured options' do
+      repo = Salus::Repo.new("dir")
+      scanner = Salus::Scanners::NPMAudit.new(repository: repo, config: { "production" => true })
+      expect(scanner.send(:audit_command_with_options)).to eql("npm audit --json --production")
+    end
+  end
+
   describe '#supported_languages' do
     context 'should return supported languages' do
       it 'should return javascript' do


### PR DESCRIPTION
In this PR, we can allow the users to provide options to "npm aduit" command. For now, "--production" can be added to the command by mentioning "production: true" in the config file.