### PR TITLE
Upgrade Semgrep

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -111,7 +111,7 @@ RUN go install github.com/svent/sift@${SIFT_VERSION}
 
 ### semgrep
 # https://semgrep.dev
-ENV SEMGREP_VERSION 0.62.0
+ENV SEMGREP_VERSION 0.112.1
 
 RUN pip3 install --user --no-cache-dir semgrep==${SEMGREP_VERSION}
 

--- a/lib/salus/scanners/semgrep.rb
+++ b/lib/salus/scanners/semgrep.rb
@@ -74,6 +74,9 @@ module Salus::Scanners
           base_path,
           pattern_exclude_flags || global_exclude_flags
         )
+
+        enforce_explicit_ignoring
+
         # run semgrep
         shell_return = run_shell(command)
 
@@ -180,6 +183,13 @@ module Salus::Scanners
       end
     end
 
+    def enforce_explicit_ignoring
+      # Create an empty .semgrepignore to prevent
+      # the scanner from implicitly ignoring files or folders
+      semgrepignore_path = "#{@repository.path_to_repo}/.semgrepignore"
+      File.open(semgrepignore_path, "w") {} if !File.exist?(semgrepignore_path)
+    end
+
     # rubocop:enable Metrics/AbcSize
 
     def should_run?
@@ -258,7 +268,7 @@ module Salus::Scanners
 
     def error_to_object(err)
       type = err.fetch('type', '')
-      message = err.fetch('long_msg', '')
+      message = err.fetch('message', '')
       level = err.fetch('level', '')
       spans = err.fetch('spans', {}).map do |s|
         start = s.fetch('start', {})

--- a/spec/fixtures/processor/local_uri/expected_report.json
+++ b/spec/fixtures/processor/local_uri/expected_report.json
@@ -1,63 +1,4 @@
 {
-  "version": "2.21.2",
-  "passed": true,
-  "running_time": 0.0,
-  "scans": {
-    "PatternSearch": {
-      "scanner_name": "PatternSearch",
-      "version": "0.9.0",
-      "passed": true,
-      "running_time": 0.0,
-      "warn": {
-      },
-      "info": {
-        "hits": [
-
-        ],
-        "misses": [
-
-        ]
-      },
-      "errors": [
-
-      ]
-    },
-    "RepoNotEmpty": {
-      "scanner_name": "RepoNotEmpty",
-      "version": "",
-      "passed": true,
-      "running_time": 0.0,
-      "warn": {
-      },
-      "info": {
-      },
-      "errors": [
-
-      ]
-    },
-    "Semgrep": {
-      "scanner_name": "Semgrep",
-      "version": "0.62.0",
-      "passed": true,
-      "running_time": 0.0,
-      "warn": {
-      },
-      "info": {
-        "hits": [
-
-        ],
-        "misses": [
-
-        ]
-      },
-      "errors": [
-
-      ]
-    }
-  },
-  "errors": [
-
-  ],
   "config": {
     "active_scanners": [
       "Bandit",
@@ -89,6 +30,10 @@
       "Semgrep",
       "YarnAudit"
     ],
+    "builds": {
+      "service_name": "buildkite",
+      "url": "http://example.com/builds/123"
+    },
     "enforced_scanners": [
       "Brakeman",
       "BundleAudit",
@@ -99,6 +44,12 @@
       "RepoNotEmpty",
       "Semgrep",
       "YarnAudit"
+    ],
+    "report_uris": [
+      {
+        "format": "json",
+        "uri": "file:///home/spec/fixtures/processor/local_uri/salus_reports_folder/salus-report.json"
+      }
     ],
     "scanner_configs": {
       "Bandit": {
@@ -125,6 +76,10 @@
         "pass_on_raise": false,
         "scanner_timeout_s": 0
       },
+      "GoVersionScanner": {
+        "pass_on_raise": false,
+        "scanner_timeout_s": 0
+      },
       "Gosec": {
         "pass_on_raise": false,
         "scanner_timeout_s": 0
@@ -142,6 +97,10 @@
         "scanner_timeout_s": 0
       },
       "NPMPackageScanner": {
+        "pass_on_raise": false,
+        "scanner_timeout_s": 0
+      },
+      "NodeAudit": {
         "pass_on_raise": false,
         "scanner_timeout_s": 0
       },
@@ -193,18 +152,6 @@
         "pass_on_raise": false,
         "scanner_timeout_s": 0
       },
-      "Semgrep": {
-        "pass_on_raise": false,
-        "scanner_timeout_s": 0
-      },
-      "YarnAudit": {
-        "pass_on_raise": false,
-        "scanner_timeout_s": 0
-      },
-      "GoVersionScanner": {
-        "pass_on_raise": false,
-        "scanner_timeout_s": 0
-      },
       "RubyPackageScanner": {
         "pass_on_raise": false,
         "scanner_timeout_s": 0
@@ -213,20 +160,14 @@
         "pass_on_raise": false,
         "scanner_timeout_s": 0
       },
-      "NodeAudit": {
+      "Semgrep": {
+        "pass_on_raise": false,
+        "scanner_timeout_s": 0
+      },
+      "YarnAudit": {
         "pass_on_raise": false,
         "scanner_timeout_s": 0
       }
-    },
-    "report_uris": [
-      {
-        "uri": "file://spec/fixtures/processor/local_uri/salus_reports_folder/salus-report.json",
-        "format": "json"
-      }
-    ],
-    "builds": {
-      "url": "http://example.com/builds/123",
-      "service_name": "buildkite"
     },
     "sources": {
       "configured": [
@@ -236,5 +177,64 @@
         "file:///salus.yaml"
       ]
     }
-  }
+  },
+  "errors": [
+
+  ],
+  "passed": true,
+  "running_time": 0.52,
+  "scans": {
+    "PatternSearch": {
+      "errors": [
+
+      ],
+      "info": {
+        "hits": [
+
+        ],
+        "misses": [
+
+        ]
+      },
+      "passed": true,
+      "running_time": 0.0,
+      "scanner_name": "PatternSearch",
+      "version": "0.9.0",
+      "warn": {
+      }
+    },
+    "RepoNotEmpty": {
+      "errors": [
+
+      ],
+      "info": {
+      },
+      "passed": true,
+      "running_time": 0.0,
+      "scanner_name": "RepoNotEmpty",
+      "version": "",
+      "warn": {
+      }
+    },
+    "Semgrep": {
+      "errors": [
+
+      ],
+      "info": {
+        "hits": [
+
+        ],
+        "misses": [
+
+        ]
+      },
+      "passed": true,
+      "running_time": 0.0,
+      "scanner_name": "Semgrep",
+      "version": "0.112.1",
+      "warn": {
+      }
+    }
+  },
+  "version": "2.21.2"
 }

