### PR TITLE
Implementing supported_languages func

### DIFF
--- a/lib/salus/scanners/osv/base.rb
+++ b/lib/salus/scanners/osv/base.rb
@@ -25,6 +25,10 @@ module Salus::Scanners::OSV
       raise NoMethodError, 'implement in subclass'
     end
 
+    def self.supported_languages
+      raise NoMethodError, 'implement in subclass'
+    end
+
     def name
       self.class.name.sub('Salus::Scanners::OSV::', '')
     end

--- a/lib/salus/scanners/osv/go_osv.rb
+++ b/lib/salus/scanners/osv/go_osv.rb
@@ -14,6 +14,10 @@ module Salus::Scanners::OSV
       @repository.go_sum_present?
     end
 
+    def self.supported_languages
+      ['go']
+    end
+
     def run
       begin
         # Find dependencies

--- a/lib/salus/scanners/osv/gradle_osv.rb
+++ b/lib/salus/scanners/osv/gradle_osv.rb
@@ -15,6 +15,10 @@ module Salus::Scanners::OSV
       @repository.build_gradle_present?
     end
 
+    def self.supported_languages
+      ['java']
+    end
+
     def run
       # Find dependencies from the project
       dependencies = gradle_dependencies
@@ -67,6 +71,7 @@ module Salus::Scanners::OSV
     def match_vulnerable_dependencies(dependencies)
       results = []
       dependencies.each do |dependency|
+        puts dependencies
         lib = "#{dependency['group_id']}:#{dependency['artifact_id']}"
 
         if dependency['version'].present?

--- a/lib/salus/scanners/osv/maven_osv.rb
+++ b/lib/salus/scanners/osv/maven_osv.rb
@@ -15,6 +15,10 @@ module Salus::Scanners::OSV
       @repository.pom_xml_present?
     end
 
+    def self.supported_languages
+      ['java']
+    end
+
     def run
       begin
         # Find dependencies

--- a/lib/salus/scanners/osv/python_osv.rb
+++ b/lib/salus/scanners/osv/python_osv.rb
@@ -15,6 +15,10 @@ module Salus::Scanners::OSV
       @repository.requirements_txt_present?
     end
 
+    def self.supported_languages
+      ['python']
+    end
+
     def run
       # Find dependencies
       dependencies = find_dependencies

--- a/lib/salus/scanners/package_version/base.rb
+++ b/lib/salus/scanners/package_version/base.rb
@@ -51,6 +51,10 @@ module Salus::Scanners::PackageVersion
       self.class.name.sub('Salus::Scanners::PackageVersion::', '')
     end
 
+    def self.supported_languages
+      raise NoMethodError, 'implement in subclass'
+    end
+
     private
 
     def parse_blocked_versions(blocked_versions)

--- a/lib/salus/scanners/package_version/go_package_version_scanner.rb
+++ b/lib/salus/scanners/package_version/go_package_version_scanner.rb
@@ -12,6 +12,10 @@ module Salus::Scanners::PackageVersion
       @repository.go_sum_present?
     end
 
+    def self.supported_languages
+      ['go']
+    end
+
     def check_for_violations(package_name, min_version, max_version, blocked_versions)
       violations = []
       if @dependencies.key?(package_name)

--- a/lib/salus/scanners/package_version/npm_package_version_scanner.rb
+++ b/lib/salus/scanners/package_version/npm_package_version_scanner.rb
@@ -12,6 +12,10 @@ module Salus::Scanners::PackageVersion
       @repository.package_lock_json_present?
     end
 
+    def self.supported_languages
+      ['javascript']
+    end
+
     def check_for_violations(package_name, min_version, max_version, blocked_versions)
       violations = []
       if @dependencies.key?(package_name)

--- a/lib/salus/scanners/package_version/ruby_package_version_scanner.rb
+++ b/lib/salus/scanners/package_version/ruby_package_version_scanner.rb
@@ -12,6 +12,10 @@ module Salus::Scanners::PackageVersion
       @repository.gemfile_lock_present?
     end
 
+    def self.supported_languages
+      ['ruby']
+    end
+
     def check_for_violations(package_name, min_version, max_version, blocked_versions)
       violations = []
       if @dependencies.key?(package_name)


### PR DESCRIPTION
Some of the new scanners don't implement the `supported_languages` function. This has been corrected. 