### PR TITLE
Add ruby license scanner

### DIFF
--- a/lib/cyclonedx/report_ruby_gems_cyclonedx.rb
+++ b/lib/cyclonedx/report_ruby_gems_cyclonedx.rb
@@ -6,5 +6,17 @@ module Cyclonedx
     def initialize(scan_report, config = {})
       super(scan_report, config)
     end
+
+    def build_component(dependency)
+      super.merge({
+                    "licenses": licenses_for(dependency)
+                  })
+    end
+
+    def licenses_for(dependency)
+      return [] if dependency[:licenses].nil?
+
+      dependency[:licenses].map { |license| { "license" => { "id" => license } } }
+    end
   end
 end

--- a/lib/salus/dice_coefficient.rb
+++ b/lib/salus/dice_coefficient.rb
@@ -1,0 +1,23 @@
+module Salus
+  class DiceCoefficient
+    # source: https://en.wikibooks.org/wiki/Algorithm_Implementation/Strings/Dice%27s_coefficient
+    # Dice co-efficient can be used for measuring the similarity of two strings
+    # bigram: A bigram or digram is a sequence of two adjacent elements
+    #         from a string of tokens, which are typically letters,
+    #         syllables, or words.
+    #         For example, bigram of a string ('hello') can be written as the following requence
+    #         [["h", "e"], ["e", "l"], ["l", "l"], ["l", "o"]]
+    #
+    # dice coefficient = bigram overlap * 2 / (bigrams in a + bigrams in b)
+    def self.dice(string_a, string_b)
+      a_bigrams = string_a.each_char.each_cons(2).to_a
+      b_bigrams = string_b.each_char.each_cons(2).to_a
+
+      overlap = (a_bigrams & b_bigrams).size
+
+      total = a_bigrams.size + b_bigrams.size
+
+      overlap * 2.0 / total
+    end
+  end
+end

--- a/lib/salus/scanners/report_ruby_gems.rb
+++ b/lib/salus/scanners/report_ruby_gems.rb
@@ -1,9 +1,17 @@
 require 'salus/scanners/base'
+require 'salus/dice_coefficient'
+require 'uri'
+require 'net/http'
 
 # Report the use of any Ruby gems.
-
 module Salus::Scanners
   class ReportRubyGems < Base
+    class RubyGemsApiError < StandardError; end
+    class ApiTooManyRequestsError < StandardError; end
+
+    SPDX_SCHEMA_FILE = 'lib/cyclonedx/schema/spdx.schema.json'.freeze
+    MAX_RETRIES_FOR_RUBY_GEMS_API = 2
+
     def run
       # A lockfile is the most definitive source of truth for what will run
       # in production. It also lists the dependencies of dependencies.
@@ -76,8 +84,80 @@ module Salus::Scanners
         type: 'gem',
         name: name,
         version: version,
-        source: source
+        source: source,
+        licenses: find_licenses_for(name, version)
       )
+    end
+
+    def find_licenses_for(gem_name, version)
+      res = send_request_to(ruby_gems_uri_for(gem_name, version))
+
+      return [] if res.nil?
+      return [] if res.is_a?(Net::HTTPNotFound)
+
+      raise RubyGemsApiError, res.body unless res.is_a?(Net::HTTPSuccess)
+
+      licenses = JSON.parse(res.body)['licenses']
+      licenses.map { |license| spdx_license_for(license) }
+    rescue RubyGemsApiError, StandardError => e
+      msg = "Unable to gather license information " \
+        "using rubygems api " \
+        "with error message #{e.class}: #{e.message}"
+      bugsnag_notify(msg)
+
+      []
+    end
+
+    # Send request to rubygems-org-api-v2
+    # with exponential backoff
+    def send_request_to(ruby_gems_uri)
+      retries = 0
+
+      begin
+        res = Net::HTTP.get_response(ruby_gems_uri)
+
+        raise ApiTooManyRequestsError if res.is_a?(Net::HTTPTooManyRequests)
+
+        res
+      rescue ApiTooManyRequestsError
+        if retries < MAX_RETRIES_FOR_RUBY_GEMS_API
+          retries += 1
+          max_sleep_seconds = Float(2**retries)
+          sleep rand(0..max_sleep_seconds)
+          retry
+        else
+          msg = "Too many requests for rubygems api after " \
+            "#{retries} retries"
+          bugsnag_notify(msg)
+
+          nil
+        end
+      end
+    end
+
+    def ruby_gems_uri_for(gem_name, version)
+      URI("https://rubygems.org/api/v2/rubygems/#{gem_name}/versions/#{version}.json")
+    end
+
+    # Compares reported license with spdx licenses and returns closest match
+    def spdx_license_for(license)
+      @spdx_license_cache ||= {}
+
+      @spdx_license_cache[license] ||=
+        begin
+          licenses_with_cof = spdx_formatted_licenses.each_with_object({}) do |spdx_license, memo|
+            memo[spdx_license] = Salus::DiceCoefficient.dice(license, spdx_license)
+          end
+
+          licenses_with_cof.max_by { |_, co_efficient| co_efficient }&.first
+        end
+
+      @spdx_license_cache[license]
+    end
+
+    def spdx_formatted_licenses
+      @spdx_formatted_licenses ||= JSON.parse(File.read(SPDX_SCHEMA_FILE))["enum"]
+      @spdx_formatted_licenses
     end
   end
 end

