### PR TITLE
Upgrade Semgrep

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -111,7 +111,7 @@ RUN go install github.com/svent/sift@${SIFT_VERSION}
 
 ### semgrep
 # https://semgrep.dev
-ENV SEMGREP_VERSION 0.62.0
+ENV SEMGREP_VERSION 0.112.1
 
 RUN pip3 install --user --no-cache-dir semgrep==${SEMGREP_VERSION}
 

--- a/lib/salus/scanners/semgrep.rb
+++ b/lib/salus/scanners/semgrep.rb
@@ -74,6 +74,9 @@ module Salus::Scanners
           base_path,
           pattern_exclude_flags || global_exclude_flags
         )
+
+        enforce_explicit_ignoring
+
         # run semgrep
         shell_return = run_shell(command)
 
@@ -180,6 +183,13 @@ module Salus::Scanners
       end
     end
 
+    def enforce_explicit_ignoring
+      # Create an empty .semgrepignore to prevent
+      # the scanner from implicitly ignoring files or folders
+      semgrepignore_path = "#{@repository.path_to_repo}/.semgrepignore"
+      File.open(semgrepignore_path, "w") {} if !File.exist?(semgrepignore_path)
+    end
+
     # rubocop:enable Metrics/AbcSize
 
     def should_run?
@@ -258,7 +268,7 @@ module Salus::Scanners
 
     def error_to_object(err)
       type = err.fetch('type', '')
-      message = err.fetch('long_msg', '')
+      message = err.fetch('message', '')
       level = err.fetch('level', '')
       spans = err.fetch('spans', {}).map do |s|
         start = s.fetch('start', {})

--- a/spec/fixtures/semgrep/pattern-not/test.py
+++ b/spec/fixtures/semgrep/pattern-not/test.py
@@ -1,0 +1,4 @@
+# This is disallowed by pattern
+db_query("SELECT * FROM ...")
+# But this is allowed, because it satisfies pattern-not
+db_query("SELECT * FROM ...", verify=True, env="prod")

--- a/spec/fixtures/semgrep/semgrep-config-pattern-not.yml
+++ b/spec/fixtures/semgrep/semgrep-config-pattern-not.yml
@@ -1,0 +1,9 @@
+rules:
+  - id: unverified-db-query
+    patterns:
+      - pattern: db_query(...)
+      - pattern-not: db_query(..., verify=True, ...)
+    message: Found unverified db query
+    severity: ERROR
+    languages:
+      - python

--- a/spec/lib/salus/scanners/semgrep_spec.rb
+++ b/spec/lib/salus/scanners/semgrep_spec.rb
@@ -244,6 +244,35 @@ describe Salus::Scanners::Semgrep do
             msg: ""
           )
         end
+
+        it "should report matches with pattern-not" do
+          repo = Salus::Repo.new("spec/fixtures/semgrep")
+          config = {
+            "matches" => [
+              {
+                "config" => "semgrep-config-pattern-not.yml",
+                "forbidden" => false
+              }
+            ]
+          }
+          scanner = Salus::Scanners::Semgrep.new(repository: repo, config: config)
+          scanner.run
+
+          expect(scanner.report.passed?).to eq(true)
+
+          info = scanner.report.to_h.fetch(:info)
+
+          expect(info[:hits]).to include(
+            config: "semgrep-config-pattern-not.yml",
+            pattern: nil,
+            forbidden: false,
+            required: false,
+            msg: "Found unverified db query\n\trule_id: unverified-db-query",
+            hit: "pattern-not/test.py:2:db_query(\"SELECT * FROM ...\")"
+          )
+
+          expect(info[:misses]).to be_empty
+        end
       end
 
       it "should report matches with a message" do

--- a/spec/lib/salus/scanners/semgrep_spec.rb
+++ b/spec/lib/salus/scanners/semgrep_spec.rb
@@ -624,15 +624,6 @@ describe Salus::Scanners::Semgrep do
           forbidden: true,
           required: false,
           msg: "Useless equality test.",
-          hit: "vendor/trivial2.py:10:    if user.id == user.id:"
-        )
-
-        expect(info[:hits]).not_to include(
-          config: nil,
-          pattern: "$X == $X",
-          forbidden: true,
-          required: false,
-          msg: "Useless equality test.",
           hit: "examples/trivial2.py:10:    if user.id == user.id:"
         )
       end
@@ -655,7 +646,7 @@ describe Salus::Scanners::Semgrep do
 
         errors = scanner.report.to_h.fetch(:errors)
         expect(errors.size).to eq(1)
-        expect(errors[0][:status]).to eq(4)
+        expect(errors[0][:status]).to eq(2)
         expect(errors[0][:stderr].downcase).to include("error")
         expect(errors[0][:message]).to eq("Call to semgrep failed")
 
@@ -685,7 +676,7 @@ describe Salus::Scanners::Semgrep do
         expect(errors.size).to eq(1)
         expect(errors[0][:status]).to eq(3) # semgrep exit code documentation
         expect(errors[0][:stderr]).to match(
-          /Could not parse unparsable_py\.py as python \(warn\)\n\t.+?unparsable_py\.py:3-3/
+          /`print\(\"foo\"` was unexpected \(warn\)\n\t.+?unparsable_py\.py:3-3/
         )
         expect(errors[0][:message]).to eq("Call to semgrep failed")
 
@@ -717,7 +708,8 @@ describe Salus::Scanners::Semgrep do
           [
             {
               level: "warn",
-              message: "Could not parse unparsable_js.js as javascript",
+              message: "Syntax error at line /home/spec/fixtures/semgrep/invalid/"\
+              "unparsable_js.js:3:\n `cosnt` was unexpected",
               spans:
               [
                 {
@@ -734,7 +726,7 @@ describe Salus::Scanners::Semgrep do
                     }
                 }
               ],
-              type: "SourceParseError"
+              type: "Syntax error"
             }
           ]
         )
@@ -761,7 +753,7 @@ describe Salus::Scanners::Semgrep do
         expect(errors.size).to eq(1)
         expect(errors[0][:status]).to eq(3) # semgrep exit code documentation
         expect(errors[0][:stderr]).to match(
-          /Could not parse unparsable_js\.js as javascript \(warn\)\n\t.+?unparsable_js\.js:3-3/
+          /\(warn\)\n\t.+?unparsable_js\.js:3-3/
         )
         expect(errors[0][:message]).to eq("Call to semgrep failed")
 


### PR DESCRIPTION
This PR upgrades the Semgrep version we use to the latest (`0.112.1`). This implicitly enables newer rule features, such as `pattern-not`, in external Semgrep configs.