--- a/spec/fixtures/processor/remote_uri/expected_report.json
+++ b/spec/fixtures/processor/remote_uri/expected_report.json
@@ -1,63 +1,4 @@
 {
-  "version": "2.21.2",
-  "passed": true,
-  "running_time": 0.35,
-  "scans": {
-    "RepoNotEmpty": {
-      "scanner_name": "RepoNotEmpty",
-      "version": "",
-      "passed": true,
-      "running_time": 0.01,
-      "warn": {
-      },
-      "info": {
-      },
-      "errors": [
-
-      ]
-    },
-    "PatternSearch": {
-      "scanner_name": "PatternSearch",
-      "version": "0.9.0",
-      "passed": true,
-      "running_time": 0.0,
-      "warn": {
-      },
-      "info": {
-        "hits": [
-
-        ],
-        "misses": [
-
-        ]
-      },
-      "errors": [
-
-      ]
-    },
-    "Semgrep": {
-      "scanner_name": "Semgrep",
-      "version": "0.62.0",
-      "passed": true,
-      "running_time": 0.0,
-      "warn": {
-      },
-      "info": {
-        "hits": [
-
-        ],
-        "misses": [
-
-        ]
-      },
-      "errors": [
-
-      ]
-    }
-  },
-  "errors": [
-
-  ],
   "config": {
     "active_scanners": [
       "Bandit",
@@ -89,6 +30,10 @@
       "Semgrep",
       "YarnAudit"
     ],
+    "builds": {
+      "service_name": "buildkite",
+      "url": "http://example.com/builds/123"
+    },
     "enforced_scanners": [
       "Brakeman",
       "BundleAudit",
@@ -99,6 +44,12 @@
       "RepoNotEmpty",
       "Semgrep",
       "YarnAudit"
+    ],
+    "report_uris": [
+      {
+        "format": "json",
+        "uri": "https://nerv.tk3/salus-report"
+      }
     ],
     "scanner_configs": {
       "Bandit": {
@@ -146,6 +97,10 @@
         "scanner_timeout_s": 0
       },
       "NPMPackageScanner": {
+        "pass_on_raise": false,
+        "scanner_timeout_s": 0
+      },
+      "NodeAudit": {
         "pass_on_raise": false,
         "scanner_timeout_s": 0
       },
@@ -212,21 +167,7 @@
       "YarnAudit": {
         "pass_on_raise": false,
         "scanner_timeout_s": 0
-      },
-      "NodeAudit": {
-        "pass_on_raise": false,
-        "scanner_timeout_s": 0
       }
-    },
-    "report_uris": [
-      {
-        "uri": "https://nerv.tk3/salus-report",
-        "format": "json"
-      }
-    ],
-    "builds": {
-      "url": "http://example.com/builds/123",
-      "service_name": "buildkite"
     },
     "sources": {
       "configured": [
@@ -236,5 +177,64 @@
         "file:///salus.yaml"
       ]
     }
-  }
+  },
+  "errors": [
+
+  ],
+  "passed": true,
+  "running_time": 1.22,
+  "scans": {
+    "PatternSearch": {
+      "errors": [
+
+      ],
+      "info": {
+        "hits": [
+
+        ],
+        "misses": [
+
+        ]
+      },
+      "passed": true,
+      "running_time": 0.0,
+      "scanner_name": "PatternSearch",
+      "version": "0.9.0",
+      "warn": {
+      }
+    },
+    "RepoNotEmpty": {
+      "errors": [
+
+      ],
+      "info": {
+      },
+      "passed": true,
+      "running_time": 0.0,
+      "scanner_name": "RepoNotEmpty",
+      "version": "",
+      "warn": {
+      }
+    },
+    "Semgrep": {
+      "errors": [
+
+      ],
+      "info": {
+        "hits": [
+
+        ],
+        "misses": [
+
+        ]
+      },
+      "passed": true,
+      "running_time": 0.0,
+      "scanner_name": "Semgrep",
+      "version": "0.112.1",
+      "warn": {
+      }
+    }
+  },
+  "version": "2.21.2"
 }

