### PR TITLE
Handle exceptions for slither scanner

### DIFF
--- a/docs/scanners/slither.md
+++ b/docs/scanners/slither.md
@@ -7,9 +7,18 @@ Performs static analysis on Solidity code. Only projects that use Truffle or Har
 ```yaml
 scanner_configs:
   Slither:
-    filter-paths: a.sol|b.sol  # Exclude file / directory paths, separated with |
-    exclude-optimization: true # Ignore findings with optimization-level impact
-    exclude-informational: true # Ignore findings with informational-level impact
+    filter-paths: a.sol|b.sol                  # Exclude file / directory paths, separated with |
+    exclude-optimization: true                 # Ignore findings with optimization-level impact
+    exclude-informational: true                # Ignore findings with informational-level impact
+    exceptions:                                # Exclude the detectors(vulnerabilities)
+      - advisory_id: incorrect-shift
+        changed_by: appsec
+        notes: This is false-positive
+        expiration: '2200-12-31'
+      - advisory_id: dead-code
+        changed_by: appsec
+        notes: This is false-positive
+        expiration: '2200-12-31'
 ```
 
 * `filter-paths` - `path1` will exclude all the results that are only related to path1. The path specified can be a path directory or a filename. Direct string comparison and [Python regular expression](https://docs.python.org/3/library/re.html) are used.  For example, the value could be `a.sol` or a regular expression like `a.sol|b.sol`.
@@ -17,3 +26,5 @@ scanner_configs:
 * `exclude-optimization` - When `true`, this option enables the `--exclude-optimization` flag when invoking Slither and causes the scanner to ignore detectors that have `Optimization` level impact. By default, this option is set to `false`. A list of detectors and their impacts can be found in [the Slither README](https://github.com/crytic/slither/tree/168e96298fb8f8a588c110aa75cd38b3a7662ed9#detectors).
 
 * `exclude-informational` - When `true`, this option enables the `--exclude-informational` flag when invoking Slither and causes the scanner to ignore detectors that have `Informational` level impact. By default, this option is set to `false`. A list of detectors and their impacts can be found in [the Slither README](https://github.com/crytic/slither/tree/168e96298fb8f8a588c110aa75cd38b3a7662ed9#detectors).
+
+* `exceptions` - Using this option, any user can provide a list of detectors(vulnerabilities) that need to be excluded from the scan result.  A list of detectors and their impacts can be found in [the Slither README](https://github.com/crytic/slither/tree/168e96298fb8f8a588c110aa75cd38b3a7662ed9#detectors).

--- a/lib/salus/scanners/slither.rb
+++ b/lib/salus/scanners/slither.rb
@@ -84,6 +84,10 @@ module Salus::Scanners
       end
       opts += ' --exclude-informational' if @config.dig('exclude-informational')
       opts += ' --exclude-optimization' if @config.dig('exclude-optimization')
+
+      exceptions = fetch_exception_ids
+      opts += ' --exclude ' + exceptions.join('|') if exceptions.count.positive?
+
       opts
     end
 


### PR DESCRIPTION
The developers can specify a number of vulnerability exceptions in the config file (salus.yaml). In this way, a scanner is able to exclude the specified vulnerabilities from the security report.

In this pr, we address the issue of handling the exceptions for [Slither](https://github.com/crytic/slither) scanner.