### PR TITLE
Support Gradle Version 6 and 7 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,12 +28,17 @@ RUN apt-get update && apt-get upgrade -y --no-install-recommends && apt-get inst
 WORKDIR /root
 
 ### JDK
-RUN wget https://download.java.net/java/GA/jdk17.0.2/dfd4a8d0985749f896bed50d7138ee7f/8/GPL/openjdk-17.0.2_linux-x64_bin.tar.gz -P /tmp
-RUN tar xvf /tmp/openjdk-17.0.2_linux-x64_bin.tar.gz -C /
+RUN wget https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_linux-x64_bin.tar.gz -P /tmp
+RUN tar xvf /tmp/openjdk-11.0.2_linux-x64_bin.tar.gz -C /
 
-### Gradle
+### Gradle 7
 RUN wget https://services.gradle.org/distributions/gradle-7.3.3-bin.zip -P /tmp
 RUN unzip -d /opt/gradle /tmp/gradle-*.zip
+
+### Gradle 6
+RUN wget https://services.gradle.org/distributions/gradle-6.9.2-bin.zip -P /tmp2
+RUN unzip -d /opt/gradle /tmp2/gradle-*.zip
+
 ENV GRADLE_HOME="/opt/gradle/gradle-7.3.3"
 ENV PATH="${GRADLE_HOME}/bin:${PATH}"
 
@@ -172,10 +177,14 @@ COPY --from=builder /root/.local /root/.local
 COPY --from=builder /root/.cargo /root/.cargo
 COPY --from=builder /usr/local/go /usr/local/go
 COPY --from=builder /usr/bin/rg /usr/bin/rg
-COPY --from=builder /jdk-17.0.2 /jdk-17.0.2
-ENV JAVA_HOME /jdk-17.0.2
+COPY --from=builder /jdk-11.0.2 /jdk-11.0.2
+ENV JAVA_HOME /jdk-11.0.2
 COPY --from=builder /opt/gradle/gradle-7.3.3 /opt/gradle/gradle-7.3.3
 ENV PATH="/opt/gradle/gradle-7.3.3/bin:${PATH}"
+
+COPY --from=builder /opt/gradle/gradle-6.9.2 /opt/gradle/gradle-6.9.2
+ENV PATH="/opt/gradle/gradle-6.9.2/bin:${PATH}"
+
 RUN ln -sf /usr/local/go/bin/go /usr/local/bin
 RUN python -m easy_install pip==${PIP_VERSION} \
   && python3 -m easy_install pip==${PIP_VERSION}

--- a/lib/salus/scanners/base.rb
+++ b/lib/salus/scanners/base.rb
@@ -14,6 +14,8 @@ module Salus::Scanners
     class ScannerTimeoutError < StandardError; end
     # Default unknown version for dependency scanners
     UNKNOWN_VERSION = ''.freeze
+    GRADLE7 = "/opt/gradle/gradle-7.3.3/bin/gradle".freeze
+    GRADLE6 = "/opt/gradle/gradle-6.9.2/bin/gradle".freeze
 
     include Salus::SalusBugsnag
 
@@ -562,6 +564,23 @@ module Salus::Scanners
       end
 
       scanner_timeout_config_param
+    end
+
+    def parse_gradle_version
+      shell_result = run_shell([GRADLE7 + " buildEnvironment"])
+      report_info('message', 'generated with gradle version 7') if shell_result.success?
+      return setup_gradle(GRADLE7) if shell_result.success?
+
+      shell_result = run_shell([GRADLE6 + " buildEnvironment"])
+      report_info('message', 'generated with gradle version 6') if shell_result.success?
+      return setup_gradle(GRADLE6) if shell_result.success?
+
+      report_error("Gradle Version Not supported. Please Upgrade to gradle version 6 and above")
+    end
+
+    def setup_gradle(version)
+      shell_result = run_shell(["export GRADLE_HOME=#{version}"])
+      shell_result.success?
     end
   end
 end

--- a/lib/salus/scanners/brakeman.rb
+++ b/lib/salus/scanners/brakeman.rb
@@ -133,6 +133,9 @@ module Salus::Scanners
         return true if item.key?('expiration')
       end
       false
+    rescue TypeError, Errno::ENOENT => e
+      report_error(e.message)
+      bugsnag_notify(e)
     end
 
     def user_supplied_ignore?