--- a/spec/fixtures/semgrep/pattern-not/test.py
+++ b/spec/fixtures/semgrep/pattern-not/test.py
@@ -1,0 +1,4 @@
+# This is disallowed by pattern
+db_query("SELECT * FROM ...")
+# But this is allowed, because it satisfies pattern-not
+db_query("SELECT * FROM ...", verify=True, env="prod")

--- a/spec/fixtures/semgrep/semgrep-config-pattern-not.yml
+++ b/spec/fixtures/semgrep/semgrep-config-pattern-not.yml
@@ -1,0 +1,9 @@
+rules:
+  - id: unverified-db-query
+    patterns:
+      - pattern: db_query(...)
+      - pattern-not: db_query(..., verify=True, ...)
+    message: Found unverified db query
+    severity: ERROR
+    languages:
+      - python

--- a/spec/fixtures/sorted_results/sorted_json.json
+++ b/spec/fixtures/sorted_results/sorted_json.json
@@ -53,15 +53,15 @@
           }
         ]
       },
-      "logs": "Could not parse unparsable_py.py as python (warn)\n\t/home/spec/fixtures/semgrep/invalid/unparsable_py.py:3-3\n\nRequired pattern \"1 == $X\" was not found - Useless equality test.",
+      "logs": "Syntax error at line /home/spec/fixtures/semgrep/invalid/unparsable_py.py:3:\n `print(\"foo\"` was unexpected (warn)\n\t/home/spec/fixtures/semgrep/invalid/unparsable_py.py:3-3\n\nRequired pattern \"1 == $X\" was not found - Useless equality test.",
       "passed": false,
       "scanner_name": "Semgrep",
-      "version": "0.62.0",
+      "version": "0.112.1",
       "warn": {
         "semgrep_non_fatal": [
           {
             "level": "warn",
-            "message": "Could not parse unparsable_py.py as python",
+            "message": "Syntax error at line /home/spec/fixtures/semgrep/invalid/unparsable_py.py:3:\n `print(\"foo\"` was unexpected",
             "spans": [
               {
                 "end": {
@@ -70,12 +70,12 @@
                 },
                 "file": "/home/spec/fixtures/semgrep/invalid/unparsable_py.py",
                 "start": {
-                  "col": 12,
+                  "col": 1,
                   "line": 3
                 }
               }
             ],
-            "type": "SourceParseError"
+            "type": "Syntax error"
           }
         ]
       }

