### PR TITLE
fix incomplete semgrep error message and exit status with pass_on_raise

### DIFF
--- a/spec/fixtures/semgrep/semgrep-misconfig.yml
+++ b/spec/fixtures/semgrep/semgrep-misconfig.yml
@@ -1,0 +1,12 @@
+rules:
+    - patterns:
+        - pattern: $X == $X
+      message: $X == $X is always true
+      languages: [python]
+      severity: WARNING
+    - id: semgrep-eqeq-test
+      patterns:
+        - pattern: $X == $X
+      message: $X == $X is always true
+      languages: [python]
+      severity: WARNING

--- a/spec/lib/salus/scanners/semgrep_spec.rb
+++ b/spec/lib/salus/scanners/semgrep_spec.rb
@@ -672,7 +672,6 @@ describe Salus::Scanners::Semgrep do
         scanner = Salus::Scanners::Semgrep.new(repository: repo, config: config)
         scanner.run
 
-        expect(scanner.report.passed?).to eq(false)
         errors = scanner.report.to_h.fetch(:errors)
         expect(errors.size).to eq(1)
         error = errors[0]

--- a/spec/lib/salus/scanners/semgrep_spec.rb
+++ b/spec/lib/salus/scanners/semgrep_spec.rb
@@ -664,7 +664,7 @@ describe Salus::Scanners::Semgrep do
         config = {
           "matches" => [
             {
-              "config" => "semgrep-misconfig.yml",
+              "config" => "semgrep-misconfig.yml", # 1 rule missing id
               "forbidden" => true
             }
           ]

--- a/spec/lib/salus/scanners/semgrep_spec.rb
+++ b/spec/lib/salus/scanners/semgrep_spec.rb
@@ -658,6 +658,31 @@ describe Salus::Scanners::Semgrep do
       end
     end
 
+    context "rule misconfigured" do
+      it "should output misconfig reason" do
+        repo = Salus::Repo.new("spec/fixtures/semgrep")
+        config = {
+          "matches" => [
+            {
+              "config" => "semgrep-misconfig.yml",
+              "forbidden" => true
+            }
+          ]
+        }
+        scanner = Salus::Scanners::Semgrep.new(repository: repo, config: config)
+        scanner.run
+
+        expect(scanner.report.passed?).to eq(false)
+        errors = scanner.report.to_h.fetch(:errors)
+        expect(errors.size).to eq(1)
+        error = errors[0]
+        expect(error[:message]).to eq("Call to semgrep failed")
+        expect(error[:stderr]).to include("semgrep-misconfig.yml:2-7 Invalid rule schema "\
+                                          "One of these properties is missing: 'id'")
+        expect(error[:stderr]).to include("invalid configuration file found")
+      end
+    end
+
     context "invalid pattern or settings which causes error" do
       it "should record the STDERR of semgrep" do
         repo = Salus::Repo.new("spec/fixtures/semgrep")

--- a/spec/lib/salus_spec.rb
+++ b/spec/lib/salus_spec.rb
@@ -4,6 +4,7 @@ require_relative '../spec_helper.rb'
 describe Salus::CLI do
   # prevent actual system exits because they kill tests
   before do
+    Salus.hard_error_encountered = false
     allow(Salus).to receive(:system_exit) do |arg|
       arg # just return the input
     end


### PR DESCRIPTION
Fixed the semgrep issue below

1. If `pass_on_raise=true` in salus config and the semgrep has a misconfiguration, like missing id in rule, then semgrep exits with success and error is hidden.
2. If there is a misconfig (`shell_return.status = 7`), then the error message does not show the key info, like scanner is misconfigured, and the associated misconfiguration details.

Tested with united tests and `docker build ...; docker run ...`.