--- a/spec/lib/cyclonedx/cyclonedx_report_spec.rb
+++ b/spec/lib/cyclonedx/cyclonedx_report_spec.rb
@@ -3,6 +3,12 @@ require 'json'
 require 'json-schema'
 
 describe Cyclonedx::ReportRubyGems do
+  before do
+    allow_any_instance_of(Salus::Scanners::ReportRubyGems)
+      .to receive(:find_licenses_for)
+      .and_return(['MIT'])
+  end
+
   let(:scan_reports) { [] }
 
   describe "to_cyclonedx schema validation" do
@@ -67,7 +73,8 @@ describe Cyclonedx::ReportRubyGems do
           "group": "",
           "name": "actioncable",
           "version": "5.1.2",
-          "purl": "pkg:gem/actioncable@5.1.2"
+          "purl": "pkg:gem/actioncable@5.1.2",
+          "licenses": [{ "license" => { "id" => "MIT" } }]
         },
         {
           "bom-ref": "pkg:gem/actionmailer@5.1.2",
@@ -75,7 +82,8 @@ describe Cyclonedx::ReportRubyGems do
           "group": "",
           "name": "actionmailer",
           "version": "5.1.2",
-          "purl": "pkg:gem/actionmailer@5.1.2"
+          "purl": "pkg:gem/actionmailer@5.1.2",
+          "licenses": [{ "license" => { "id" => "MIT" } }]
         },
         {
           "bom-ref": "pkg:gem/actionpack@5.1.2",
@@ -83,7 +91,8 @@ describe Cyclonedx::ReportRubyGems do
           "group": "",
           "name": "actionpack",
           "version": "5.1.2",
-          "purl": "pkg:gem/actionpack@5.1.2"
+          "purl": "pkg:gem/actionpack@5.1.2",
+          "licenses": [{ "license" => { "id" => "MIT" } }]
         }
       ]
       expect(ruby_cyclonedx.build_components_object).to include(*expected)
@@ -100,6 +109,7 @@ describe Cyclonedx::ReportRubyGems do
           "bom-ref": "pkg:gem/actioncable@5.1.2",
           "type": "library",
           "group": "",
+          "licenses": [{ "license" => { "id" => "MIT" } }],
           "name": "actioncable",
           "version": "5.1.2",
           "purl": "pkg:gem/actioncable@5.1.2",
@@ -118,6 +128,7 @@ describe Cyclonedx::ReportRubyGems do
           "bom-ref": "pkg:gem/actionmailer@5.1.2",
           "type": "library",
           "group": "",
+          "licenses": [{ "license" => { "id" => "MIT" } }],
           "name": "actionmailer",
           "version": "5.1.2",
           "purl": "pkg:gem/actionmailer@5.1.2",
@@ -136,6 +147,7 @@ describe Cyclonedx::ReportRubyGems do
           "bom-ref": "pkg:gem/actionpack@5.1.2",
           "type": "library",
           "group": "",
+          "licenses": [{ "license" => { "id" => "MIT" } }],
           "name": "actionpack",
           "version": "5.1.2",
           "purl": "pkg:gem/actionpack@5.1.2",

--- a/spec/lib/cyclonedx/report_ruby_gems_cyclonedx_spec.rb
+++ b/spec/lib/cyclonedx/report_ruby_gems_cyclonedx_spec.rb
@@ -2,6 +2,12 @@ require_relative '../../spec_helper'
 require 'json'
 
 describe Cyclonedx::ReportRubyGems do
+  before do
+    allow_any_instance_of(Salus::Scanners::ReportRubyGems)
+      .to receive(:find_licenses_for)
+      .and_return(['MIT'])
+  end
+
   describe "#run" do
     it 'should report all the deps in the Gemfile if Gemfile.lock is absent in cyclonedx' do
       repo = Salus::Repo.new('spec/fixtures/report_ruby_gems/gemfile_only')
