### PR TITLE
Fix deprecation warning

### DIFF
--- a/spec/lib/salus/processor_spec.rb
+++ b/spec/lib/salus/processor_spec.rb
@@ -316,7 +316,7 @@ describe Salus::Processor do
           .with(headers: { 'Content-Type' => 'application/json' })
           .to_return(status: 202)
 
-        Salus::ReportRequest.should_receive(:send_report).twice
+        expect(Salus::ReportRequest).to receive(:send_report).twice
 
         processor = Salus::Processor.new(repo_path: 'spec/fixtures/processor/multiple_endpoints')
         processor.scan_project


### PR DESCRIPTION
Fix for warning message - 

```
Deprecation Warnings:

Using `should_receive` from rspec-mocks' old `:should` syntax without explicitly enabling the syntax is deprecated. Use the new `:expect` syntax or explicitly enable `:should` instead. Called from /home/spec/lib/salus/processor_spec.rb:319:in `block (4 levels) in <top (required)>'.
```