### PR TITLE
update brakeman to v5.3.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'thor', '~> 1.1.0'
 gem 'toml', '~> 0.2.0'
 
 group :scanners do
-  gem 'brakeman', '5.3.0'
+  gem 'brakeman', '5.3.1'
   gem 'bundler-audit', '~> 0.8.0'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,7 +18,7 @@ GEM
       json (>= 1.5.1)
     ast (2.4.2)
     atomos (0.1.3)
-    brakeman (5.3.0)
+    brakeman (5.3.1)
     bugsnag (6.19.0)
       concurrent-ruby (~> 1.0)
     bundler-audit (0.8.0)
@@ -196,7 +196,7 @@ PLATFORMS
 DEPENDENCIES
   activemodel (~> 6.1.3)
   activesupport (~> 6.1.3)
-  brakeman (= 5.3.0)
+  brakeman (= 5.3.1)
   bugsnag (~> 6.19.0)
   bundler (= 2.3.1)
   bundler-audit (~> 0.8.0)

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ docker run --rm -t -v $(pwd):/home/repo coinbase/salus
 ## Supported Scanners
 
 - [Bandit](docs/scanners/bandit.md) - Execution of [Bandit](https://pypi.org/project/bandit/) 1.6.2, looks for common security issues in Python code.
-- [Brakeman](docs/scanners/brakeman.md) - Execution of [Brakeman](https://brakemanscanner.org/) 5.3.0, looks for vulnerable code in Rails projects.
+- [Brakeman](docs/scanners/brakeman.md) - Execution of [Brakeman](https://brakemanscanner.org/) 5.3.1, looks for vulnerable code in Rails projects.
 - [semgrep](docs/scanners/semgrep.md) - Execution of [`semgrep`](https://semgrep.dev) 0.62.0 which looks for semantic and syntactical patterns in code at the AST level.
 - [BundleAudit](docs/scanners/bundle_audit.md) - Execution of [bundle-audit](https://github.com/rubysec/bundler-audit) 0.8.0, looks for CVEs in ruby gem dependencies.
 - [Gosec](docs/scanners/gosec.md) - Execution of [gosec](https://github.com/securego/gosec) 2.11.0, looks for security problems in go code.

--- a/spec/fixtures/sarifs/diff/sarif_1.json
+++ b/spec/fixtures/sarifs/diff/sarif_1.json
@@ -6,7 +6,7 @@
       "tool": {
         "driver": {
           "name": "Brakeman",
-          "version": "5.3.0",
+          "version": "5.3.1",
           "informationUri": "https://github.com/presidentbeef/brakeman",
           "rules": [
 

--- a/spec/fixtures/sarifs/diff/sarif_1_2.json
+++ b/spec/fixtures/sarifs/diff/sarif_1_2.json
@@ -6,7 +6,7 @@
       "tool": {
         "driver": {
           "name": "Brakeman",
-          "version": "5.3.0",
+          "version": "5.3.1",
           "informationUri": "https://github.com/presidentbeef/brakeman",
           "rules": [
 

--- a/spec/fixtures/sarifs/diff/sarif_1_3.json
+++ b/spec/fixtures/sarifs/diff/sarif_1_3.json
@@ -6,7 +6,7 @@
       "tool": {
         "driver": {
           "name": "Brakeman",
-          "version": "5.3.0",
+          "version": "5.3.1",
           "informationUri": "https://github.com/presidentbeef/brakeman",
           "rules": [
 

--- a/spec/fixtures/sarifs/diff/sarif_1_non_enforced.json
+++ b/spec/fixtures/sarifs/diff/sarif_1_non_enforced.json
@@ -6,7 +6,7 @@
       "tool": {
         "driver": {
           "name": "Brakeman",
-          "version": "5.3.0",
+          "version": "5.3.1",
           "informationUri": "https://github.com/presidentbeef/brakeman",
           "rules": [
 

--- a/spec/fixtures/sarifs/diff/sarif_2.json
+++ b/spec/fixtures/sarifs/diff/sarif_2.json
@@ -6,7 +6,7 @@
       "tool": {
         "driver": {
           "name": "Brakeman",
-          "version": "5.3.0",
+          "version": "5.3.1",
           "informationUri": "https://github.com/presidentbeef/brakeman",
           "rules": [
             {

--- a/spec/fixtures/sarifs/diff/sarif_2_1.json
+++ b/spec/fixtures/sarifs/diff/sarif_2_1.json
@@ -6,7 +6,7 @@
       "tool": {
         "driver": {
           "name": "Brakeman",
-          "version": "5.3.0",
+          "version": "5.3.1",
           "informationUri": "https://github.com/presidentbeef/brakeman",
           "rules": [
             {

--- a/spec/fixtures/sarifs/diff/sarif_3.json
+++ b/spec/fixtures/sarifs/diff/sarif_3.json
@@ -6,7 +6,7 @@
       "tool": {
         "driver": {
           "name": "Brakeman",
-          "version": "5.3.0",
+          "version": "5.3.1",
           "informationUri": "https://github.com/presidentbeef/brakeman",
           "rules": [
 

--- a/spec/fixtures/sarifs/diff/sarif_all_passed.json
+++ b/spec/fixtures/sarifs/diff/sarif_all_passed.json
@@ -6,7 +6,7 @@
       "tool": {
         "driver": {
           "name": "Brakeman",
-          "version": "5.3.0",
+          "version": "5.3.1",
           "informationUri": "https://github.com/presidentbeef/brakeman",
           "rules": [
 

--- a/spec/fixtures/sarifs/diff/sarif_succ.json
+++ b/spec/fixtures/sarifs/diff/sarif_succ.json
@@ -6,7 +6,7 @@
       "tool": {
         "driver": {
           "name": "Brakeman",
-          "version": "5.3.0",
+          "version": "5.3.1",
           "informationUri": "https://github.com/presidentbeef/brakeman",
           "rules": [
 


### PR DESCRIPTION
This PR updates salus to v5.3.1. We saw an issue in 5.3.0 with CVE-2022-32209

The brakeman team released a

Updating brakeman to this patched version will fix issues with CVE-2022-32209