### PR TITLE
Eliminate NPM audit vulnerabilities not likely introduced by commit

### DIFF
--- a/lib/sarif/npm_audit_sarif.rb
+++ b/lib/sarif/npm_audit_sarif.rb
@@ -44,6 +44,7 @@ module Sarif
       if issue[:line_number]
         parsed_issue[:start_line] = issue[:line_number]
         parsed_issue[:start_column] = 1
+        parsed_issue[:code] = issue[:module_name].to_s
       end
 
       parsed_issue
@@ -68,6 +69,11 @@ module Sarif
       invocation = super(scan_report, supported)
       invocation[:executionSuccessful] = @results.empty?
       invocation
+    end
+
+    def self.snippet_possibly_in_git_diff?(snippet, lines_added)
+      snippet = '"' + snippet + '":'
+      lines_added.keys.any? { |line| line.start_with? snippet }
     end
   end
 end

--- a/lib/sarif/npm_audit_sarif.rb
+++ b/lib/sarif/npm_audit_sarif.rb
@@ -73,7 +73,7 @@ module Sarif
 
     def self.snippet_possibly_in_git_diff?(snippet, lines_added)
       snippet = "\"" + snippet + "\":"
-      lines_added.keys.include? snippet
+      lines_added.keys.any? { |k| k.include? snippet }
     end
   end
 end

--- a/lib/sarif/npm_audit_sarif.rb
+++ b/lib/sarif/npm_audit_sarif.rb
@@ -72,7 +72,7 @@ module Sarif
     end
 
     def self.snippet_possibly_in_git_diff?(snippet, lines_added)
-      snippet = '"' + snippet + '":'
+      snippet = "\"" + snippet + "\":"
       lines_added.keys.include? snippet
     end
   end

--- a/lib/sarif/npm_audit_sarif.rb
+++ b/lib/sarif/npm_audit_sarif.rb
@@ -73,7 +73,7 @@ module Sarif
 
     def self.snippet_possibly_in_git_diff?(snippet, lines_added)
       snippet = '"' + snippet + '":'
-      lines_added.keys.any? { |line| line.start_with? snippet }
+      lines_added.keys.include? snippet
     end
   end
 end

--- a/spec/fixtures/sarifs/diff/git_diff_8.txt
+++ b/spec/fixtures/sarifs/diff/git_diff_8.txt
@@ -1,0 +1,25 @@
+diff --git a/spec/fixtures/npm_audit/failure/package-lock.json b/spec/fixtures/npm_audit/failure/package-lock.json
+index 63c2c660..e5948f43 100644
+--- a/spec/fixtures/npm_audit/failure/package-lock.json
++++ b/spec/fixtures/npm_audit/failure/package-lock.json
+@@ -4,7 +4,7 @@
+   "lockfileVersion": 1,
+   "requires": true,
+   "dependencies": {
+-    "classnames": {
++    "classnamesabcd": {
+       "version": "2.2.6",
+       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
+       "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
+@@ -18,6 +18,11 @@
+       "version": "1.2.3",
+       "resolved": "http://registry.npmjs.org/uglify-js/-/uglify-js-1.2.3.tgz",
+       "integrity": "sha1-OwzmYxoo3KpkMCuJMSOyCHa9xTY="
++    },
++    "my-package-abcd": {
++      "version": "1.2.3",
++      "resolved": "http://my-package",
++      "integrity": "sha1-xyz="
+     }
+   }
+ }

--- a/spec/lib/sarif/npm_audit_sarif_spec.rb
+++ b/spec/lib/sarif/npm_audit_sarif_spec.rb
@@ -198,7 +198,7 @@ describe Sarif::NPMAuditSarif do
         r = Sarif::NPMAuditSarif.snippet_possibly_in_git_diff?(snippet, new_lines_in_git_diff)
         expect(r).to be true
 
-        snippet = 'my-package-abc'
+        snippet = 'my-package-abcd'
         r = Sarif::NPMAuditSarif.snippet_possibly_in_git_diff?(snippet, new_lines_in_git_diff)
         expect(r).to be true
       end


### PR DESCRIPTION
Code stores the dependency name without version in snippet.  Then looks for the snippet in git diff.
If there are multiple versions of the same dependency, then it may be an issue. However, this PR is just here to eliminate vulnerabilities that are not likely introduced commit.

PR assumes package-lock.json was auto-created.  If the user manually updates it to have some unconventional format, then things may break.

Tested with
* Unit tests
* ` docker run --rm -t -v $(pwd):/home/repo salus-local --sarif_diff_full pr.json master.json --git-diff git_diff.txt`