### PR TITLE
Updated gradle parsing

### DIFF
--- a/docs/scanners/gradle_osv.md
+++ b/docs/scanners/gradle_osv.md
@@ -4,14 +4,14 @@ Finds vulnerable dependencies in a Gradle project. By default, GradleOSV Scanner
 
 ## Configuration
 
-To enable Gradle Scanning, add the following configuration to build.gradle for repo with single project or a repo with multiple sub projects.
+To enable Gradle Scanning, add the following configuration to root build.gradle.
 ```java
 # Single Project setup
-task reportDependencies(type: reportDependencies) {}
+task reportDependencies(type: DependencyReportTask) {}
 
 # Muti Project setup
 subprojects {
-    task allDeps(type: DependencyReportTask) {}
+    task reportDependencies(type: DependencyReportTask) {}
 }
 ```
 

--- a/docs/scanners/gradle_osv.md
+++ b/docs/scanners/gradle_osv.md
@@ -4,6 +4,17 @@ Finds vulnerable dependencies in a Gradle project. By default, GradleOSV Scanner
 
 ## Configuration
 
+To enable Gradle Scanning, add the following configuration to build.gradle for repo with single project or a repo with multiple sub projects.
+```java
+# Single Project setup
+task reportDependencies(type: reportDependencies) {}
+
+# Muti Project setup
+subprojects {
+    task allDeps(type: DependencyReportTask) {}
+}
+```
+
 When a CVE is present in a dependency, the best course of action is to upgrade the dependency to a patched version. However, if there is currently no patch available or its a false positive you can use the following configuration option to ignore a particular CVE.
 
 ```yaml

--- a/lib/salus/package_utils/gradle_dependency_parser.rb
+++ b/lib/salus/package_utils/gradle_dependency_parser.rb
@@ -6,9 +6,9 @@ module Gradle
     dependency_metadata_regex = /-\s(?<group_id>.+):(?<artifact_id>.+):(?<version>.+)/
 
     # 'gradle dependencies' command needs to be run in the folder where buid.gradle is present.
-    shell_result = run_shell("#{GRADLE7} dependencies")
+    shell_result = run_shell("#{GRADLE7} reportDependencies")
 
-    shell_result = run_shell("#{GRADLE6} dependencies") if !shell_result.success?
+    shell_result = run_shell("#{GRADLE6} reportDependencies") if !shell_result.success?
     if !shell_result.success?
       report_error("Gradle Version Not supported. Please Upgrade to gradle version 6 and above")
       return []

--- a/spec/fixtures/osv/gradle_osv/failure_vulnerability_present/build.gradle
+++ b/spec/fixtures/osv/gradle_osv/failure_vulnerability_present/build.gradle
@@ -6,6 +6,8 @@ repositories {
     mavenCentral()
 }
 
+task reportDependencies(type: DependencyReportTask) {}
+
 dependencies {
     testImplementation group: 'com.google.guava', name: 'guava', version: '30.1-jre'
 }

--- a/spec/fixtures/osv/gradle_osv/gradle_versions/unsupported_version/build.gradle
+++ b/spec/fixtures/osv/gradle_osv/gradle_versions/unsupported_version/build.gradle
@@ -6,6 +6,8 @@ repositories {
     mavenCentral()
 }
 
+task reportDependencies(type: DependencyReportTask) {}
+
 dependencies {
   implementation group: 'test.test.test', name: 'sample', version: '2.6.2'
   runtime group: 'org.springframework.boot', name: 'spring-boot-starter-web'

--- a/spec/fixtures/osv/gradle_osv/gradle_versions/version_6/build.gradle
+++ b/spec/fixtures/osv/gradle_osv/gradle_versions/version_6/build.gradle
@@ -6,6 +6,8 @@ repositories {
     mavenCentral()
 }
 
+task reportDependencies(type: DependencyReportTask) {}
+
 // The compile keyword is deprecated but still available in gradle version 6.
 // However, its been removed in gradle version 7
 dependencies {

--- a/spec/fixtures/osv/gradle_osv/gradle_versions/version_7/build.gradle
+++ b/spec/fixtures/osv/gradle_osv/gradle_versions/version_7/build.gradle
@@ -6,6 +6,8 @@ repositories {
     mavenCentral()
 }
 
+task reportDependencies(type: DependencyReportTask) {}
+
 // RuntimeOnly replaces runtime
 dependencies {
   implementation group: 'test.test.test', name: 'sample', version: '2.6.2'

--- a/spec/fixtures/osv/gradle_osv/no_dependency_found/build.gradle
+++ b/spec/fixtures/osv/gradle_osv/no_dependency_found/build.gradle
@@ -6,5 +6,8 @@ repositories {
     mavenCentral()
 }
 
+task reportDependencies(type: DependencyReportTask) {}
+
+
 dependencies {
 }

--- a/spec/fixtures/osv/gradle_osv/success_no_vulnerability/build.gradle
+++ b/spec/fixtures/osv/gradle_osv/success_no_vulnerability/build.gradle
@@ -6,6 +6,8 @@ repositories {
     mavenCentral()
 }
 
+task reportDependencies(type: DependencyReportTask) {}
+
 dependencies {
     implementation group: 'test.test.test', name: 'sample', version: '2.6.2'
 }

--- a/spec/fixtures/osv/gradle_osv/success_resolved_dependency/build.gradle
+++ b/spec/fixtures/osv/gradle_osv/success_resolved_dependency/build.gradle
@@ -6,6 +6,7 @@ repositories {
     mavenCentral()
 }
 
+task reportDependencies(type: DependencyReportTask) {}
 
 dependencies {
     // testImplementation group: 'com.google.guava', name: 'guava', version: '30.1-jre'

--- a/spec/fixtures/osv/gradle_osv/success_vulnerability_present_exception_added/build.gradle
+++ b/spec/fixtures/osv/gradle_osv/success_vulnerability_present_exception_added/build.gradle
@@ -6,6 +6,8 @@ repositories {
     mavenCentral()
 }
 
+task reportDependencies(type: DependencyReportTask) {}
+
 dependencies {
     testImplementation group: 'com.google.guava', name: 'guava', version: '30.1-jre'
 }

--- a/spec/fixtures/report_gradle_deps/normal/build.gradle
+++ b/spec/fixtures/report_gradle_deps/normal/build.gradle
@@ -6,6 +6,8 @@ repositories {
     mavenCentral()
 }
 
+task reportDependencies(type: DependencyReportTask) {}
+
 dependencies {
     implementation group: 'org.apache.kafka', name: 'connect-transforms', version: '2.6.2'
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.10.5.1'


### PR DESCRIPTION
Updated parsing of gradle dependencies using `reportDependencies` task. For this to work the users would need to update the root build.gradle to create a task which Salus will call during runtime and parse dependencies.

TODO
Enabling different configs for runtime, compile time etc.