### PR TITLE
Support for files and not-followed-within in PatternSearch config.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ RUN pip install wheel \
 # ruby gems
 COPY Gemfile Gemfile.lock /home/
 RUN cd /home \
-  && gem install bundler -v '2.2.19' \
+  && gem install bundler -v '2.3.1' \
   && gem update --system \
   && bundle install --deployment --no-cache --clean --with scanners \
   && bundle exec bundle audit update
@@ -177,7 +177,7 @@ COPY lib /home/lib
 COPY salus-default.yaml /home/
 
 # install salus dependencies
-RUN gem install bundler -v'2.2.19' \
+RUN gem install bundler -v'2.3.1' \
   && bundle config --local path vendor/bundle \
   && bundle config --local without development:test
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ RUN pip install wheel \
 # ruby gems
 COPY Gemfile Gemfile.lock /home/
 RUN cd /home \
-  && gem install bundler -v '2.3.1' \
+  && gem install bundler -v '2.2.19' \
   && gem update --system \
   && bundle install --deployment --no-cache --clean --with scanners \
   && bundle exec bundle audit update
@@ -177,7 +177,7 @@ COPY lib /home/lib
 COPY salus-default.yaml /home/
 
 # install salus dependencies
-RUN gem install bundler -v'2.3.1' \
+RUN gem install bundler -v'2.2.19' \
   && bundle config --local path vendor/bundle \
   && bundle config --local without development:test
 

--- a/docs/scanners/pattern_search.md
+++ b/docs/scanners/pattern_search.md
@@ -9,7 +9,7 @@ The scanner also allows the options below.  These options can be set globally an
 * `exclude_extension` and `include_extension` for excluding and including file extensions, respectively. While these options can be combined, exclusions take precedence when extensions conflict (are both included and excluded) in declarations.
 * `exclude_directory` for excluding directories whose name matches GLOB.  It appears that sift does not support `/`s in the directory name.
 * `exclude_filepaths` for excluding file paths. Note the file paths must be regular paths, not GLOB, and cannot include regular expressions.
-* `not_followed_within` for only show matches not followed by PATTERN within NUM lines. The value must have the format `NUM:PATTERN`.
+* `not_followed_within` for only showing matches not followed by PATTERN within NUM lines. The value must have the format `NUM:PATTERN`. Use 0 for excluding on the same line.
 * `files` for search only files whose name matches GLOB.
 
 ## Configuration

--- a/docs/scanners/pattern_search.md
+++ b/docs/scanners/pattern_search.md
@@ -9,7 +9,8 @@ The scanner also allows the options below.  These options can be set globally an
 * `exclude_extension` and `include_extension` for excluding and including file extensions, respectively. While these options can be combined, exclusions take precedence when extensions conflict (are both included and excluded) in declarations.
 * `exclude_directory` for excluding directories whose name matches GLOB.  It appears that sift does not support `/`s in the directory name.
 * `exclude_filepaths` for excluding file paths. Note the file paths must be regular paths, not GLOB, and cannot include regular expressions.
-
+* `not_followed_within` for only show matches not followed by PATTERN within NUM lines. The value must have the format `NUM:PATTERN`.
+* `files` for search only files whose name matches GLOB.
 
 ## Configuration
 
@@ -30,6 +31,10 @@ scanner_configs:
           - erb
           - html
           - htm
+        not_followed_within: 0:my_pattern
+        files:
+          - a.js
+          - b.js
       - regex: "# Threat Model"
         message: All repos must contain a documented threat model.
         required: true

--- a/lib/salus/scanners/pattern_search.rb
+++ b/lib/salus/scanners/pattern_search.rb
@@ -63,6 +63,13 @@ module Salus::Scanners
             *(match_include_extension_flags || global_include_extension_flags)
           ].compact
 
+          not_followed_within = match["not_followed_within"]
+          command_array += ['--not-followed-within', not_followed_within] if not_followed_within
+          files = match['files']
+          files&.each do |file|
+            command_array += ['--files', file]
+          end
+
           shell_return = run_shell(command_array)
           # Set defaults.
           match['forbidden'] ||= false

--- a/spec/fixtures/pattern_search/test_paths3/salus.yaml
+++ b/spec/fixtures/pattern_search/test_paths3/salus.yaml
@@ -1,0 +1,6 @@
+scanner_configs:
+  PatternSearch:
+    matches:
+      - regex: hello
+        forbidden: true
+        not_followed_within: 0:bye

--- a/spec/fixtures/pattern_search/test_paths3/test.txt
+++ b/spec/fixtures/pattern_search/test_paths3/test.txt
@@ -1,0 +1,2 @@
+hello world
+hello bye

--- a/spec/fixtures/pattern_search/test_paths4/salus.yaml
+++ b/spec/fixtures/pattern_search/test_paths4/salus.yaml
@@ -1,0 +1,9 @@
+scanner_configs:
+  PatternSearch:
+    matches:
+      - regex: hello
+        forbidden: true
+        not_followed_within: 0:bye
+        files:
+          - "*.txt"
+          - "*.py"

