### PR TITLE
fix semgrep non-uniq ids for forbidden patterns

### DIFF
--- a/lib/salus/scanners/semgrep.rb
+++ b/lib/salus/scanners/semgrep.rb
@@ -1,5 +1,6 @@
 require "salus/scanners/base"
 require "json"
+require 'digest/sha1'
 
 # Report any matches to a list of semantic grep patterns provided by the config file.
 # semgrep is a grep like tool for doing AST pattern matching.
@@ -98,6 +99,7 @@ module Salus::Scanners
             if match["required"]
               failure_messages << "\nRequired #{user_message} was not found " \
               "- #{match['message']}"
+
               all_misses << {
                 pattern: match['pattern'],
                 config: match['config'],
@@ -114,7 +116,13 @@ module Salus::Scanners
                 "- #{msg}\n" \
                 "\t#{hit_to_string(hit, base_path)}"
               end
+              hit_id = if hit['check_id'] == '-'
+                         Digest::SHA1.hexdigest(match['pattern'])
+                       else
+                         hit['check_id']
+                       end
               all_hits << {
+                id: hit_id,
                 pattern: match['pattern'],
                 config: match['config'],
                 forbidden: match["forbidden"],

--- a/lib/salus/scanners/semgrep.rb
+++ b/lib/salus/scanners/semgrep.rb
@@ -117,7 +117,7 @@ module Salus::Scanners
               end
               hit_id = if hit['check_id'] == '-' # id not specified by user
                          Digest::SHA1.hexdigest(match['pattern'])
-                       else
+                       else # id specified by user
                          hit['check_id']
                        end
               all_hits << {

--- a/lib/salus/scanners/semgrep.rb
+++ b/lib/salus/scanners/semgrep.rb
@@ -99,7 +99,6 @@ module Salus::Scanners
             if match["required"]
               failure_messages << "\nRequired #{user_message} was not found " \
               "- #{match['message']}"
-
               all_misses << {
                 pattern: match['pattern'],
                 config: match['config'],

--- a/lib/salus/scanners/semgrep.rb
+++ b/lib/salus/scanners/semgrep.rb
@@ -115,7 +115,7 @@ module Salus::Scanners
                 "- #{msg}\n" \
                 "\t#{hit_to_string(hit, base_path)}"
               end
-              hit_id = if hit['check_id'] == '-'
+              hit_id = if hit['check_id'] == '-' # id not specified by user
                          Digest::SHA1.hexdigest(match['pattern'])
                        else
                          hit['check_id']

--- a/lib/sarif/semgrep_sarif.rb
+++ b/lib/sarif/semgrep_sarif.rb
@@ -76,7 +76,7 @@ module Sarif
       location = hit[:hit].split(":") # [file_name, line, code_preview]
 
       {
-        id: "Forbidden Pattern Found",
+        id: hit[:id],
         name: "#{hit[:pattern]} / #{hit[:msg]} Forbidden Pattern Found",
         level: "HIGH",
         details: message(hit, false),

--- a/spec/lib/salus/scanners/semgrep_spec.rb
+++ b/spec/lib/salus/scanners/semgrep_spec.rb
@@ -22,6 +22,7 @@ describe Salus::Scanners::Semgrep do
         info = scanner.report.to_h.fetch(:info)
 
         expect(info[:hits]).to include(
+          id: "11d6bdec931137a1063338f1f80a631f5b1f2fc2",
           config: nil,
           pattern: "$X == $X",
           forbidden: false,
@@ -31,6 +32,7 @@ describe Salus::Scanners::Semgrep do
         )
 
         expect(info[:hits]).to include(
+          id: "11d6bdec931137a1063338f1f80a631f5b1f2fc2",
           config: nil,
           pattern: "$X == $X",
           forbidden: false,
@@ -40,6 +42,7 @@ describe Salus::Scanners::Semgrep do
         )
 
         expect(info[:hits]).to include(
+          id: "11d6bdec931137a1063338f1f80a631f5b1f2fc2",
           config: nil,
           pattern: "$X == $X",
           forbidden: false,
@@ -90,6 +93,7 @@ describe Salus::Scanners::Semgrep do
           info = scanner.report.to_h.fetch(:info)
 
           expect(info[:hits]).to include(
+            id: "semgrep-eqeq-test",
             config: "semgrep-config.yml",
             pattern: nil,
             forbidden: false,
@@ -99,6 +103,7 @@ describe Salus::Scanners::Semgrep do
           )
 
           expect(info[:hits]).to include(
+            id: "semgrep-eqeq-test",
             config: "semgrep-config.yml",
             pattern: nil,
             forbidden: false,
@@ -108,6 +113,7 @@ describe Salus::Scanners::Semgrep do
           )
 
           expect(info[:hits]).to include(
+            id: "semgrep-eqeq-test",
             config: "semgrep-config.yml",
             pattern: nil,
             forbidden: false,
@@ -137,6 +143,7 @@ describe Salus::Scanners::Semgrep do
           info = scanner.report.to_h.fetch(:info)
 
           expect(info[:hits]).to include(
+            id: "semgrep-eqeq-test",
             config: "semgrep-config.yml",
             pattern: nil,
             forbidden: true,
@@ -146,6 +153,7 @@ describe Salus::Scanners::Semgrep do
           )
 
           expect(info[:hits]).to include(
+            id: "semgrep-eqeq-test",
             config: "semgrep-config.yml",
             pattern: nil,
             forbidden: true,
@@ -155,6 +163,7 @@ describe Salus::Scanners::Semgrep do
           )
 
           expect(info[:hits]).to include(
+            id: "semgrep-eqeq-test",
             config: "semgrep-config.yml",
             pattern: nil,
             forbidden: true,
@@ -184,6 +193,7 @@ describe Salus::Scanners::Semgrep do
           info = scanner.report.to_h.fetch(:info)
 
           expect(info[:hits]).to include(
+            id: "semgrep-eqeq-test",
             config: "semgrep-config.yml",
             pattern: nil,
             forbidden: false,
@@ -193,6 +203,7 @@ describe Salus::Scanners::Semgrep do
           )
 
           expect(info[:hits]).to include(
+            id: "semgrep-eqeq-test",
             config: "semgrep-config.yml",
             pattern: nil,
             forbidden: false,
@@ -202,6 +213,7 @@ describe Salus::Scanners::Semgrep do
           )
 
           expect(info[:hits]).to include(
+            id: "semgrep-eqeq-test",
             config: "semgrep-config.yml",
             pattern: nil,
             forbidden: false,
@@ -263,6 +275,7 @@ describe Salus::Scanners::Semgrep do
           info = scanner.report.to_h.fetch(:info)
 
           expect(info[:hits]).to include(
+            id: "unverified-db-query",
             config: "semgrep-config-pattern-not.yml",
             pattern: nil,
             forbidden: false,
@@ -296,6 +309,7 @@ describe Salus::Scanners::Semgrep do
         info = scanner.report.to_h.fetch(:info)
 
         expect(info[:hits]).to include(
+          id: "11d6bdec931137a1063338f1f80a631f5b1f2fc2",
           config: nil,
           pattern: "$X == $X",
           forbidden: false,
@@ -305,6 +319,7 @@ describe Salus::Scanners::Semgrep do
         )
 
         expect(info[:hits]).to include(
+          id: "11d6bdec931137a1063338f1f80a631f5b1f2fc2",
           config: nil,
           pattern: "$X == $X",
           forbidden: false,
@@ -314,6 +329,7 @@ describe Salus::Scanners::Semgrep do
         )
 
         expect(info[:hits]).to include(
+          id: "11d6bdec931137a1063338f1f80a631f5b1f2fc2",
           config: nil,
           pattern: "$X == $X",
           forbidden: false,
@@ -346,6 +362,7 @@ describe Salus::Scanners::Semgrep do
         info = scanner.report.to_h.fetch(:info)
 
         expect(info[:hits]).to include(
+          id: "11d6bdec931137a1063338f1f80a631f5b1f2fc2",
           config: nil,
           pattern: "$X == $X",
           forbidden: true,
@@ -355,6 +372,7 @@ describe Salus::Scanners::Semgrep do
         )
 
         expect(info[:hits]).to include(
+          id: "11d6bdec931137a1063338f1f80a631f5b1f2fc2",
           config: nil,
           pattern: "$X == $X",
           forbidden: true,
@@ -364,6 +382,7 @@ describe Salus::Scanners::Semgrep do
         )
 
         expect(info[:hits]).to include(
+          id: "11d6bdec931137a1063338f1f80a631f5b1f2fc2",
           config: nil,
           pattern: "$X == $X",
           forbidden: true,
@@ -398,6 +417,7 @@ describe Salus::Scanners::Semgrep do
         info = scanner.report.to_h.fetch(:info)
 
         expect(info[:hits]).to include(
+          id: "11d6bdec931137a1063338f1f80a631f5b1f2fc2",
           config: nil,
           pattern: "$X == $X",
           forbidden: false,
@@ -407,6 +427,7 @@ describe Salus::Scanners::Semgrep do
         )
 
         expect(info[:hits]).to include(
+          id: "11d6bdec931137a1063338f1f80a631f5b1f2fc2",
           config: nil,
           pattern: "$X == $X",
           forbidden: false,
@@ -416,6 +437,7 @@ describe Salus::Scanners::Semgrep do
         )
 
         expect(info[:hits]).to include(
+          id: "11d6bdec931137a1063338f1f80a631f5b1f2fc2",
           config: nil,
           pattern: "$X == $X",
           forbidden: false,
@@ -486,6 +508,7 @@ describe Salus::Scanners::Semgrep do
         info = scanner.report.to_h.fetch(:info)
 
         expect(info[:hits]).to include(
+          id: "11d6bdec931137a1063338f1f80a631f5b1f2fc2",
           config: nil,
           pattern: "$X == $X",
           forbidden: true,
@@ -495,6 +518,7 @@ describe Salus::Scanners::Semgrep do
         )
 
         expect(info[:hits]).to include(
+          id: "11d6bdec931137a1063338f1f80a631f5b1f2fc2",
           config: nil,
           pattern: "$X == $X",
           forbidden: true,
@@ -504,6 +528,7 @@ describe Salus::Scanners::Semgrep do
         )
 
         expect(info[:hits]).not_to include(
+          id: "11d6bdec931137a1063338f1f80a631f5b1f2fc2",
           config: nil,
           pattern: "$X == $X",
           forbidden: true,
@@ -537,6 +562,7 @@ describe Salus::Scanners::Semgrep do
         info = scanner.report.to_h.fetch(:info)
 
         expect(info[:hits]).to include(
+          id: "11d6bdec931137a1063338f1f80a631f5b1f2fc2",
           config: nil,
           pattern: "$X == $X",
           forbidden: true,
@@ -546,6 +572,7 @@ describe Salus::Scanners::Semgrep do
         )
 
         expect(info[:hits]).not_to include(
+          id: "11d6bdec931137a1063338f1f80a631f5b1f2fc2",
           config: nil,
           pattern: "$X == $X",
           forbidden: true,
@@ -555,6 +582,7 @@ describe Salus::Scanners::Semgrep do
         )
 
         expect(info[:hits]).not_to include(
+          id: "11d6bdec931137a1063338f1f80a631f5b1f2fc2",
           config: nil,
           pattern: "$X == $X",
           forbidden: true,
@@ -588,6 +616,7 @@ describe Salus::Scanners::Semgrep do
         info = scanner.report.to_h.fetch(:info)
 
         expect(info[:hits]).to include(
+          id: "11d6bdec931137a1063338f1f80a631f5b1f2fc2",
           config: nil,
           pattern: "$X == $X",
           forbidden: true,
@@ -597,6 +626,7 @@ describe Salus::Scanners::Semgrep do
         )
 
         expect(info[:hits]).to include(
+          id: "11d6bdec931137a1063338f1f80a631f5b1f2fc2",
           config: nil,
           pattern: "$X == $X",
           forbidden: true,
@@ -606,6 +636,7 @@ describe Salus::Scanners::Semgrep do
         )
 
         expect(info[:hits]).not_to include(
+          id: "11d6bdec931137a1063338f1f80a631f5b1f2fc2",
           config: nil,
           pattern: "$X == $X",
           forbidden: true,
@@ -639,6 +670,7 @@ describe Salus::Scanners::Semgrep do
         info = scanner.report.to_h.fetch(:info)
 
         expect(info[:hits]).to include(
+          id: "11d6bdec931137a1063338f1f80a631f5b1f2fc2",
           config: nil,
           pattern: "$X == $X",
           forbidden: true,
@@ -648,6 +680,7 @@ describe Salus::Scanners::Semgrep do
         )
 
         expect(info[:hits]).not_to include(
+          id: "11d6bdec931137a1063338f1f80a631f5b1f2fc2",
           config: nil,
           pattern: "$X == $X",
           forbidden: true,

--- a/spec/lib/sarif/semgrep_sarif_spec.rb
+++ b/spec/lib/sarif/semgrep_sarif_spec.rb
@@ -67,7 +67,7 @@ describe Sarif::SemgrepSarif do
         report.add_scan_report(scanner.report, required: true)
         sarif_report = JSON.parse(report.to_sarif)
         result = sarif_report["runs"][0]["results"]
-        # semgrep-eqeq-test an user-specified id in the semgrep config
+        # semgrep-eqeq-test is the user-specified id in the semgrep config
         matches = result.select { |r| r["ruleId"] == "semgrep-eqeq-test" }
         expect(matches.size).to eq(3)
       end

--- a/spec/lib/sarif/semgrep_sarif_spec.rb
+++ b/spec/lib/sarif/semgrep_sarif_spec.rb
@@ -24,7 +24,7 @@ describe Sarif::SemgrepSarif do
         result = sarif_report["runs"][0]["results"]
 
         expect(result).to include({
-          "ruleId": "Forbidden Pattern Found",
+          "ruleId": "11d6bdec931137a1063338f1f80a631f5b1f2fc2",
           "ruleIndex": 0,
           "level": "error",
           "message": {
@@ -49,6 +49,27 @@ describe Sarif::SemgrepSarif do
           ],
           "properties": { "severity": "HIGH" }
         }.deep_stringify_keys)
+      end
+
+      it 'vulnerabilities found in report have user specified id' do
+        repo = Salus::Repo.new("spec/fixtures/semgrep")
+        config = {
+          "matches" => [
+            {
+              "config" => "semgrep-config.yml",
+              "forbidden" => true
+            }
+          ]
+        }
+        scanner = Salus::Scanners::Semgrep.new(repository: repo, config: config)
+        scanner.run
+        report = Salus::Report.new(project_name: "Neon Genesis")
+        report.add_scan_report(scanner.report, required: true)
+        sarif_report = JSON.parse(report.to_sarif)
+        result = sarif_report["runs"][0]["results"]
+        # semgrep-eqeq-test an user-specified id in the semgrep config
+        matches = result.select { |r| r["ruleId"] == "semgrep-eqeq-test" }
+        expect(matches.size).to eq(3)
       end
 
       it 'contains info about missing required vulnerabilities' do


### PR DESCRIPTION
In the current master, every semgrep forbidden pattern ends with ruleID `Forbidden Pattern Found` in the sarif.  

This PR updates the ruleID to be the `id` specified for the pattern in the semgrep config.
In case the pattern is directly specified without id in salus.yaml and a semgrep config is not used, then the `id` would be set to the sha1 hash of the pattern.