### PR TITLE
Update the Project Name Blocklist

### DIFF
--- a/lib/salus/config.rb
+++ b/lib/salus/config.rb
@@ -114,7 +114,7 @@ module Salus
     def valid_name?(name)
       return true if name.nil?
 
-      name.count("[\s;]").zero?
+      name.count("[\s;]{}").zero?
     end
 
     def scanner_active?(scanner_class)

--- a/lib/salus/config.rb
+++ b/lib/salus/config.rb
@@ -93,7 +93,8 @@ module Salus
       @builds            = final_config['builds'] || {}
 
       if !valid_name?(@project_name)
-        bad_name_msg = "project name #{@project_name} cannot contain spaces or ;"
+        bad_name_msg = "project name #{@project_name} cannot contain spaces, "\
+          "square brackets ([]), curly braces ({}) or semicolons (;)"
         raise StandardError, bad_name_msg
       end
 

--- a/spec/lib/salus/config_spec.rb
+++ b/spec/lib/salus/config_spec.rb
@@ -38,6 +38,10 @@ describe Salus::Config do
         config = Salus::Config.new
         expect(config.valid_name?("abcd def")).to be_falsey
         expect(config.valid_name?("hello;world")).to be_falsey
+        expect(config.valid_name?("foo{bar")).to be_falsey
+        expect(config.valid_name?("hello[world")).to be_falsey
+        expect(config.valid_name?("helloworld}")).to be_falsey
+        expect(config.valid_name?("helloworld]")).to be_falsey
       end
 
       it 'should accept project names with valid chars' do


### PR DESCRIPTION
**Notes to Reviewers**
Surprisingly enough, curly braces are the only remaining characters I can find that cause issues with the project name during my testing.
