### PR TITLE
Selecting resolved version in Gradle dependency graph

### DIFF
--- a/lib/salus/scanners/osv/gradle_osv.rb
+++ b/lib/salus/scanners/osv/gradle_osv.rb
@@ -76,6 +76,7 @@ module Salus::Scanners::OSV
         if dependency['version'].present?
           version = dependency['version']
           # Cleanup version string to handle case like -
+          # dependency.xx.xx:1.1.1 -> 1.5.0
           # 1.2.1.somestring / 9999.0-empty-to-avoid-conflict-with-test /
           # 30.3.0-deprecated-use-gradle-api
           version = version.split("->")[1].strip if version.include? "->"

--- a/lib/salus/scanners/osv/gradle_osv.rb
+++ b/lib/salus/scanners/osv/gradle_osv.rb
@@ -79,7 +79,7 @@ module Salus::Scanners::OSV
           # Dynamic resolved version: dependency.xx.xx:1.1.1 -> 1.5.0
           # Version strings: 1.2.1.somestring / 9999.0-empty-to-avoid-conflict-with-test /
           # Version strings: 30.3.0-deprecated-use-gradle-api
-          version = version.split("->")[1].strip if version.include? "->"
+          version = version.split("->").last.strip if version.include? "->"
           version = version.delete("^0-9.").gsub(/\.+$/, "")
           package_matches = @osv_vulnerabilities.select do |v|
             v.dig("package", "name") == lib

--- a/lib/salus/scanners/osv/gradle_osv.rb
+++ b/lib/salus/scanners/osv/gradle_osv.rb
@@ -76,9 +76,9 @@ module Salus::Scanners::OSV
         if dependency['version'].present?
           version = dependency['version']
           # Cleanup version string to handle case like -
-          # dependency.xx.xx:1.1.1 -> 1.5.0
-          # 1.2.1.somestring / 9999.0-empty-to-avoid-conflict-with-test /
-          # 30.3.0-deprecated-use-gradle-api
+          # Dynamic resolved version: dependency.xx.xx:1.1.1 -> 1.5.0
+          # Version strings: 1.2.1.somestring / 9999.0-empty-to-avoid-conflict-with-test /
+          # Version strings: 30.3.0-deprecated-use-gradle-api
           version = version.split("->")[1].strip if version.include? "->"
           version = version.delete("^0-9.").gsub(/\.+$/, "")
           package_matches = @osv_vulnerabilities.select do |v|

--- a/lib/salus/scanners/osv/gradle_osv.rb
+++ b/lib/salus/scanners/osv/gradle_osv.rb
@@ -78,6 +78,7 @@ module Salus::Scanners::OSV
           # Cleanup version string to handle case like -
           # 1.2.1.somestring / 9999.0-empty-to-avoid-conflict-with-test /
           # 30.3.0-deprecated-use-gradle-api
+          version = version.split("->")[1].strip if version.include? "->"
           version = version.delete("^0-9.").gsub(/\.+$/, "")
           package_matches = @osv_vulnerabilities.select do |v|
             v.dig("package", "name") == lib

--- a/spec/fixtures/osv/gradle_osv/success_resolved_dependency/build.gradle
+++ b/spec/fixtures/osv/gradle_osv/success_resolved_dependency/build.gradle
@@ -1,0 +1,20 @@
+plugins {
+    id 'java'
+}
+
+repositories {
+    mavenCentral()
+}
+
+
+dependencies {
+    // testImplementation group: 'com.google.guava', name: 'guava', version: '30.1-jre'
+    testImplementation('org.apache.logging.log4j:log4j-api:2.17.1') {
+        force = true
+    }
+    testImplementation('org.apache.logging.log4j:log4j-api:2.11.2') {
+        force = true
+    }
+}
+
+

--- a/spec/lib/salus/scanners/osv/gradle_osv_spec.rb
+++ b/spec/lib/salus/scanners/osv/gradle_osv_spec.rb
@@ -95,6 +95,16 @@ describe Salus::Scanners::OSV::GradleOSV do
         expect(scanner.report.to_h.fetch(:passed)).to eq(true)
       end
 
+      it 'should pass when resolved dependencies are found in build.gradle' do
+        repo = Salus::Repo.new(File.join(fixture_path, 'success_resolved_dependency'))
+
+        scanner = Salus::Scanners::OSV::GradleOSV.new(repository: repo, config: {})
+        stub_req_with_valid_response
+        scanner.run
+
+        expect(scanner.report.to_h.fetch(:passed)).to eq(true)
+      end
+
       it 'should fail when no dependencies are found in build.gradle' do
         repo = Salus::Repo.new(File.join(fixture_path, 'no_dependency_found'))
 


### PR DESCRIPTION
Currently when parsing the dependency gradle dependency graph there are instances when gradle [resolves to a different version](https://stackoverflow.com/questions/27952388/what-does-arrow-mean-in-gradles-dependency-graph), this change allows us to select the resolved version.



