### PR TITLE
Adding config option in ReportNodeModules to report only production dependencies

### DIFF
--- a/lib/cyclonedx/base.rb
+++ b/lib/cyclonedx/base.rb
@@ -43,7 +43,9 @@ module Cyclonedx
         "group": "", # TODO: add group or domain name of the publisher
         "name": dependency[:name],
         "version": version_string(dependency),
-        "purl": package_url(dependency)
+        "purl": package_url(dependency),
+        "scope": dependency[:scope] || "required" # Add scope if available:
+        # https://cyclonedx.org/docs/1.3/json/#components_items_scope
       }
     end
 

--- a/lib/salus/scanners/report_node_modules.rb
+++ b/lib/salus/scanners/report_node_modules.rb
@@ -91,6 +91,7 @@ module Salus::Scanners
     end
 
     def record_dependencies_from_package_lock_json
+      include_dev_dependencies = @config.fetch('include_dev_deps', true)
       package_lock = JSON.parse(@repository.package_lock_json)
 
       # Record the lock file version.
@@ -101,12 +102,17 @@ module Salus::Scanners
 
       # Record each dependency.
       package_lock['dependencies']&.each do |dependency, data|
-        record_node_module(
-          name: dependency,
-          version: data['version'],
-          source: "#{data['resolved']}#{"##{data['integrity']}" if data['integrity']}",
-          dependency_file: 'package-lock.json'
-        )
+        is_dev = data['dev'] || false
+
+        if !is_dev || is_dev && include_dev_dependencies
+          record_node_module(
+            name: dependency,
+            version: data['version'],
+            source: "#{data['resolved']}#{"##{data['integrity']}" if data['integrity']}",
+            dependency_file: 'package-lock.json',
+            scope: is_dev ? 'optional' : 'required'
+          )
+        end
       end
     end
 
@@ -200,13 +206,14 @@ module Salus::Scanners
       end
     end
 
-    def record_node_module(dependency_file:, name:, version:, source:)
+    def record_node_module(dependency_file:, name:, version:, source:, scope:)
       report_dependency(
         dependency_file,
         type: 'node_module',
         name: name,
         version: version,
-        source: source
+        source: source,
+        scope: scope
       )
     end
   end


### PR DESCRIPTION
- Adding configuration option to exclude dev dependencies for ReportNodeModules

```
scanner_configs:
  ReportNodeModules:
   include_dev_deps: true
```

- Adding cyclonedx 'scope' attribute to Component - https://cyclonedx.org/docs/1.3/json/#components_items_scope. By default 'required' scope is assumed, so all reports will now have it set unless sent from Reporting Scanners. 