### PR TITLE
Fixing Incorrect Auto Fix Doc

### DIFF
--- a/docs/scanners/yarn_audit.md
+++ b/docs/scanners/yarn_audit.md
@@ -26,7 +26,7 @@ scanner_configs:
 ```
 
 If you want salus to autofix the yarn dependency files, then set `auto_fix: true`.
-> NOTE: Only availabe for yarn > 2.0.0.
+> NOTE: Only availabe for yarn < 2.0.0.
 
 ```yaml
 scanner_configs:


### PR DESCRIPTION
Doc incorrectly mentioned yarn auto fix worked for version greater than 2.0 that has been changed to saying it works for version under 2.0.