### PR TITLE
add path for yarn 1

### DIFF
--- a/lib/salus/scanners/yarn_audit.rb
+++ b/lib/salus/scanners/yarn_audit.rb
@@ -147,13 +147,10 @@ module Salus::Scanners
           line_split = lines[i].split("│")
           curr_key = line_split[1].strip
           val = line_split[2].strip
-
-          if curr_key != "" && curr_key != 'Path'
+          if curr_key != ""
             vuln[curr_key] = val
             prev_key = curr_key
-          elsif curr_key == 'Path'
-            prev_key = curr_key
-          elsif prev_key != 'Path'
+          else
             vuln[prev_key] += ' ' + val
           end
         elsif lines[i].start_with?("└─") && lines[i].end_with?("─┘")

--- a/lib/salus/scanners/yarn_audit.rb
+++ b/lib/salus/scanners/yarn_audit.rb
@@ -25,7 +25,7 @@ module Salus::Scanners
     end
 
     def run
-      @vulns_w_paths = {}
+      @vulns_w_paths = []
       if Gem::Version.new(version) >= Gem::Version.new(BREAKING_VERSION)
         handle_latest_yarn_audit
       else

--- a/lib/salus/scanners/yarn_audit.rb
+++ b/lib/salus/scanners/yarn_audit.rb
@@ -25,6 +25,7 @@ module Salus::Scanners
     end
 
     def run
+      @vulns_w_paths = {}
       if Gem::Version.new(version) >= Gem::Version.new(BREAKING_VERSION)
         handle_latest_yarn_audit
       else
@@ -86,7 +87,6 @@ module Salus::Scanners
     end
 
     def handle_legacy_yarn_audit
-      @vulns_w_paths = {}
       command = "#{LEGACY_YARN_AUDIT_COMMAND} #{scan_deps}"
       shell_return = run_shell(command)
 

--- a/lib/salus/scanners/yarn_audit.rb
+++ b/lib/salus/scanners/yarn_audit.rb
@@ -86,6 +86,7 @@ module Salus::Scanners
     end
 
     def handle_legacy_yarn_audit
+      @vulns_w_paths = {}
       command = "#{LEGACY_YARN_AUDIT_COMMAND} #{scan_deps}"
       shell_return = run_shell(command)
 
@@ -108,6 +109,8 @@ module Salus::Scanners
       # lines contain 1 or more vuln tables
 
       vulns = parse_output(table_lines)
+      @vulns_w_paths = deep_copy_wo_paths(vulns)
+      vulns.each { |vul| vul.delete('Path') }
       vuln_ids = vulns.map { |v| v['ID'] }
       report_info(:vulnerabilities, vuln_ids.uniq)
 
@@ -227,6 +230,16 @@ module Salus::Scanners
         vul['Dependency of'] = vul['Dependency of'].sort.join(', ')
       end
       vulns
+    end
+
+    def deep_copy_wo_paths(vulns)
+      vuln_list = []
+      vulns.each do |vuln|
+        vt = {}
+        vuln.each { |k, v| vt[k] = v }
+        vuln_list.push vt
+      end
+      vuln_list
     end
 
     def format_vulns(vulns)

--- a/spec/lib/salus/scanners/yarn_audit_spec.rb
+++ b/spec/lib/salus/scanners/yarn_audit_spec.rb
@@ -93,6 +93,13 @@ describe Salus::Scanners::YarnAudit do
                       "ID" => 1_070_415 }
       expect(id_vuls[0]).to eq(expected_vul)
 
+      id_vuls_w_paths = scanner.instance_variable_get(:@vulns_w_paths)
+        .select { |v| v['ID'] == 1_070_415 }
+      expect(id_vuls.size).to eq(1)
+      expected_vul['Path'] = "rollup-plugin-postcss > cssnano > cssnano-preset-default > "\
+                             "postcss-svgo > svgo > css-select > nth-check"
+      expect(id_vuls_w_paths[0]).to eq(expected_vul)
+
       id_vuls = vulns.select { |v| v['ID'] == 1_067_342 }
       expect(id_vuls.size).to eq(1)
       # vul has 1 dependency of
@@ -104,6 +111,12 @@ describe Salus::Scanners::YarnAudit do
                       "Title" => "Prototype Pollution in minimist",
                       "ID" => 1_067_342 }
       expect(id_vuls[0]).to eq(expected_vul)
+
+      id_vuls_w_paths = scanner.instance_variable_get(:@vulns_w_paths)
+        .select { |v| v['ID'] == 1_067_342 }
+      expect(id_vuls.size).to eq(1)
+      expected_vul['Path'] = "gulp-cssmin > gulp-util > minimist"
+      expect(id_vuls_w_paths[0]).to eq(expected_vul)
     end
 
     it 'should fail with error if there are errors' do

--- a/spec/lib/salus/scanners/yarn_audit_spec.rb
+++ b/spec/lib/salus/scanners/yarn_audit_spec.rb
@@ -56,7 +56,8 @@ describe Salus::Scanners::YarnAudit do
       expect(vulns.size).to eq(7)
 
       vulns.each do |vul|
