### PR TITLE
fix weird bandit errors from circle ci

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,9 @@ RUN curl -fsSL "$RUST_DOWNLOAD_URL" -o rust.tar.gz \
 # Install bandit, python static code scanner
 ENV BANDIT_VERSION 1.6.2
 
+# added pip3 install --user importlib_metadata==4.7.1
+# because the newer version causes a bandit error that is only reproducible with circle ci
+# "No such file or directory: '/root/.cache/python-entrypoints/"
 RUN pip install wheel \
   && pip3 install wheel \
   && pip install --user bandit==${BANDIT_VERSION} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,8 @@ RUN pip install wheel \
   && pip3 install wheel \
   && pip install --user bandit==${BANDIT_VERSION} \
   && mv .local/bin/bandit .local/bin/bandit2 \
-  && pip3 install --user bandit==${BANDIT_VERSION}
+  && pip3 install --user bandit==${BANDIT_VERSION} \
+  && pip3 install --user importlib_metadata==4.7.1
 
 ### Ruby
 # ruby gems


### PR DESCRIPTION
Fixed weird bandit errors, like
```
raceback (most recent call last):
  File "/root/.local/lib/python3.7/site-packages/stevedore/_cache.py", line 159, in _get_data_for_path
    with open(filename, 'r') as f:
FileNotFoundError: [Errno 2] No such file or directory: '/root/.cache/python-entrypoints/c0ae7819d13f155229993453594e1ca065bae25b5a38401db52942abea84eca9'
```

These errors could only be reproduced from circle ci.

Solution described in https://github.com/PyCQA/bandit/issues/730