--- a/spec/fixtures/pattern_search/test_paths4/salus2.yaml
+++ b/spec/fixtures/pattern_search/test_paths4/salus2.yaml
@@ -1,0 +1,11 @@
+scanner_configs:
+  PatternSearch:
+    matches:
+      - regex: hello
+        forbidden: true
+        not_followed_within: 0:bye
+        files:
+          - "*.txt"
+          - "*.py"
+        exclude_filepaths:
+          - test.txt

--- a/spec/fixtures/pattern_search/test_paths4/test.py
+++ b/spec/fixtures/pattern_search/test_paths4/test.py
@@ -1,0 +1,2 @@
+hello world
+

--- a/spec/fixtures/pattern_search/test_paths4/test.rb
+++ b/spec/fixtures/pattern_search/test_paths4/test.rb
@@ -1,0 +1,2 @@
+hello world
+

--- a/spec/fixtures/pattern_search/test_paths4/test.txt
+++ b/spec/fixtures/pattern_search/test_paths4/test.txt
@@ -1,0 +1,2 @@
+hello world
+

--- a/spec/lib/salus/scanners/pattern_search_spec.rb
+++ b/spec/lib/salus/scanners/pattern_search_spec.rb
@@ -375,7 +375,7 @@ describe Salus::Scanners::PatternSearch do
         )
       end
 
-      it '--exclude_filepaths should override --files' do
+      it '--exclude_filepaths should work with --files' do
         config_file = "#{repo_dir}/salus2.yaml"
         repo = Salus::Repo.new(repo_dir)
         configs = Salus::Config.new([File.read(config_file)]).scanner_configs['PatternSearch']

--- a/spec/lib/salus/scanners/pattern_search_spec.rb
+++ b/spec/lib/salus/scanners/pattern_search_spec.rb
@@ -326,6 +326,73 @@ describe Salus::Scanners::PatternSearch do
       end
     end
 
+    context 'not_followed_within is used' do
+      let(:repo_dir) { "spec/fixtures/pattern_search/test_paths3" }
+      it 'not_followed_within should filter out files when possible' do
+        config_file = "#{repo_dir}/salus.yaml"
+        repo = Salus::Repo.new(repo_dir)
+        configs = Salus::Config.new([File.read(config_file)]).scanner_configs['PatternSearch']
+        scanner = Salus::Scanners::PatternSearch.new(repository: repo, config: configs)
+        scanner.run
+        expect(scanner.report.passed?).to eq(false)
+
+        info = scanner.report.to_h.fetch(:info)
+        # In salus.yaml, "not_followed_within: 0:bye" filters out the "hello bye" in results
+        expect(info[:hits]).to eq([{ regex: 'hello',
+                                    forbidden: true,
+                                    required: false,
+                                    msg: '',
+                                    hit: 'test.txt:1:hello world' }])
+      end
+    end
+
+    context '--files is used' do
+      let(:repo_dir) { "spec/fixtures/pattern_search/test_paths4" }
+      it 'results should only include files matching --files' do
+        config_file = "#{repo_dir}/salus.yaml"
+        repo = Salus::Repo.new(repo_dir)
+        configs = Salus::Config.new([File.read(config_file)]).scanner_configs['PatternSearch']
+        scanner = Salus::Scanners::PatternSearch.new(repository: repo, config: configs)
+        scanner.run
+        expect(scanner.report.passed?).to eq(false)
+
+        info = scanner.report.to_h.fetch(:info)
+        # results include only the file names matching "files" in salus.yaml
+        expect(info[:hits].size).to eq(2)
+        expect(info[:hits]).to include(
+          regex: 'hello',
+          forbidden: true,
+          required: false,
+          msg: '',
+          hit: 'test.txt:1:hello world'
+        )
+        expect(info[:hits]).to include(
+          regex: 'hello',
+          forbidden: true,
+          required: false,
+          msg: '',
+          hit: 'test.py:1:hello world'
+        )
+      end
+
+      it '--exclude_filepaths should override --files' do
+        config_file = "#{repo_dir}/salus2.yaml"
+        repo = Salus::Repo.new(repo_dir)
+        configs = Salus::Config.new([File.read(config_file)]).scanner_configs['PatternSearch']
+        scanner = Salus::Scanners::PatternSearch.new(repository: repo, config: configs)
+        scanner.run
+        expect(scanner.report.passed?).to eq(false)
+
+        info = scanner.report.to_h.fetch(:info)
+        # salus config excludes txt
+        expect(info[:hits]).to eq([{ regex: 'hello',
+                                    forbidden: true,
+                                    required: false,
+                                    msg: '',
+                                    hit: 'test.py:1:hello world' }])
+      end
+    end
+
     context 'exclude filepaths are given' do
       let(:repo_dir) { "spec/fixtures/pattern_search/test_paths" }
 


### PR DESCRIPTION
Support for `files` and `not_followed_within` in PatternSearch config.

Sift doc:
```
--files=GLOB                           search only files whose name matches GLOB
--not-followed-within=NUM:PATTERN      only show matches not followed by PATTERN within NUM lines
```