@@ -15,6 +21,7 @@ describe Cyclonedx::ReportRubyGems do
             "bom-ref": "pkg:gem/kibana_url",
             "type": "library",
             "group": "",
+            "licenses": [{ "license" => { "id" => "MIT" } }],
             "name": "kibana_url",
             "version": "~> 1.0",
             "purl": "pkg:gem/kibana_url",
@@ -33,6 +40,7 @@ describe Cyclonedx::ReportRubyGems do
             "bom-ref": "pkg:gem/rails",
             "type": "library",
             "group": "",
+            "licenses": [{ "license" => { "id" => "MIT" } }],
             "name": "rails",
             "version": ">= 0",
             "purl": "pkg:gem/rails",
@@ -51,6 +59,7 @@ describe Cyclonedx::ReportRubyGems do
             "bom-ref": "pkg:gem/master_lock",
             "type": "library",
             "group": "",
+            "licenses": [{ "license" => { "id" => "MIT" } }],
             "name": "master_lock",
             "version": ">= 0",
             "purl": "pkg:gem/master_lock",
@@ -80,6 +89,7 @@ describe Cyclonedx::ReportRubyGems do
           "bom-ref": "pkg:gem/actioncable@5.1.2",
           "type": "library",
           "group": "",
+          "licenses": [{ "license" => { "id" => "MIT" } }],
           "name": "actioncable",
           "version": "5.1.2",
           "purl": "pkg:gem/actioncable@5.1.2",
@@ -98,6 +108,7 @@ describe Cyclonedx::ReportRubyGems do
           "bom-ref": "pkg:gem/actionmailer@5.1.2",
           "type": "library",
           "group": "",
+          "licenses": [{ "license" => { "id" => "MIT" } }],
           "name": "actionmailer",
           "version": "5.1.2",
           "purl": "pkg:gem/actionmailer@5.1.2",
@@ -116,6 +127,7 @@ describe Cyclonedx::ReportRubyGems do
           "bom-ref": "pkg:gem/actionpack@5.1.2",
           "type": "library",
           "group": "",
+          "licenses": [{ "license" => { "id" => "MIT" } }],
           "name": "actionpack",
           "version": "5.1.2",
           "purl": "pkg:gem/actionpack@5.1.2",
@@ -134,6 +146,7 @@ describe Cyclonedx::ReportRubyGems do
           "bom-ref": "pkg:gem/nio4r@2.1.0",
           "type": "library",
           "group": "",
+          "licenses": [{ "license" => { "id" => "MIT" } }],
           "name": "nio4r",
           "version": "2.1.0",
           "purl": "pkg:gem/nio4r@2.1.0",
@@ -152,6 +165,7 @@ describe Cyclonedx::ReportRubyGems do
           "bom-ref": "pkg:gem/kibana_url@1.0.1",
           "type": "library",
           "group": "",
+          "licenses": [{ "license" => { "id" => "MIT" } }],
           "name": "kibana_url",
           "version": "1.0.1",
           "purl": "pkg:gem/kibana_url@1.0.1",
@@ -170,6 +184,7 @@ describe Cyclonedx::ReportRubyGems do
           "bom-ref": "pkg:gem/master_lock@0.9.1",
           "type": "library",
           "group": "",
+          "licenses": [{ "license" => { "id" => "MIT" } }],
           "name": "master_lock",
           "version": "0.9.1",
           "purl": "pkg:gem/master_lock@0.9.1",
@@ -199,6 +214,7 @@ describe Cyclonedx::ReportRubyGems do
           "bom-ref": "pkg:gem/dep1@0.0.47",
           "type": "library",
           "group": "",
+          "licenses": [{ "license" => { "id" => "MIT" } }],
           "name": "dep1",
           "version": "0.0.47",
           "purl": "pkg:gem/dep1@0.0.47",
@@ -217,6 +233,7 @@ describe Cyclonedx::ReportRubyGems do
           "bom-ref": "pkg:gem/dep2@0.15.3",
           "type": "library",
           "group": "",
+          "licenses": [{ "license" => { "id" => "MIT" } }],
           "name": "dep2",
           "version": "0.15.3",
           "purl": "pkg:gem/dep2@0.15.3",
@@ -235,6 +252,7 @@ describe Cyclonedx::ReportRubyGems do
           "bom-ref": "pkg:gem/minitest@5.14.4",
           "type": "library",
           "group": "",
+          "licenses": [{ "license" => { "id" => "MIT" } }],
           "name": "minitest",
           "version": "5.14.4",
           "purl": "pkg:gem/minitest@5.14.4",