-        ["Package", "Patched in", "Dependency of", "More info", "Severity", "Title"].each do |attr|
+        ["Package", "Patched in", "Dependency of", "Path",
+         "More info", "Severity", "Title"].each do |attr|
           expect(vul[attr]).to be_kind_of(String)
           expect(vul[attr]).not_to be_empty
         end
@@ -74,7 +75,8 @@ describe Salus::Scanners::YarnAudit do
       expect(vulns.size).to eq(17)
 
       vulns.each do |vul|
-        ["Package", "Patched in", "Dependency of", "More info", "Severity", "Title"].each do |attr|
+        ["Package", "Patched in", "Dependency of", "Path",
+         "More info", "Severity", "Title"].each do |attr|
           expect(vul[attr]).to be_kind_of(String)
           expect(vul[attr]).not_to be_empty
         end
@@ -87,10 +89,13 @@ describe Salus::Scanners::YarnAudit do
       expected_vul = { "Package" => "nth-check",
                       "Patched in" => ">=2.0.1",
                       "Dependency of" => "rollup-plugin-postcss",
+                      "Path" => "rollup-plugin-postcss > cssnano > cssnano-preset-default > "\
+                                "postcss-svgo > svgo > css-select > nth-check",
                       "More info" => "https://www.npmjs.com/advisories/1070415",
                       "Severity" => "high",
                       "Title" => "Inefficient Regular Expression Complexity in nth-check",
                       "ID" => 1_070_415 }
+
       expect(id_vuls[0]).to eq(expected_vul)
 
       id_vuls = vulns.select { |v| v['ID'] == 1_067_342 }
@@ -99,6 +104,7 @@ describe Salus::Scanners::YarnAudit do
       expected_vul = { "Package" => "minimist",
                       "Patched in" => ">=1.2.6",
                       "Dependency of" => "gulp-cssmin",
+                      "Path" => "gulp-cssmin > gulp-util > minimist",
                       "More info" => "https://www.npmjs.com/advisories/1067342",
                       "Severity" => "critical",
                       "Title" => "Prototype Pollution in minimist",

--- a/spec/lib/salus/scanners/yarn_audit_spec.rb
+++ b/spec/lib/salus/scanners/yarn_audit_spec.rb
@@ -56,8 +56,7 @@ describe Salus::Scanners::YarnAudit do
       expect(vulns.size).to eq(7)
 
       vulns.each do |vul|
-        ["Package", "Patched in", "Dependency of", "Path",
-         "More info", "Severity", "Title"].each do |attr|
+        ["Package", "Patched in", "Dependency of", "More info", "Severity", "Title"].each do |attr|
           expect(vul[attr]).to be_kind_of(String)
           expect(vul[attr]).not_to be_empty
         end
@@ -75,8 +74,7 @@ describe Salus::Scanners::YarnAudit do
       expect(vulns.size).to eq(17)
 
       vulns.each do |vul|
-        ["Package", "Patched in", "Dependency of", "Path",
-         "More info", "Severity", "Title"].each do |attr|
+        ["Package", "Patched in", "Dependency of", "More info", "Severity", "Title"].each do |attr|
           expect(vul[attr]).to be_kind_of(String)
           expect(vul[attr]).not_to be_empty
         end
@@ -89,8 +87,6 @@ describe Salus::Scanners::YarnAudit do
       expected_vul = { "Package" => "nth-check",
                       "Patched in" => ">=2.0.1",
                       "Dependency of" => "rollup-plugin-postcss",
-                      "Path" => "rollup-plugin-postcss > cssnano > cssnano-preset-default > "\
-                                "postcss-svgo > svgo > css-select > nth-check",
                       "More info" => "https://www.npmjs.com/advisories/1070415",
                       "Severity" => "high",
                       "Title" => "Inefficient Regular Expression Complexity in nth-check",
@@ -104,7 +100,6 @@ describe Salus::Scanners::YarnAudit do
       expected_vul = { "Package" => "minimist",
                       "Patched in" => ">=1.2.6",
                       "Dependency of" => "gulp-cssmin",
-                      "Path" => "gulp-cssmin > gulp-util > minimist",
                       "More info" => "https://www.npmjs.com/advisories/1067342",
                       "Severity" => "critical",
                       "Title" => "Prototype Pollution in minimist",

--- a/spec/lib/salus/scanners/yarn_audit_spec.rb
+++ b/spec/lib/salus/scanners/yarn_audit_spec.rb
@@ -91,7 +91,6 @@ describe Salus::Scanners::YarnAudit do
                       "Severity" => "high",
                       "Title" => "Inefficient Regular Expression Complexity in nth-check",
                       "ID" => 1_070_415 }
-
       expect(id_vuls[0]).to eq(expected_vul)
 
       id_vuls = vulns.select { |v| v['ID'] == 1_067_342 }


### PR DESCRIPTION
For yarn 1, add path to  `@vulns_w_paths`.
For newer yarn versions, ` @vulns_w_paths` stays `[]`.

Tested with new unit tests and from local salus container.