### PR TITLE
YarnAudit - Removing duplicate Dependency of

### DIFF
--- a/lib/salus/scanners/yarn_audit.rb
+++ b/lib/salus/scanners/yarn_audit.rb
@@ -281,7 +281,7 @@ module Salus::Scanners
 
       vulns = uniq_vulns.values
       vulns.each do |vul|
-        vul['Dependency of'] = vul['Dependency of'].sort.join(', ')
+        vul['Dependency of'] = vul['Dependency of'].uniq.sort.join(', ')
       end
       vulns
     end


### PR DESCRIPTION
YarnAudit returns duplicate `'Dependency of'` instead of returning duplicate we return only unique.