--- a/spec/lib/salus/dice_coefficient_spec.rb
+++ b/spec/lib/salus/dice_coefficient_spec.rb
@@ -1,0 +1,24 @@
+require_relative '../../spec_helper.rb'
+
+describe Salus::DiceCoefficient do
+  let(:string_a) { 'hello' }
+  let(:string_b) { 'world' }
+  let(:string_c) { 'hello.' }
+  let(:string_d) { 'ioklo' }
+
+  it 'should return 1.0 if two strings are same' do
+    expect(described_class.dice(string_a, string_a)).to eql(1.0)
+  end
+
+  it 'should return 0.0 if two strings are completely different' do
+    expect(described_class.dice(string_a, string_b)).to eql(0.0)
+  end
+
+  it 'should return higher value if two strings are very similar' do
+    expect(described_class.dice(string_a, string_c)).to be > 0.8
+  end
+
+  it 'should return lower value if two strings are less similar' do
+    expect(described_class.dice(string_a, string_d)).to be < 0.3
+  end
+end

--- a/spec/lib/salus/processor_spec.rb
+++ b/spec/lib/salus/processor_spec.rb
@@ -29,6 +29,12 @@ RSpec::Matchers.define :match_cyclonedx_report_json do |expected|
 end
 
 describe Salus::Processor do
+  before do
+    allow_any_instance_of(Salus::Scanners::ReportRubyGems)
+      .to receive(:find_licenses_for)
+      .and_return(['MIT'])
+  end
+
   describe '#initialize' do
     let(:config_file_path) { 'spec/fixtures/processor/repo/salus.yaml' }
     let(:config_file)      { File.read(config_file_path) }

--- a/spec/lib/salus/scanners/report_ruby_gems_spec.rb
+++ b/spec/lib/salus/scanners/report_ruby_gems_spec.rb
@@ -2,6 +2,10 @@ require_relative '../../../spec_helper.rb'
 
 describe Salus::Scanners::ReportRubyGems do
   describe '#run' do
+    before do
+      allow_any_instance_of(described_class).to receive(:find_licenses_for).and_return(['MIT'])
+    end
+
     it 'should throw an error in the absence of Gemfile/Gemfile.lock' do
       repo = Salus::Repo.new('spec/fixtures/blank_repository')
       scanner = Salus::Scanners::ReportRubyGems.new(repository: repo, config: {})
@@ -28,21 +32,24 @@ describe Salus::Scanners::ReportRubyGems do
             type: 'gem',
             name: 'kibana_url',
             version: '~> 1.0',
-            source: 'https://rubygems.org/'
+            source: 'https://rubygems.org/',
+            licenses: ['MIT']
           },
           {
             dependency_file: 'Gemfile',
             type: 'gem',
             name: 'rails',
             version: '>= 0',
-            source: 'https://rubygems.org/'
+            source: 'https://rubygems.org/',
+            licenses: ['MIT']
           },
           {
             dependency_file: 'Gemfile',
             type: 'gem',
             name: 'master_lock',
             version: '>= 0',
-            source: 'git@github.com:coinbase/master_lock.git'
+            source: 'git@github.com:coinbase/master_lock.git',
+            licenses: ['MIT']
           }
         ]
       )
@@ -64,23 +71,122 @@ describe Salus::Scanners::ReportRubyGems do
           type: 'gem',
           name: 'actioncable',
           version: '5.1.2',
-          source: "locally installed gems"
+          source: "locally installed gems",
+          licenses: ['MIT']
         },
         {
           dependency_file: 'Gemfile.lock',
           type: 'gem',
           name: 'kibana_url',
           version: '1.0.1',
-          source: "locally installed gems"
+          source: "locally installed gems",
+          licenses: ['MIT']
         },
-        dependency_file: 'Gemfile.lock',
-        type: 'gem',
-        name: 'master_lock',
-        version: '0.9.1',
-        source: 'git@github.com:coinbase/master_lock.git'
+        {
+          dependency_file: 'Gemfile.lock',
+          type: 'gem',
+          name: 'master_lock',
+          version: '0.9.1',
+          source: 'git@github.com:coinbase/master_lock.git',
+          licenses: ['MIT']
+        }
       ]
 
       expect(info[:dependencies]).to include(*expected)
