### PR TITLE
print out details of error

### DIFF
--- a/lib/salus/scanners/yarn_audit.rb
+++ b/lib/salus/scanners/yarn_audit.rb
@@ -147,8 +147,8 @@ module Salus::Scanners
         # TODO: Fix indirect dependencies as well
         fix_direct_dependency(vuln) if is_direct_dep
       end
-    rescue StandardError
-      report_error("An error occurred while auto-fixing vulnerabilities")
+    rescue StandardError => e
+      report_error("An error occurred while auto-fixing vulnerabilities #{e.backtrace}")
     end
 
     def fix_direct_dependency(vuln)

--- a/lib/salus/scanners/yarn_audit.rb
+++ b/lib/salus/scanners/yarn_audit.rb
@@ -148,7 +148,7 @@ module Salus::Scanners
         fix_direct_dependency(vuln) if is_direct_dep
       end
     rescue StandardError => e
-      report_error("An error occurred while auto-fixing vulnerabilities #{e.backtrace}")
+      report_error("An error occurred while auto-fixing vulnerabilities: #{e}, #{e.backtrace}")
     end
 
     def fix_direct_dependency(vuln)


### PR DESCRIPTION
Print out actual error with call stack.
Otherwise, it could be very hard to debug.