### PR TITLE
Change exception delimiter to comma

### DIFF
--- a/lib/salus/scanners/slither.rb
+++ b/lib/salus/scanners/slither.rb
@@ -86,7 +86,7 @@ module Salus::Scanners
       opts += ' --exclude-optimization' if @config.dig('exclude-optimization')
 
       exceptions = fetch_exception_ids
-      opts += ' --exclude ' + exceptions.join('|') if exceptions.count.positive?
+      opts += ' --exclude ' + exceptions.join(',') if exceptions.count.positive?
 
       opts
     end


### PR DESCRIPTION
In order to separate detectors in **exclude**, we can use both '|' and ','. 

However, in this pr, we will change the delimiter to **comma** in order to be consistent with the document from 'slither help'

```
 --exclude DETECTORS_TO_EXCLUDE
                        Comma-separated list of detectors that should be
                        excluded
```