+    end
+  end
+
+  describe '#find_licenses_for' do
+    let(:repo) { Salus::Repo.new('spec/fixtures/report_ruby_gems/lockfile') }
+    let(:scanner) { Salus::Scanners::ReportRubyGems.new(repository: repo, config: {}) }
+    let(:gem_name) { 'bundler-audit' }
+    let(:gem_version) { '0.8.0' }
+    let(:gem_license) { 'MIT' }
+
+    let(:ok_code) { 200 }
+    let(:not_found_code) { 404 }
+    let(:internal_server_error_code) { 500 }
+    let(:too_many_req_error_code) { 429 }
+
+    let(:request_str) do
+      "https://rubygems.org/api/v2/rubygems/#{gem_name}/versions/#{gem_version}.json"
+    end
+
+    let(:response_body) do
+      "{\"name\":\"#{gem_name}\",\"version\":\"#{gem_version}\",\"licenses\":[\"MIT\"]}"
+    end
+
+    let(:response_body_with_no_license) do
+      "{\"name\":\"#{gem_name}\",\"version\":\"#{gem_version}\",\"licenses\":[]}"
+    end
+
+    def stub_req_with(request_str, response_body, response_status)
+      stub_request(:get, request_str)
+        .with(
+          headers: {
+            'Accept' => '*/*',
+            'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+            'Host' => 'rubygems.org',
+            'User-Agent' => 'Ruby'
+          }
+        )
+        .to_return(status: response_status, body: response_body, headers: {})
+    end
+
+    context 'with successful request' do
+      it 'should return a list of valid licenses' do
+        stub_req_with(request_str, response_body, ok_code)
+        expect(scanner.send(:find_licenses_for, gem_name,
+                            gem_version)).to include(gem_license)
+      end
+
+      it 'should return an empty array if there exists no license' do
+        stub_req_with(request_str, response_body_with_no_license, ok_code)
+        expect(scanner.send(:find_licenses_for, gem_name,
+                            gem_version)).to be_empty
+      end
+    end
+
+    it 'should return an empty array if there occurs too many requests' do
+      msg = "Too many requests for rubygems api after " \
+        "#{described_class::MAX_RETRIES_FOR_RUBY_GEMS_API} retries"
+      stub_req_with(request_str, '', too_many_req_error_code)
+
+      expect_any_instance_of(described_class).to receive(:bugsnag_notify).with(msg)
+      expect(scanner.send(:find_licenses_for, gem_name,
+                          gem_version)).to be_empty
+    end
+
+    it 'should return an empty array if the gem does not exist' do
+      stub_req_with(request_str, '', not_found_code)
+      expect(scanner.send(:find_licenses_for, gem_name,
+                          gem_version)).to be_empty
+    end
+
+    it 'should return an empty array if there is an error in the api call to rubygems.org' do
+      msg = "Unable to gather license information using rubygems api with error " \
+        "message Salus::Scanners::ReportRubyGems::RubyGemsApiError: Server error"
+      stub_req_with(request_str, 'Server error', internal_server_error_code)
+
+      expect_any_instance_of(described_class).to receive(:bugsnag_notify).with(msg)
+      expect(scanner.send(:find_licenses_for, gem_name,
+                          gem_version)).to be_empty
+    end
+
+    it 'should return an empty array if there is an error' do
+      allow(JSON).to receive(:parse).and_raise(StandardError.new("Error in parsing"))
+      stub_req_with(request_str, response_body_with_no_license, ok_code)
+      expect(scanner.send(:find_licenses_for, gem_name,
+                          gem_version)).to be_empty
+    end
+  end
+
+  describe '#spdx_license_for' do
+    let(:repo) { Salus::Repo.new('spec/fixtures/report_ruby_gems/lockfile') }
+    let(:scanner) { Salus::Scanners::ReportRubyGems.new(repository: repo, config: {}) }
+
+    it 'should return a valid spdx formatted license for a given license' do
+      expect(scanner.send(:spdx_license_for, 'MIT')).to eql('MIT')
     end
   end
 


### PR DESCRIPTION
This PR is the continuation of this [work](https://github.com/coinbase/salus/pull/486). In the PR, we gather the spdx license information of ruby gems and incorporate them to CycloneDx report. In order to match proper spdx formatted license for a particular license, we have used [dice coefficient](https://en.wikibooks.org/wiki/Algorithm_Implementation/Strings/Dice%27s_coefficient)

Following is a screenshot of how the `bom` looks like with license information:

<img width="889" alt="Screen Shot 2022-01-14 at 10 26 46 AM" src="https://user-images.githubusercontent.com/1566651/149558814-c21fba4f-ab35-407d-b504-5834d0e1e1e0.png">

We are using https://guides.rubygems.org/rubygems-org-api-v2/ api to find information about ruby gem licenses. Ruby gems can be downloaded from multiple sources. But, here we are only targeting rubygems.org.