### PR TITLE
bump nokogiri to 1.13.9

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,7 +108,7 @@ GEM
     nanaimo (0.3.0)
     nap (1.1.0)
     netrc (0.11.0)
-    nokogiri (1.13.6)
+    nokogiri (1.13.9)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     parallel (1.19.2)


### PR DESCRIPTION
bump nokogiri to 1.13.9.
The older version results in a new bundle audit vulnerability and causes CI to fail.