--- a/spec/fixtures/sorted_results/sorted_sarif.json
+++ b/spec/fixtures/sorted_results/sorted_sarif.json
@@ -43,16 +43,16 @@
                   "uriBaseId": "%SRCROOT%"
                 },
                 "region": {
-                  "startColumn": 12,
+                  "startColumn": 1,
                   "startLine": 3
                 }
               }
             }
           ],
           "message": {
-            "text": "Could not parse unparsable_py.py as python"
+            "text": "Syntax error at line /home/spec/fixtures/semgrep/invalid/unparsable_py.py:3:\n `print(\"foo\"` was unexpected"
           },
-          "ruleId": "SourceParseError",
+          "ruleId": "Syntax error",
           "ruleIndex": 0
         }
       ],
@@ -66,20 +66,6 @@
           "rules": [
             {
               "fullDescription": {
-                "text": "Could not parse unparsable_py.py as python"
-              },
-              "help": {
-                "markdown": "[More info](https://github.com/coinbase/salus/blob/master/docs/scanners/semgrep.md).",
-                "text": "More info: https://github.com/coinbase/salus/blob/master/docs/scanners/semgrep.md"
-              },
-              "helpUri": "https://github.com/coinbase/salus/blob/master/docs/scanners/semgrep.md",
-              "id": "SourceParseError",
-              "messageStrings": {
-              },
-              "name": "SourceParseError"
-            },
-            {
-              "fullDescription": {
                 "text": "Required Pattern Not Found"
               },
               "help": {
@@ -91,9 +77,23 @@
               "messageStrings": {
               },
               "name": "Required Pattern Not Found"
+            },
+            {
+              "fullDescription": {
+                "text": "Syntax error at line /home/spec/fixtures/semgrep/invalid/unparsable_py.py:3:\n `print(\"foo\"` was unexpected"
+              },
+              "help": {
+                "markdown": "[More info](https://github.com/coinbase/salus/blob/master/docs/scanners/semgrep.md).",
+                "text": "More info: https://github.com/coinbase/salus/blob/master/docs/scanners/semgrep.md"
+              },
+              "helpUri": "https://github.com/coinbase/salus/blob/master/docs/scanners/semgrep.md",
+              "id": "Syntax error",
+              "messageStrings": {
+              },
+              "name": "Syntax error"
             }
           ],
-          "version": "0.62.0"
+          "version": "0.112.1"
         }
       }
     },

--- a/spec/fixtures/sorted_results/sorted_yaml.yml
+++ b/spec/fixtures/sorted_results/sorted_yaml.yml
@@ -28,22 +28,25 @@
         :msg: Useless equality test.
         :pattern: 1 == $X
         :required: true
-    :logs: "Could not parse unparsable_py.py as python (warn)\n\t/home/spec/fixtures/semgrep/invalid/unparsable_py.py:3-3\n\nRequired
+    :logs: "Syntax error at line /home/spec/fixtures/semgrep/invalid/unparsable_py.py:3:\n
+      `print(\"foo\"` was unexpected (warn)\n\t/home/spec/fixtures/semgrep/invalid/unparsable_py.py:3-3\n\nRequired
       pattern \"1 == $X\" was not found - Useless equality test."
     :passed: false
     :scanner_name: Semgrep
-    :version: 0.62.0
+    :version: 0.112.1
     :warn:
       :semgrep_non_fatal:
       - :level: warn
-        :message: Could not parse unparsable_py.py as python
+        :message: |-
+          Syntax error at line /home/spec/fixtures/semgrep/invalid/unparsable_py.py:3:
+           `print("foo"` was unexpected
         :spans:
         - :end:
             col: 12
             line: 3
           :file: "/home/spec/fixtures/semgrep/invalid/unparsable_py.py"
           :start:
-            col: 12
+            col: 1
             line: 3
-        :type: SourceParseError
+        :type: Syntax error
 :version: 2.21.2

--- a/spec/lib/salus/report_spec.rb
+++ b/spec/lib/salus/report_spec.rb
@@ -1,4 +1,5 @@
 require_relative '../../spec_helper.rb'
+require 'yaml'
 
 describe Salus::Report do
   let(:report) { build_report }
@@ -762,6 +763,11 @@ describe Salus::Report do
         expected_yaml.slice!("---\n")
         result = report.to_yaml
         result.slice!("---\n")
