### PR TITLE
git diff support for semgrep

### DIFF
--- a/lib/sarif/semgrep_sarif.rb
+++ b/lib/sarif/semgrep_sarif.rb
@@ -124,5 +124,10 @@ module Sarif
         help_url: SEMGREP_URI
       }
     end
+
+    def self.snippet_possibly_in_git_diff?(snippet, lines_added)
+      lines = snippet.split("\n")
+      lines.all? { |line| lines_added.keys.include?(line) }
+    end
   end
 end

--- a/spec/fixtures/sarifs/diff/git_diff_9.txt
+++ b/spec/fixtures/sarifs/diff/git_diff_9.txt
@@ -1,0 +1,17 @@
+diff --git a/lib/salus.rb b/lib/salus.rb
+index 9f37e7bf..a5e8efd7 100644
+--- a/lib/salus.rb
++++ b/lib/salus.rb
+@@ -128,6 +128,13 @@ module Salus
+       exit(status)
+     end
+ 
++    def foo
++      if x ==
++         x
++        puts "no"
++      end
++      bar()
++    end
++
+

--- a/spec/lib/sarif/semgrep_sarif_spec.rb
+++ b/spec/lib/sarif/semgrep_sarif_spec.rb
@@ -164,28 +164,24 @@ describe Sarif::SemgrepSarif do
 
   describe 'sarif diff' do
     context 'git diff support' do
+      let(:git_diff) { File.read('spec/fixtures/sarifs/diff/git_diff_9.txt') }
+
       it 'should find code in git diff if snippet' do
-        git_diff_file = 'spec/fixtures/sarifs/diff/git_diff_9.txt'
         snippet = "      bar()"
-        git_diff = File.read(git_diff_file)
         new_lines_in_git_diff = Sarif::BaseSarif.new_lines_in_git_diff(git_diff)
         r = Sarif::SemgrepSarif.snippet_possibly_in_git_diff?(snippet, new_lines_in_git_diff)
         expect(r).to be true
       end
 
       it 'should find code in git diff if snippet has multiple lines' do
-        git_diff_file = 'spec/fixtures/sarifs/diff/git_diff_9.txt'
         snippet = "      if x ==\n         x"
-        git_diff = File.read(git_diff_file)
         new_lines_in_git_diff = Sarif::BaseSarif.new_lines_in_git_diff(git_diff)
         r = Sarif::SemgrepSarif.snippet_possibly_in_git_diff?(snippet, new_lines_in_git_diff)
         expect(r).to be true
       end
 
       it 'should not find code in git diff if snippet not in git diff' do
-        git_diff_file = 'spec/fixtures/sarifs/diff/git_diff_9.txt'
         snippet = "hello_world()"
-        git_diff = File.read(git_diff_file)
         new_lines_in_git_diff = Sarif::BaseSarif.new_lines_in_git_diff(git_diff)
         r = Sarif::SemgrepSarif.snippet_possibly_in_git_diff?(snippet, new_lines_in_git_diff)
         expect(r).to be false

--- a/spec/lib/sarif/semgrep_sarif_spec.rb
+++ b/spec/lib/sarif/semgrep_sarif_spec.rb
@@ -161,4 +161,35 @@ describe Sarif::SemgrepSarif do
       end
     end
   end
+
+  describe 'sarif diff' do
+    context 'git diff support' do
+      it 'should find code in git diff if snippet' do
+        git_diff_file = 'spec/fixtures/sarifs/diff/git_diff_9.txt'
+        snippet = "      bar()"
+        git_diff = File.read(git_diff_file)
+        new_lines_in_git_diff = Sarif::BaseSarif.new_lines_in_git_diff(git_diff)
+        r = Sarif::SemgrepSarif.snippet_possibly_in_git_diff?(snippet, new_lines_in_git_diff)
+        expect(r).to be true
+      end
+
+      it 'should find code in git diff if snippet has multiple lines' do
+        git_diff_file = 'spec/fixtures/sarifs/diff/git_diff_9.txt'
+        snippet = "      if x ==\n         x"
+        git_diff = File.read(git_diff_file)
+        new_lines_in_git_diff = Sarif::BaseSarif.new_lines_in_git_diff(git_diff)
+        r = Sarif::SemgrepSarif.snippet_possibly_in_git_diff?(snippet, new_lines_in_git_diff)
+        expect(r).to be true
+      end
+
+      it 'should not find code in git diff if snippet not in git diff' do
+        git_diff_file = 'spec/fixtures/sarifs/diff/git_diff_9.txt'
+        snippet = "hello_world()"
+        git_diff = File.read(git_diff_file)
+        new_lines_in_git_diff = Sarif::BaseSarif.new_lines_in_git_diff(git_diff)
+        r = Sarif::SemgrepSarif.snippet_possibly_in_git_diff?(snippet, new_lines_in_git_diff)
+        expect(r).to be false
+      end
+    end
+  end
 end


### PR DESCRIPTION
Added support to check if semgrep code snippet in vulnerability likely appears in the git diff.
If snippet does not appear in the git diff between PR and master, then the finding will be hidden. 

**Tested with**

* Unit tests
* `docker run --rm -t -v $(pwd):/home/repo salus-local --sarif_diff_full pr.json master.json --git-diff git_diff.txt`