### PR TITLE
Recursive ReportNodeModules Scanner

### DIFF
--- a/lib/salus/scanners/report_node_modules.rb
+++ b/lib/salus/scanners/report_node_modules.rb
@@ -94,6 +94,16 @@ module Salus::Scanners
       end
     end
 
+    def record_dependency_from_package_lock_json(dependency, data, dev_flag)
+      record_node_module(
+        name: dependency,
+        version: data['version'],
+        source: "#{data['resolved']}#{"##{data['integrity']}" if data['integrity']}",
+        dependency_file: 'package-lock.json',
+        scope: dev_flag ? SCOPE_OPTIONAL : SCOPE_REQUIRED
+      )
+    end
+
     def record_dependencies_from_package_lock_json
       include_dev_dependencies = @config.fetch('include_dev_deps', true)
       package_lock = JSON.parse(@repository.package_lock_json)
@@ -109,31 +119,16 @@ module Salus::Scanners
         is_dev = data['dev'] || false
 
         if !is_dev || is_dev && include_dev_dependencies
-          record_node_module(
-            name: dependency,
-            version: data['version'],
-            source: "#{data['resolved']}#{"##{data['integrity']}" if data['integrity']}",
-            dependency_file: 'package-lock.json',
-            scope: is_dev ? SCOPE_OPTIONAL : SCOPE_REQUIRED
-          )
+          record_dependency_from_package_lock_json(dependency, data, is_dev)
 
           # Handling recursive dependencies.
           if data.key?("dependencies")
             nested_dependencies = data.dig("dependencies")
             nested_dependencies.each do |nested_dependency, nested_data|
               nested_is_dev = nested_data['dev'] || false
-              nested_scope = nested_is_dev ? SCOPE_OPTIONAL : SCOPE_REQUIRED
-              nested_source = "#{nested_data['resolved']}#{if nested_data['integrity']
-                                                             "##{nested_data['integrity']}"
-                                                           end}"
               if !nested_is_dev || nested_is_dev && include_dev_dependencies
-                record_node_module(
-                  name: nested_dependency,
-                  version: nested_data['version'],
-                  source: nested_source,
-                  dependency_file: 'package-lock.json',
-                  scope: nested_scope
-                )
+                record_dependency_from_package_lock_json(nested_dependency,
+                                                         nested_data, nested_is_dev)
               end
             end
           end

--- a/lib/salus/scanners/report_node_modules.rb
+++ b/lib/salus/scanners/report_node_modules.rb
@@ -116,6 +116,28 @@ module Salus::Scanners
             dependency_file: 'package-lock.json',
             scope: is_dev ? SCOPE_OPTIONAL : SCOPE_REQUIRED
           )
+
+          # Handling recursive dependencies.
+          if data.key?("dependencies")
+            nested_dependencies = data.dig("dependencies")
+            nested_dependencies.each do |nested_dependency, nested_data|
+              nested_is_dev = nested_data['dev'] || false
+              nested_scope = nested_is_dev ? SCOPE_OPTIONAL : SCOPE_REQUIRED
+              nested_source = "#{nested_data['resolved']}#{if nested_data['integrity']
+                                                             "##{nested_data['integrity']}"
+                                                           end}"
+              if !nested_is_dev || nested_is_dev && include_dev_dependencies
+                record_node_module(
+                  name: nested_dependency,
+                  version: nested_data['version'],
+                  source: nested_source,
+                  dependency_file: 'package-lock.json',
+                  scope: nested_scope
+                )
+              end
+            end
+          end
+
         end
       end
     end

--- a/spec/lib/salus/scanners/report_node_modules_spec.rb
+++ b/spec/lib/salus/scanners/report_node_modules_spec.rb
@@ -248,6 +248,16 @@ describe Salus::Scanners::ReportNodeModules do
             source: 'https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz'\
               '#sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=',
             scope: 'required'
+          },
+          {
+            dependency_file: 'package-lock.json',
+            type: 'node_module',
+            name: 'prop-types',
+            version: '15.7.1',
+            source: 'https://registry.npmjs.org/prop-types/-/prop-types-15.7.1.tgz'\
+              '#sha512-f8Lku2z9kERjOCcnDOPm68EBJAO2K00Q5mSgPAUE/'\
+              'gJuBgsYLbVy6owSrtcHj90zt8PvW+z0qaIIgsIhHOa1Qw==',
+            scope: 'optional'
           }
         ]
       )


### PR DESCRIPTION
- Add nested dependencies support for ReportNodeModules Scanner.
- Respect `include_dev_deps` flag for both direct and nested dependency.
- Updating test cases to account for nested dependencies.