--- a/lib/salus/scanners/osv/gradle_osv.rb
+++ b/lib/salus/scanners/osv/gradle_osv.rb
@@ -15,6 +15,8 @@ module Salus::Scanners::OSV
     end
 
     def run
+      return if !parse_gradle_version
+
       # Find dependencies
       dependencies = find_dependencies
       if dependencies.empty?

--- a/lib/salus/scanners/report_gradle_deps.rb
+++ b/lib/salus/scanners/report_gradle_deps.rb
@@ -5,6 +5,8 @@ require 'salus/scanners/base'
 module Salus::Scanners
   class ReportGradleDeps < Base
     def run
+      return if !parse_gradle_version
+
       shell_return = run_shell(['bin/parse_gradle_deps', @repository.path_to_repo], chdir: nil)
       if !shell_return.success?
         report_error(shell_return.stderr)

--- a/spec/fixtures/osv/gradle_osv/gradle_versions/unsupported_version/build.gradle
+++ b/spec/fixtures/osv/gradle_osv/gradle_versions/unsupported_version/build.gradle
@@ -1,0 +1,15 @@
+plugins {
+    id 'java'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+  implementation group: 'test.test.test', name: 'sample', version: '2.6.2'
+  runtime group: 'org.springframework.boot', name: 'spring-boot-starter-web'
+}
+
+// Wrapper is a built in task. This feature for overriding of built in tasks were removed in Gradle version 5
+task wrapper(type:Wrapper) { }

--- a/spec/fixtures/osv/gradle_osv/gradle_versions/version_6/build.gradle
+++ b/spec/fixtures/osv/gradle_osv/gradle_versions/version_6/build.gradle
@@ -1,0 +1,14 @@
+plugins {
+    id 'java'
+}
+
+repositories {
+    mavenCentral()
+}
+
+// The compile keyword is deprecated but still available in gradle version 6.
+// However, its been removed in gradle version 7
+dependencies {
+  implementation group: 'test.test.test', name: 'sample', version: '2.6.2'
+  compile group: 'org.springframework.boot', name: 'spring-boot-starter-web'
+}

--- a/spec/fixtures/osv/gradle_osv/gradle_versions/version_7/build.gradle
+++ b/spec/fixtures/osv/gradle_osv/gradle_versions/version_7/build.gradle
@@ -1,0 +1,13 @@
+plugins {
+    id 'java'
+}
+
+repositories {
+    mavenCentral()
+}
+
+// RuntimeOnly replaces runtime
+dependencies {
+  implementation group: 'test.test.test', name: 'sample', version: '2.6.2'
+  runtimeOnly group: 'org.springframework.boot', name: 'spring-boot-starter-web'
+}

--- a/spec/lib/salus/scanners/brakeman_spec.rb
+++ b/spec/lib/salus/scanners/brakeman_spec.rb
@@ -360,6 +360,30 @@ describe Salus::Scanners::Brakeman do
       scanner.run
       expect(scanner.report.passed?).to eq(true)
     end
+
+    it 'should report an error if ignore config value is not a string' do
+      repo = Salus::Repo.new(File.join(fixture_path, 'vulnerable_rails_app'))
+      scanner = Salus::Scanners::Brakeman.new(repository: repo, config: {
+                                                'ignore' => File.join(fixture_path,
+                                                                      'brakeman.ignore')
+                                              })
+      scanner.run
+
+      expect(scanner.report.passed?).to eq(false)
+      errors = scanner.report.to_h.fetch(:errors)
+      expect(errors[0][:message]).to include("No such file or directory @ rb_sysopen")
+    end
+
+    it 'should report an error if ignore config path does not exist' do
+      repo = Salus::Repo.new(File.join(fixture_path, 'vulnerable_rails_app'))
+      scanner = Salus::Scanners::Brakeman.new(repository: repo, config: {
+                                                'ignore' => ["brakeman.ignore"]
+                                              })
+      scanner.run
+      expect(scanner.report.passed?).to eq(false)
+      errors = scanner.report.to_h.fetch(:errors)
+      expect(errors[0][:message]).to include("no implicit conversion of Array into String")
+    end
   end
 
   describe '#should_run?' do


### PR DESCRIPTION
This PR 
- adds support for gradle version 6 and 7
- projects using a gradle version not supported by Salus are shown upgrade notifications. 
<img width="394" alt="Screen Shot 2022-04-28 at 12 56 21 PM" src="https://user-images.githubusercontent.com/23368832/165835099-8f147a4a-9fc6-48f1-bc3c-e35ae31041a8.png">