+        # Prevent whitespace issues by
+        # formatting both values identically
+        result = YAML.safe_load(result).to_s
+        expected_yaml = YAML.safe_load(expected_yaml).to_s
+
         expect(expected_yaml).to eq(result)
       end
 

--- a/spec/lib/salus/scanners/semgrep_spec.rb
+++ b/spec/lib/salus/scanners/semgrep_spec.rb
@@ -653,15 +653,6 @@ describe Salus::Scanners::Semgrep do
           forbidden: true,
           required: false,
           msg: "Useless equality test.",
-          hit: "vendor/trivial2.py:10:    if user.id == user.id:"
-        )
-
-        expect(info[:hits]).not_to include(
-          config: nil,
-          pattern: "$X == $X",
-          forbidden: true,
-          required: false,
-          msg: "Useless equality test.",
           hit: "examples/trivial2.py:10:    if user.id == user.id:"
         )
       end
@@ -684,7 +675,7 @@ describe Salus::Scanners::Semgrep do
 
         errors = scanner.report.to_h.fetch(:errors)
         expect(errors.size).to eq(1)
-        expect(errors[0][:status]).to eq(4)
+        expect(errors[0][:status]).to eq(2)
         expect(errors[0][:stderr].downcase).to include("error")
         expect(errors[0][:message]).to eq("Call to semgrep failed")
 
@@ -714,7 +705,7 @@ describe Salus::Scanners::Semgrep do
         expect(errors.size).to eq(1)
         expect(errors[0][:status]).to eq(3) # semgrep exit code documentation
         expect(errors[0][:stderr]).to match(
-          /Could not parse unparsable_py\.py as python \(warn\)\n\t.+?unparsable_py\.py:3-3/
+          /`print\(\"foo\"` was unexpected \(warn\)\n\t.+?unparsable_py\.py:3-3/
         )
         expect(errors[0][:message]).to eq("Call to semgrep failed")
 
@@ -746,7 +737,8 @@ describe Salus::Scanners::Semgrep do
           [
             {
               level: "warn",
-              message: "Could not parse unparsable_js.js as javascript",
+              message: "Syntax error at line /home/spec/fixtures/semgrep/invalid/"\
+              "unparsable_js.js:3:\n `cosnt` was unexpected",
               spans:
               [
                 {
@@ -763,7 +755,7 @@ describe Salus::Scanners::Semgrep do
                     }
                 }
               ],
-              type: "SourceParseError"
+              type: "Syntax error"
             }
           ]
         )
@@ -790,7 +782,7 @@ describe Salus::Scanners::Semgrep do
         expect(errors.size).to eq(1)
         expect(errors[0][:status]).to eq(3) # semgrep exit code documentation
         expect(errors[0][:stderr]).to match(
-          /Could not parse unparsable_js\.js as javascript \(warn\)\n\t.+?unparsable_js\.js:3-3/
+          /\(warn\)\n\t.+?unparsable_js\.js:3-3/
         )
         expect(errors[0][:message]).to eq("Call to semgrep failed")
 

--- a/spec/lib/salus/scanners/semgrep_spec.rb
+++ b/spec/lib/salus/scanners/semgrep_spec.rb
@@ -244,6 +244,35 @@ describe Salus::Scanners::Semgrep do
             msg: ""
           )
         end
+
+        it "should report matches with pattern-not" do
+          repo = Salus::Repo.new("spec/fixtures/semgrep")
+          config = {
+            "matches" => [
+              {
+                "config" => "semgrep-config-pattern-not.yml",
+                "forbidden" => false
+              }
+            ]
+          }
+          scanner = Salus::Scanners::Semgrep.new(repository: repo, config: config)
+          scanner.run
+
+          expect(scanner.report.passed?).to eq(true)
+
+          info = scanner.report.to_h.fetch(:info)
+
+          expect(info[:hits]).to include(
+            config: "semgrep-config-pattern-not.yml",
+            pattern: nil,
+            forbidden: false,
+            required: false,
+            msg: "Found unverified db query\n\trule_id: unverified-db-query",
+            hit: "pattern-not/test.py:2:db_query(\"SELECT * FROM ...\")"
+          )
+
+          expect(info[:misses]).to be_empty
+        end
       end
 
       it "should report matches with a message" do


### PR DESCRIPTION
This PR upgrades the Semgrep version we use to the latest (0.112.1). This implicitly enables newer rule features, such as pattern-not, in external Semgrep configs.