### PR TITLE
Eliminate bundle audit vulnerabilities that are likely not introduced by the commit.

### DIFF
--- a/lib/sarif/bundle_audit_sarif.rb
+++ b/lib/sarif/bundle_audit_sarif.rb
@@ -29,7 +29,7 @@ module Sarif
       if issue[:line_number]
         result[:start_line] = issue[:line_number]
         result[:start_column] = 1
-        result[:code] = issue[:name].to_s
+        result[:code] = issue[:name].to_s # Code stores the gem name without version in snippet
       end
 
       if issue[:type] == "InsecureSource"

--- a/lib/sarif/bundle_audit_sarif.rb
+++ b/lib/sarif/bundle_audit_sarif.rb
@@ -29,6 +29,7 @@ module Sarif
       if issue[:line_number]
         result[:start_line] = issue[:line_number]
         result[:start_column] = 1
+        result[:code] = issue[:name].to_s
       end
 
       if issue[:type] == "InsecureSource"
@@ -49,6 +50,13 @@ module Sarif
       when 7.0..10.0
         SARIF_WARNINGS[:error]
       end
+    end
+
+    def self.snippet_possibly_in_git_diff?(snippet, lines_added)
+      # snippet in sarif just has the package name (without spaces/version)
+      # actual snippet in Gemfile.lock looks like " nokogiri (>= 1.5.11, < 2.0.0)"
+      snippet = ' ' + snippet + ' ('
+      lines_added.keys.any? { |line| line.include? snippet }
     end
   end
 end

--- a/spec/fixtures/sarifs/diff/git_diff_7.txt
+++ b/spec/fixtures/sarifs/diff/git_diff_7.txt
@@ -1,0 +1,10 @@
+diff --git a/Gemfile.lock b/Gemfile.lock
+index 995b16a447..d3e6979312 100644
+--- a/Gemfile.lock
++++ b/Gemfile.lock
+@@ -844,6 +844,7 @@ GEM
+       nokogiri (>= 1.5.11, < 2.0.0)
++    helloworld (1.2.3)
++    bye (1.2.3)
+     fuubar (2.3.1)
+       rspec-core (~> 3.0)

--- a/spec/lib/sarif/bundle_audit_spec.rb
+++ b/spec/lib/sarif/bundle_audit_spec.rb
@@ -141,23 +141,28 @@ describe Sarif::BundleAuditSarif do
 
   describe 'sarif diff' do
     context 'git diff support' do
-      it 'should find code in git diff' do
+      let(:new_lines_in_git_diff) do
         git_diff_file = 'spec/fixtures/sarifs/diff/git_diff_7.txt'
-        snippet = 'helloworld'
         git_diff = File.read(git_diff_file)
-        new_lines_in_git_diff = Sarif::BaseSarif.new_lines_in_git_diff(git_diff)
+        Sarif::BaseSarif.new_lines_in_git_diff(git_diff)
+      end
+
+      it 'should find code in git diff' do
+        snippet = 'helloworld'
         r = Sarif::BundleAuditSarif.snippet_possibly_in_git_diff?(snippet, new_lines_in_git_diff)
         expect(r).to be true
         snippet = 'bye'
         r = Sarif::BundleAuditSarif.snippet_possibly_in_git_diff?(snippet, new_lines_in_git_diff)
         expect(r).to be true
+      end
 
-        # should not match part of the package name
+      it 'should not match part of the package name' do
         snippet = 'hello'
         r = Sarif::BundleAuditSarif.snippet_possibly_in_git_diff?(snippet, new_lines_in_git_diff)
         expect(r).to be false
+      end
 
-        # should not match package that was in git diff but not added with this commit
+      it 'should not match package that was in git diff but not added with this commit' do
         snippet = 'fuubar'
         r = Sarif::BundleAuditSarif.snippet_possibly_in_git_diff?(snippet, new_lines_in_git_diff)
         expect(r).to be false


### PR DESCRIPTION
Code stores the gem name without version in snippet.  Then looks for the snippet in git diff.
If there are multiple versions of the same gem, then it may be an issue. However, this PR is just here to eliminate vulnerabilities that are not likely introduced commit.

PR assumes Gemfile.lock was auto-created.  If the user manually updates it to have some unconventional format, then things may break.

PR has also been tested using docker build ..., docker run local salus with `--sarif_full_dif ... --git-diff ...` to make sure
1.  vuls caused by changed lines do not show up in the diffed results.
2. vuls introduced by the commit still show up.