### PR TITLE
Add salusWarnMessage flag

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -148,6 +148,7 @@ enforced_scanners:
 # Defines configuration relevant to specific scanners.
 scanner_configs:
   BundleAudit:
+    warn_message: true # Used to update salusWarnMessage field in SARIF report. This attribute allows for more customization further downstream in the CI pipelines.
     ignore:
       - CVE-XXXX-YYYY # irrelevant CVE which does not have a patch yet
     recursion: # optional recusion settings.  
@@ -174,7 +175,6 @@ scanner_configs:
       # copied to sub directories for proper scanning.
         - Gemfile
         - Gemfile.lock
-      warn_message: true # Used to update salusWarnMessage field in SARIF report. This attribute allows for more customization further downstream in the CI pipelines.
 ```
 
 Special configuration that exist for particular scanners is defined in the [scanners directory](/docs/scanners).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -174,6 +174,7 @@ scanner_configs:
       # copied to sub directories for proper scanning.
         - Gemfile
         - Gemfile.lock
+      warn: true # Used to update salusWarn field in SARIF report. This attribute allows for more customization further downstream in the CI pipelines.
 ```
 
 Special configuration that exist for particular scanners is defined in the [scanners directory](/docs/scanners).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -174,7 +174,7 @@ scanner_configs:
       # copied to sub directories for proper scanning.
         - Gemfile
         - Gemfile.lock
-      warn: true # Used to update salusWarnMessage field in SARIF report. This attribute allows for more customization further downstream in the CI pipelines.
+      warn_message: true # Used to update salusWarnMessage field in SARIF report. This attribute allows for more customization further downstream in the CI pipelines.
 ```
 
 Special configuration that exist for particular scanners is defined in the [scanners directory](/docs/scanners).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -174,7 +174,7 @@ scanner_configs:
       # copied to sub directories for proper scanning.
         - Gemfile
         - Gemfile.lock
-      warn: true # Used to update salusWarn field in SARIF report. This attribute allows for more customization further downstream in the CI pipelines.
+      warn: true # Used to update salusWarnMessage field in SARIF report. This attribute allows for more customization further downstream in the CI pipelines.
 ```
 
 Special configuration that exist for particular scanners is defined in the [scanners directory](/docs/scanners).

--- a/docs/scanners/base.md
+++ b/docs/scanners/base.md
@@ -47,14 +47,14 @@ scanner_configs:
     scanner_timeout_s: 60
 ```
 
-## Override salusWarn flag
+## Override salusWarnMessage flag
 
-Currently, we support two types of scanners - Active / Enforced. We want allow for more customization where we want the scanner to be Active but still warn end users about the risks, so to handle that case we are adding a new field in SARIF called ```salusWarn```. By default it will be set to False and can be changed using the scanner_configs.
+Currently, we support two types of scanners - Active / Enforced. We want allow for more customization where we want the scanner to be Active but still warn end users about the risks, so to handle that case we are adding a new field in SARIF called ```salusWarnMessage```. By default it will be set to False and can be changed using the scanner_configs.
 
 ```yaml
 scanner_configs:
   YarnAudit:
-    warn: true
+    warnMessage: true
 
 This will limit YarnAudit scans to 1 minute (60 seconds) in execution time.
 

--- a/docs/scanners/base.md
+++ b/docs/scanners/base.md
@@ -47,6 +47,15 @@ scanner_configs:
     scanner_timeout_s: 60
 ```
 
+## Override salusWarn flag
+
+Currently, we support two types of scanners - Active / Enforced. We want allow for more customization where we want the scanner to be Active but still warn end users about the risks, so to handle that case we are adding a new field in SARIF called ```salusWarn```. By default it will be set to False and can be changed using the scanner_configs.
+
+```yaml
+scanner_configs:
+  YarnAudit:
+    warn: true
+
 This will limit YarnAudit scans to 1 minute (60 seconds) in execution time.
 
 ## Reading/setting up custom configs for your scanner

--- a/lib/salus/report.rb
+++ b/lib/salus/report.rb
@@ -195,7 +195,7 @@ module Salus
     end
 
     def to_sarif(config = {})
-      sarif_json = Sarif::SarifReport.new(@scan_reports, config, @repo_path, @config).to_sarif
+      sarif_json = Sarif::SarifReport.new(@scan_reports, config, @repo_path, config).to_sarif
       begin
         sorted_sarif = JSON.parse(sarif_json).deep_sort
       rescue StandardError => e

--- a/lib/salus/report.rb
+++ b/lib/salus/report.rb
@@ -195,7 +195,7 @@ module Salus
     end
 
     def to_sarif(config = {})
-      sarif_json = Sarif::SarifReport.new(@scan_reports, config, @repo_path).to_sarif
+      sarif_json = Sarif::SarifReport.new(@scan_reports, config, @repo_path, @config).to_sarif
       begin
         sorted_sarif = JSON.parse(sarif_json).deep_sort
       rescue StandardError => e

--- a/lib/salus/report.rb
+++ b/lib/salus/report.rb
@@ -195,7 +195,7 @@ module Salus
     end
 
     def to_sarif(config = {})
-      sarif_json = Sarif::SarifReport.new(@scan_reports, config, @repo_path, config).to_sarif
+      sarif_json = Sarif::SarifReport.new(@scan_reports, config, @repo_path, @config).to_sarif
       begin
         sorted_sarif = JSON.parse(sarif_json).deep_sort
       rescue StandardError => e

--- a/lib/sarif/bandit_sarif.rb
+++ b/lib/sarif/bandit_sarif.rb
@@ -4,10 +4,11 @@ module Sarif
 
     BANDIT_URI = 'https://github.com/PyCQA/bandit'.freeze
 
-    def initialize(scan_report, repo_path = nil)
+    def initialize(scan_report, repo_path = nil, scanner_config={})
       super(scan_report, {}, repo_path)
       @uri = BANDIT_URI
       @logs = parse_scan_report!
+      @scanner_config = scanner_config
     end
 
     def parse_scan_report!

--- a/lib/sarif/bandit_sarif.rb
+++ b/lib/sarif/bandit_sarif.rb
@@ -4,7 +4,7 @@ module Sarif
 
     BANDIT_URI = 'https://github.com/PyCQA/bandit'.freeze
 
-    def initialize(scan_report, repo_path = nil, scanner_config={})
+    def initialize(scan_report, repo_path = nil, scanner_config = {})
       super(scan_report, {}, repo_path)
       @uri = BANDIT_URI
       @logs = parse_scan_report!

--- a/lib/sarif/base_sarif.rb
+++ b/lib/sarif/base_sarif.rb
@@ -33,8 +33,10 @@ module Sarif
     end
 
     def handle_warn_flag
-      unless @config.nil?
-        return @config.dig(:scanner_configs, @scan_report.scanner_name, "warn_message") || false
+      if @scanner_config.nil?
+        false
+      else
+        @scanner_config.dig(:scanner_configs, @scan_report.scanner_name, "warn_message") || false
       end
     end
 

--- a/lib/sarif/base_sarif.rb
+++ b/lib/sarif/base_sarif.rb
@@ -33,10 +33,9 @@ module Sarif
     end
 
     def check_warn
-      unless @scanner_config.nil? 
-        return @scanner_config.dig(:scanner_configs, @scan_report.scanner_name, "warn") || false
+      unless @scanner_config.nil?
+        @scanner_config.dig(:scanner_configs, @scan_report.scanner_name, "warn") || false
       end
-      return false
     end
 
     # Retrieve tool section for sarif report

--- a/lib/sarif/base_sarif.rb
+++ b/lib/sarif/base_sarif.rb
@@ -34,7 +34,7 @@ module Sarif
 
     def check_warn
       unless @scanner_config.nil?
-        @scanner_config.dig(:scanner_configs, @scan_report.scanner_name, "warn") || false
+        @scanner_config.dig(:scanner_configs, @scan_report.scanner_name, "warn_message") || false
       end
 
       false
@@ -50,7 +50,7 @@ module Sarif
           "rules" => rules,
           "properties" => {
             "salusEnforced": @required || false,
-            "salusWarn": check_warn
+            "salusWarnMessage": check_warn
           }
         }
       }

--- a/lib/sarif/base_sarif.rb
+++ b/lib/sarif/base_sarif.rb
@@ -36,6 +36,8 @@ module Sarif
       unless @scanner_config.nil?
         @scanner_config.dig(:scanner_configs, @scan_report.scanner_name, "warn") || false
       end
+
+      false
     end
 
     # Retrieve tool section for sarif report

--- a/lib/sarif/base_sarif.rb
+++ b/lib/sarif/base_sarif.rb
@@ -36,8 +36,6 @@ module Sarif
       unless @scanner_config.nil?
         @scanner_config.dig(:scanner_configs, @scan_report.scanner_name, "warn_message") || false
       end
-
-      false
     end
 
     # Retrieve tool section for sarif report

--- a/lib/sarif/base_sarif.rb
+++ b/lib/sarif/base_sarif.rb
@@ -32,9 +32,9 @@ module Sarif
       @base_path ||= @repo_path.nil? ? nil : File.expand_path(@repo_path)
     end
 
-    def check_warn
+    def handle_warn_flag
       unless @scanner_config.nil?
-        @scanner_config.dig(:scanner_configs, @scan_report.scanner_name, "warn_message") || false
+        return @scanner_config.dig(:scanner_configs, @scan_report.scanner_name, "warn_message") || false
       end
     end
 
@@ -48,7 +48,7 @@ module Sarif
           "rules" => rules,
           "properties" => {
             "salusEnforced": @required || false,
-            "salusWarnMessage": check_warn
+            "salusWarnMessage": handle_warn_flag
           }
         }
       }

--- a/lib/sarif/base_sarif.rb
+++ b/lib/sarif/base_sarif.rb
@@ -33,8 +33,8 @@ module Sarif
     end
 
     def handle_warn_flag
-      unless @scanner_config.nil?
-        return @scanner_config.dig(:scanner_configs, @scan_report.scanner_name, "warn_message") || false
+      unless @config.nil?
+        return @config.dig(:scanner_configs, @scan_report.scanner_name, "warn_message") || false
       end
     end
 

--- a/lib/sarif/base_sarif.rb
+++ b/lib/sarif/base_sarif.rb
@@ -42,7 +42,8 @@ module Sarif
           "rules" => rules,
           "properties" => {
             "salusEnforced": @required || false,
-            "salusWarn": @scanner_config[:scanner_configs][@scan_report.scanner_name]["warn"] || false
+            "salusWarn": @scanner_config[:scanner_configs][
+              @scan_report.scanner_name]["warn"] || false
           }
         }
       }

--- a/lib/sarif/base_sarif.rb
+++ b/lib/sarif/base_sarif.rb
@@ -32,6 +32,13 @@ module Sarif
       @base_path ||= @repo_path.nil? ? nil : File.expand_path(@repo_path)
     end
 
+    def check_warn
+      unless @scanner_config.nil? 
+        return @scanner_config.dig(:scanner_configs, @scan_report.scanner_name, "warn") || false
+      end
+      return false
+    end
+
     # Retrieve tool section for sarif report
     def build_tool(rules: [])
       {
@@ -42,8 +49,7 @@ module Sarif
           "rules" => rules,
           "properties" => {
             "salusEnforced": @required || false,
-            "salusWarn": @scanner_config[:scanner_configs][
-              @scan_report.scanner_name]["warn"] || false
+            "salusWarn": check_warn
           }
         }
       }

--- a/lib/sarif/base_sarif.rb
+++ b/lib/sarif/base_sarif.rb
@@ -16,7 +16,7 @@ module Sarif
 
     attr_accessor :config, :required # sarif_options
 
-    def initialize(scan_report, config = {}, repo_path = nil)
+    def initialize(scan_report, config = {}, repo_path = nil, scanner_config = {})
       @scan_report = scan_report
       @mapped_rules = {} # map each rule to an index
       @rule_index = 0
@@ -25,6 +25,7 @@ module Sarif
       @issues = Set.new
       @config = config
       @repo_path = repo_path || Dir.getwd # Fallback, we should make repo_path required
+      @scanner_config = scanner_config
     end
 
     def base_path
@@ -40,7 +41,8 @@ module Sarif
           "informationUri" => @uri,
           "rules" => rules,
           "properties" => {
-            "salusEnforced": @required || false
+            "salusEnforced": @required || false,
+            "salusWarn": @scanner_config[:scanner_configs][@scan_report.scanner_name]["warn"] || false
           }
         }
       }

--- a/lib/sarif/brakeman_sarif.rb
+++ b/lib/sarif/brakeman_sarif.rb
@@ -4,7 +4,7 @@ module Sarif
 
     BRAKEMAN_URI = 'https://github.com/presidentbeef/brakeman'.freeze
 
-    def initialize(scan_report, repo_path = nil, scanner_config={})
+    def initialize(scan_report, repo_path = nil, scanner_config = {})
       super(scan_report, {}, repo_path)
       @uri = BRAKEMAN_URI
       @logs = parse_scan_report!

--- a/lib/sarif/brakeman_sarif.rb
+++ b/lib/sarif/brakeman_sarif.rb
@@ -4,10 +4,11 @@ module Sarif
 
     BRAKEMAN_URI = 'https://github.com/presidentbeef/brakeman'.freeze
 
-    def initialize(scan_report, repo_path = nil)
+    def initialize(scan_report, repo_path = nil, scanner_config={})
       super(scan_report, {}, repo_path)
       @uri = BRAKEMAN_URI
       @logs = parse_scan_report!
+      @scanner_config = scanner_config
     end
 
     def parse_scan_report!

--- a/lib/sarif/bundle_audit_sarif.rb
+++ b/lib/sarif/bundle_audit_sarif.rb
@@ -2,7 +2,7 @@ module Sarif
   class BundleAuditSarif < BaseSarif
     BUNDLEAUDIT_URI = 'https://github.com/rubysec/bundler-audit/'.freeze
 
-    def initialize(scan_report, repo_path = nil, scanner_config={})
+    def initialize(scan_report, repo_path = nil, scanner_config = {})
       super(scan_report, {}, repo_path)
       @logs = @scan_report.to_h.dig(:info, :vulnerabilities) || []
       @uri = BUNDLEAUDIT_URI

--- a/lib/sarif/bundle_audit_sarif.rb
+++ b/lib/sarif/bundle_audit_sarif.rb
@@ -2,10 +2,11 @@ module Sarif
   class BundleAuditSarif < BaseSarif
     BUNDLEAUDIT_URI = 'https://github.com/rubysec/bundler-audit/'.freeze
 
-    def initialize(scan_report, repo_path = nil)
+    def initialize(scan_report, repo_path = nil, scanner_config={})
       super(scan_report, {}, repo_path)
       @logs = @scan_report.to_h.dig(:info, :vulnerabilities) || []
       @uri = BUNDLEAUDIT_URI
+      @scanner_config = scanner_config
     end
 
     def parse_issue(issue)

--- a/lib/sarif/cargo_audit_sarif.rb
+++ b/lib/sarif/cargo_audit_sarif.rb
@@ -4,7 +4,7 @@ module Sarif
 
     CARGO_AUDIT_URI = 'https://github.com/RustSec/cargo-audit/'.freeze
 
-    def initialize(scan_report, repo_path = nil, scanner_config={})
+    def initialize(scan_report, repo_path = nil, scanner_config = {})
       super(scan_report, {}, repo_path)
       @uri = CARGO_AUDIT_URI
       @logs = parse_scan_report!

--- a/lib/sarif/cargo_audit_sarif.rb
+++ b/lib/sarif/cargo_audit_sarif.rb
@@ -4,10 +4,11 @@ module Sarif
 
     CARGO_AUDIT_URI = 'https://github.com/RustSec/cargo-audit/'.freeze
 
-    def initialize(scan_report, repo_path = nil)
+    def initialize(scan_report, repo_path = nil, scanner_config={})
       super(scan_report, {}, repo_path)
       @uri = CARGO_AUDIT_URI
       @logs = parse_scan_report!
+      @scanner_config = scanner_config
     end
 
     def parse_scan_report!

--- a/lib/sarif/gosec_sarif.rb
+++ b/lib/sarif/gosec_sarif.rb
@@ -7,7 +7,7 @@ module Sarif
 
     GOSEC_URI = 'https://github.com/securego/gosec'.freeze
 
-    def initialize(scan_report, repo_path = nil, scanner_config={})
+    def initialize(scan_report, repo_path = nil, scanner_config = {})
       super(scan_report, {}, repo_path)
       @uri = GOSEC_URI
       @logs = parse_scan_report!(scan_report)

--- a/lib/sarif/gosec_sarif.rb
+++ b/lib/sarif/gosec_sarif.rb
@@ -7,10 +7,11 @@ module Sarif
 
     GOSEC_URI = 'https://github.com/securego/gosec'.freeze
 
-    def initialize(scan_report, repo_path = nil)
+    def initialize(scan_report, repo_path = nil, scanner_config={})
       super(scan_report, {}, repo_path)
       @uri = GOSEC_URI
       @logs = parse_scan_report!(scan_report)
+      @scanner_config = scanner_config
     end
 
     def parse_scan_report!(scan_report)

--- a/lib/sarif/language_version/base_sarif.rb
+++ b/lib/sarif/language_version/base_sarif.rb
@@ -10,7 +10,7 @@ module Sarif::LanguageVersion
     LANGUAGE_VERSION_MISMATCH = "LV0001".freeze
     SEVERITY = "HIGH".freeze
 
-    def initialize(scan_report, repo_path = nil, scanner_config={})
+    def initialize(scan_report, repo_path = nil, scanner_config = {})
       super(scan_report, {}, repo_path)
       @uri = LANGUAGE_VERSION_DOC_URI
       @logs = parse_scan_report!

--- a/lib/sarif/language_version/base_sarif.rb
+++ b/lib/sarif/language_version/base_sarif.rb
@@ -10,10 +10,11 @@ module Sarif::LanguageVersion
     LANGUAGE_VERSION_MISMATCH = "LV0001".freeze
     SEVERITY = "HIGH".freeze
 
-    def initialize(scan_report, repo_path = nil)
+    def initialize(scan_report, repo_path = nil, scanner_config={})
       super(scan_report, {}, repo_path)
       @uri = LANGUAGE_VERSION_DOC_URI
       @logs = parse_scan_report!
+      @scanner_config = scanner_config
     end
 
     def parse_scan_report!

--- a/lib/sarif/npm_audit_sarif.rb
+++ b/lib/sarif/npm_audit_sarif.rb
@@ -2,12 +2,12 @@ module Sarif
   class NPMAuditSarif < BaseSarif
     NPM_URI = 'https://docs.npmjs.com/cli/v7/commands/npm-audit'.freeze
 
-    def initialize(scan_report, repo_path = nil, scanner_config={})
+    def initialize(scan_report, repo_path = nil, scanner_config = {})
       super(scan_report, {}, repo_path)
       @uri = NPM_URI
       @logs = parse_scan_report!
       @exceptions = Set.new(@scan_report.to_h.dig(:info, :exceptions))
-      @results = [],
+      @results = []
       @scanner_config = scanner_config
     end
 

--- a/lib/sarif/npm_audit_sarif.rb
+++ b/lib/sarif/npm_audit_sarif.rb
@@ -2,12 +2,13 @@ module Sarif
   class NPMAuditSarif < BaseSarif
     NPM_URI = 'https://docs.npmjs.com/cli/v7/commands/npm-audit'.freeze
 
-    def initialize(scan_report, repo_path = nil)
+    def initialize(scan_report, repo_path = nil, scanner_config={})
       super(scan_report, {}, repo_path)
       @uri = NPM_URI
       @logs = parse_scan_report!
       @exceptions = Set.new(@scan_report.to_h.dig(:info, :exceptions))
-      @results = []
+      @results = [],
+      @scanner_config = scanner_config
     end
 
     def parse_scan_report!

--- a/lib/sarif/osv/base_sarif.rb
+++ b/lib/sarif/osv/base_sarif.rb
@@ -7,10 +7,11 @@ module Sarif::OSV
     OSV_URI = "https://osv.dev/list".freeze
     SCANNER_NAME = "OSV Scanner".freeze
 
-    def initialize(scan_report, repo_path = nil)
+    def initialize(scan_report, repo_path = nil, scanner_config = {})
       super(scan_report, {}, repo_path)
       @uri = OSV_URI
       @logs = parse_scan_report!
+      @scanner_config = scanner_config
     end
 
     def parse_scan_report!

--- a/lib/sarif/package_version/base_sarif.rb
+++ b/lib/sarif/package_version/base_sarif.rb
@@ -10,10 +10,11 @@ module Sarif::PacakgeVersion
     PACKAGE_VERSION_MISMATCH = "PV0001".freeze
     SEVERITY = "HIGH".freeze
 
-    def initialize(scan_report, repo_path = nil)
+    def initialize(scan_report, repo_path = nil, scanner_config={})
       super(scan_report, {}, repo_path)
       @uri = PACKAGE_VERSION_DOC_URI
       @logs = parse_scan_report!
+      @scanner_config = scanner_config
     end
 
     def parse_scan_report!

--- a/lib/sarif/package_version/base_sarif.rb
+++ b/lib/sarif/package_version/base_sarif.rb
@@ -10,7 +10,7 @@ module Sarif::PacakgeVersion
     PACKAGE_VERSION_MISMATCH = "PV0001".freeze
     SEVERITY = "HIGH".freeze
 
-    def initialize(scan_report, repo_path = nil, scanner_config={})
+    def initialize(scan_report, repo_path = nil, scanner_config = {})
       super(scan_report, {}, repo_path)
       @uri = PACKAGE_VERSION_DOC_URI
       @logs = parse_scan_report!

--- a/lib/sarif/pattern_search_sarif.rb
+++ b/lib/sarif/pattern_search_sarif.rb
@@ -8,10 +8,11 @@ module Sarif
     PATTERN_SEARCH_URI = "https://github.com/coinbase/salus/blob/master/docs/scanners/"\
     "pattern_search.md".freeze
 
-    def initialize(scan_report, repo_path = nil)
+    def initialize(scan_report, repo_path = nil, scanner_config={})
       super(scan_report, {}, repo_path)
       @uri = PATTERN_SEARCH_URI
       @logs = parse_scan_report!
+      @scanner_config = scanner_config
     end
 
     def parse_scan_report!

--- a/lib/sarif/pattern_search_sarif.rb
+++ b/lib/sarif/pattern_search_sarif.rb
@@ -8,7 +8,7 @@ module Sarif
     PATTERN_SEARCH_URI = "https://github.com/coinbase/salus/blob/master/docs/scanners/"\
     "pattern_search.md".freeze
 
-    def initialize(scan_report, repo_path = nil, scanner_config={})
+    def initialize(scan_report, repo_path = nil, scanner_config = {})
       super(scan_report, {}, repo_path)
       @uri = PATTERN_SEARCH_URI
       @logs = parse_scan_report!

--- a/lib/sarif/repo_not_empty_sarif.rb
+++ b/lib/sarif/repo_not_empty_sarif.rb
@@ -7,10 +7,11 @@ module Sarif
     REPO_NOT_EMPTY_URI = "https://github.com/coinbase/salus/blob/master/docs/scanners/"\
     "repository_not_blank.md".freeze
 
-    def initialize(scan_report, repo_path = nil)
+    def initialize(scan_report, repo_path = nil, scanner_config={})
       super(scan_report, {}, repo_path)
       @uri = REPO_NOT_EMPTY_URI
       @logs = parse_scan_report!
+      @scanner_config = scanner_config
     end
 
     def parse_scan_report!

--- a/lib/sarif/repo_not_empty_sarif.rb
+++ b/lib/sarif/repo_not_empty_sarif.rb
@@ -7,7 +7,7 @@ module Sarif
     REPO_NOT_EMPTY_URI = "https://github.com/coinbase/salus/blob/master/docs/scanners/"\
     "repository_not_blank.md".freeze
 
-    def initialize(scan_report, repo_path = nil, scanner_config={})
+    def initialize(scan_report, repo_path = nil, scanner_config = {})
       super(scan_report, {}, repo_path)
       @uri = REPO_NOT_EMPTY_URI
       @logs = parse_scan_report!

--- a/lib/sarif/sarif_report.rb
+++ b/lib/sarif/sarif_report.rb
@@ -20,7 +20,7 @@ module Sarif
     SARIF_SCHEMA = "https://docs.oasis-open.org/sarif/sarif/v#{SARIF_VERSION}/csprd01/schemas/"\
     "sarif-schema-#{SARIF_VERSION}".freeze
 
-    def initialize(scan_reports, config = {}, repo_path = nil, scanner_config)
+    def initialize(scan_reports, config = {}, repo_path = nil, scanner_config = {})
       @scan_reports = scan_reports
       @config = config
       @repo_path = repo_path

--- a/lib/sarif/sarif_report.rb
+++ b/lib/sarif/sarif_report.rb
@@ -20,10 +20,11 @@ module Sarif
     SARIF_SCHEMA = "https://docs.oasis-open.org/sarif/sarif/v#{SARIF_VERSION}/csprd01/schemas/"\
     "sarif-schema-#{SARIF_VERSION}".freeze
 
-    def initialize(scan_reports, config = {}, repo_path = nil)
+    def initialize(scan_reports, config = {}, repo_path = nil, scanner_config)
       @scan_reports = scan_reports
       @config = config
       @repo_path = repo_path
+      @scanner_config = scanner_config
     end
 
     # Builds Sarif Report. Raises an SarifInvalidFormatError if generated SARIF report is invalid
@@ -62,12 +63,12 @@ module Sarif
     def converter(scan_report, required)
       adapter = "Sarif::#{scan_report.scanner_name}Sarif"
       begin
-        converter = Object.const_get(adapter).new(scan_report, @repo_path)
+        converter = Object.const_get(adapter).new(scan_report, @repo_path, @scanner_config)
         converter.config = @config
         converter.required = required
         converter.build_runs_object(true)
       rescue NameError # this is greedy and will catch NoMethodError's too
-        converter = BaseSarif.new(scan_report, @config, @repo_path)
+        converter = BaseSarif.new(scan_report, @config, @scanner_config, @repo_path)
         converter.required = required
         converter.build_runs_object(false)
       end

--- a/lib/sarif/sarif_report.rb
+++ b/lib/sarif/sarif_report.rb
@@ -68,7 +68,7 @@ module Sarif
         converter.required = required
         converter.build_runs_object(true)
       rescue NameError # this is greedy and will catch NoMethodError's too
-        converter = BaseSarif.new(scan_report, @config, @repo_path,  @scanner_config)
+        converter = BaseSarif.new(scan_report, @config, @repo_path, @scanner_config)
         converter.required = required
         converter.build_runs_object(false)
       end

--- a/lib/sarif/sarif_report.rb
+++ b/lib/sarif/sarif_report.rb
@@ -63,12 +63,12 @@ module Sarif
     def converter(scan_report, required)
       adapter = "Sarif::#{scan_report.scanner_name}Sarif"
       begin
-        converter = Object.const_get(adapter).new(scan_report, @repo_path, @scanner_config)
+        converter = Object.const_get(adapter).new(scan_report, @repo_path)
         converter.config = @config
         converter.required = required
         converter.build_runs_object(true)
       rescue NameError # this is greedy and will catch NoMethodError's too
-        converter = BaseSarif.new(scan_report, @config, @repo_path, @scanner_config)
+        converter = BaseSarif.new(scan_report, @config, @repo_path)
         converter.required = required
         converter.build_runs_object(false)
       end

--- a/lib/sarif/sarif_report.rb
+++ b/lib/sarif/sarif_report.rb
@@ -68,7 +68,7 @@ module Sarif
         converter.required = required
         converter.build_runs_object(true)
       rescue NameError # this is greedy and will catch NoMethodError's too
-        converter = BaseSarif.new(scan_report, @config, @scanner_config, @repo_path)
+        converter = BaseSarif.new(scan_report, @config, @repo_path, @scanner_config)
         converter.required = required
         converter.build_runs_object(false)
       end

--- a/lib/sarif/sarif_report.rb
+++ b/lib/sarif/sarif_report.rb
@@ -63,12 +63,12 @@ module Sarif
     def converter(scan_report, required)
       adapter = "Sarif::#{scan_report.scanner_name}Sarif"
       begin
-        converter = Object.const_get(adapter).new(scan_report, @repo_path)
+        converter = Object.const_get(adapter).new(scan_report, @repo_path, @scanner_config)
         converter.config = @config
         converter.required = required
         converter.build_runs_object(true)
       rescue NameError # this is greedy and will catch NoMethodError's too
-        converter = BaseSarif.new(scan_report, @config, @repo_path)
+        converter = BaseSarif.new(scan_report, @config, @repo_path,  @scanner_config)
         converter.required = required
         converter.build_runs_object(false)
       end

--- a/lib/sarif/semgrep_sarif.rb
+++ b/lib/sarif/semgrep_sarif.rb
@@ -8,11 +8,12 @@ module Sarif
     SEMGREP_URI = "https://github.com/coinbase/salus/blob/master/docs/scanners/"\
                      "semgrep.md".freeze
 
-    def initialize(scan_report, repo_path = nil)
+    def initialize(scan_report, repo_path = nil, scanner_config={})
       super(scan_report, {}, repo_path)
       @uri = SEMGREP_URI
       @logs = parse_scan_report!
       @issues = Set.new
+      @scanner_config = scanner_config
     end
 
     def build_rule(parsed_issue)

--- a/lib/sarif/semgrep_sarif.rb
+++ b/lib/sarif/semgrep_sarif.rb
@@ -8,7 +8,7 @@ module Sarif
     SEMGREP_URI = "https://github.com/coinbase/salus/blob/master/docs/scanners/"\
                      "semgrep.md".freeze
 
-    def initialize(scan_report, repo_path = nil, scanner_config={})
+    def initialize(scan_report, repo_path = nil, scanner_config = {})
       super(scan_report, {}, repo_path)
       @uri = SEMGREP_URI
       @logs = parse_scan_report!

--- a/lib/sarif/yarn_audit_sarif.rb
+++ b/lib/sarif/yarn_audit_sarif.rb
@@ -4,10 +4,11 @@ module Sarif
     include Salus::SalusBugsnag
     YARN_URI = 'https://classic.yarnpkg.com/en/docs/cli/audit/'.freeze
 
-    def initialize(scan_report, repo_path = nil)
+    def initialize(scan_report, repo_path = nil, scanner_config={})
       super(scan_report, {}, repo_path)
       @uri = YARN_URI
       parse_scan_report!
+      @scanner_config = scanner_config
     end
 
     def parse_scan_report!

--- a/lib/sarif/yarn_audit_sarif.rb
+++ b/lib/sarif/yarn_audit_sarif.rb
@@ -4,7 +4,7 @@ module Sarif
     include Salus::SalusBugsnag
     YARN_URI = 'https://classic.yarnpkg.com/en/docs/cli/audit/'.freeze
 
-    def initialize(scan_report, repo_path = nil, scanner_config={})
+    def initialize(scan_report, repo_path = nil, scanner_config = {})
       super(scan_report, {}, repo_path)
       @uri = YARN_URI
       parse_scan_report!

--- a/spec/fixtures/gosec/multiple_vulns2/out.sarif
+++ b/spec/fixtures/gosec/multiple_vulns2/out.sarif
@@ -144,7 +144,7 @@
           "name": "Gosec",
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           },
           "rules": [
             {

--- a/spec/fixtures/gosec/multiple_vulns2/out.sarif
+++ b/spec/fixtures/gosec/multiple_vulns2/out.sarif
@@ -143,7 +143,8 @@
           "informationUri": "https://github.com/securego/gosec",
           "name": "Gosec",
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           },
           "rules": [
             {

--- a/spec/fixtures/sarifs/diff/diff_1_2.json
+++ b/spec/fixtures/sarifs/diff/diff_1_2.json
@@ -13,7 +13,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -67,7 +67,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -126,7 +126,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -158,7 +158,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -190,7 +190,7 @@
           ],
           "properties": {
             "salusEnforced": false,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -232,7 +232,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },

--- a/spec/fixtures/sarifs/diff/diff_1_2.json
+++ b/spec/fixtures/sarifs/diff/diff_1_2.json
@@ -12,7 +12,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -65,7 +66,8 @@
             }
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -123,7 +125,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -154,7 +157,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -185,7 +189,8 @@
 
           ],
           "properties": {
-            "salusEnforced": false
+            "salusEnforced": false,
+            "salusWarn": false
           }
         }
       },
@@ -226,7 +231,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },

--- a/spec/fixtures/sarifs/diff/diff_3_4.json
+++ b/spec/fixtures/sarifs/diff/diff_3_4.json
@@ -126,7 +126,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -242,7 +242,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -329,7 +329,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -361,7 +361,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -393,7 +393,7 @@
           ],
           "properties": {
             "salusEnforced": false,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -435,7 +435,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },

--- a/spec/fixtures/sarifs/diff/diff_3_4.json
+++ b/spec/fixtures/sarifs/diff/diff_3_4.json
@@ -125,7 +125,8 @@
             }
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -240,7 +241,8 @@
             }
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -326,7 +328,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -357,7 +360,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -388,7 +392,8 @@
 
           ],
           "properties": {
-            "salusEnforced": false
+            "salusEnforced": false,
+            "salusWarn": false
           }
         }
       },
@@ -429,7 +434,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },

--- a/spec/fixtures/sarifs/diff/sarif_1.json
+++ b/spec/fixtures/sarifs/diff/sarif_1.json
@@ -12,7 +12,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -118,7 +119,8 @@
             }
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -190,7 +192,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -221,7 +224,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -252,7 +256,8 @@
 
           ],
           "properties": {
-            "salusEnforced": false
+            "salusEnforced": false,
+            "salusWarn": false
           }
         }
       },
@@ -293,7 +298,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },

--- a/spec/fixtures/sarifs/diff/sarif_1.json
+++ b/spec/fixtures/sarifs/diff/sarif_1.json
@@ -13,7 +13,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -120,7 +120,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -193,7 +193,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -225,7 +225,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -257,7 +257,7 @@
           ],
           "properties": {
             "salusEnforced": false,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -299,7 +299,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },

--- a/spec/fixtures/sarifs/diff/sarif_1_2.json
+++ b/spec/fixtures/sarifs/diff/sarif_1_2.json
@@ -12,7 +12,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -43,7 +44,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -74,7 +76,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -105,7 +108,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -136,7 +140,8 @@
 
           ],
           "properties": {
-            "salusEnforced": false
+            "salusEnforced": false,
+            "salusWarn": false
           }
         }
       },
@@ -177,7 +182,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },

--- a/spec/fixtures/sarifs/diff/sarif_1_2.json
+++ b/spec/fixtures/sarifs/diff/sarif_1_2.json
@@ -13,7 +13,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -45,7 +45,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -77,7 +77,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -109,7 +109,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -141,7 +141,7 @@
           ],
           "properties": {
             "salusEnforced": false,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -183,7 +183,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },

--- a/spec/fixtures/sarifs/diff/sarif_1_3.json
+++ b/spec/fixtures/sarifs/diff/sarif_1_3.json
@@ -13,7 +13,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -82,7 +82,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -134,7 +134,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -166,7 +166,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -198,7 +198,7 @@
           ],
           "properties": {
             "salusEnforced": false,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -240,7 +240,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },

--- a/spec/fixtures/sarifs/diff/sarif_1_3.json
+++ b/spec/fixtures/sarifs/diff/sarif_1_3.json
@@ -12,7 +12,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -80,7 +81,8 @@
             }
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -131,7 +133,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -162,7 +165,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -193,7 +197,8 @@
 
           ],
           "properties": {
-            "salusEnforced": false
+            "salusEnforced": false,
+            "salusWarn": false
           }
         }
       },
@@ -234,7 +239,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },

--- a/spec/fixtures/sarifs/diff/sarif_1_non_enforced.json
+++ b/spec/fixtures/sarifs/diff/sarif_1_non_enforced.json
@@ -12,7 +12,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -118,7 +119,8 @@
             }
           ],
           "properties": {
-            "salusEnforced": false
+            "salusEnforced": false,
+            "salusWarn": false
           }
         }
       },
@@ -190,7 +192,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -221,7 +224,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -252,7 +256,8 @@
 
           ],
           "properties": {
-            "salusEnforced": false
+            "salusEnforced": false,
+            "salusWarn": false
           }
         }
       },
@@ -293,7 +298,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },

--- a/spec/fixtures/sarifs/diff/sarif_1_non_enforced.json
+++ b/spec/fixtures/sarifs/diff/sarif_1_non_enforced.json
@@ -13,7 +13,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -120,7 +120,7 @@
           ],
           "properties": {
             "salusEnforced": false,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -193,7 +193,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -225,7 +225,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -257,7 +257,7 @@
           ],
           "properties": {
             "salusEnforced": false,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -299,7 +299,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },

--- a/spec/fixtures/sarifs/diff/sarif_2.json
+++ b/spec/fixtures/sarifs/diff/sarif_2.json
@@ -34,7 +34,8 @@
             }
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -1577,7 +1578,8 @@
             }
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -2426,7 +2428,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -2457,7 +2460,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -2488,7 +2492,8 @@
 
           ],
           "properties": {
-            "salusEnforced": false
+            "salusEnforced": false,
+            "salusWarn": false
           }
         }
       },
@@ -2529,7 +2534,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },

--- a/spec/fixtures/sarifs/diff/sarif_2.json
+++ b/spec/fixtures/sarifs/diff/sarif_2.json
@@ -35,7 +35,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -1579,7 +1579,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -2429,7 +2429,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -2461,7 +2461,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -2493,7 +2493,7 @@
           ],
           "properties": {
             "salusEnforced": false,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -2535,7 +2535,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },

--- a/spec/fixtures/sarifs/diff/sarif_2_1.json
+++ b/spec/fixtures/sarifs/diff/sarif_2_1.json
@@ -35,7 +35,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -1503,7 +1503,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -2311,7 +2311,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -2343,7 +2343,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -2375,7 +2375,7 @@
           ],
           "properties": {
             "salusEnforced": false,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -2417,7 +2417,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },

--- a/spec/fixtures/sarifs/diff/sarif_2_1.json
+++ b/spec/fixtures/sarifs/diff/sarif_2_1.json
@@ -34,7 +34,8 @@
             }
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -1501,7 +1502,8 @@
             }
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -2308,7 +2310,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -2339,7 +2342,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -2370,7 +2374,8 @@
 
           ],
           "properties": {
-            "salusEnforced": false
+            "salusEnforced": false,
+            "salusWarn": false
           }
         }
       },
@@ -2411,7 +2416,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },

--- a/spec/fixtures/sarifs/diff/sarif_3.json
+++ b/spec/fixtures/sarifs/diff/sarif_3.json
@@ -12,7 +12,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -118,7 +119,8 @@
             }
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -190,7 +192,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -221,7 +224,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -252,7 +256,8 @@
 
           ],
           "properties": {
-            "salusEnforced": false
+            "salusEnforced": false,
+            "salusWarn": false
           }
         }
       },
@@ -293,7 +298,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },

--- a/spec/fixtures/sarifs/diff/sarif_3.json
+++ b/spec/fixtures/sarifs/diff/sarif_3.json
@@ -13,7 +13,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -120,7 +120,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -193,7 +193,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -225,7 +225,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -257,7 +257,7 @@
           ],
           "properties": {
             "salusEnforced": false,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -299,7 +299,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },

--- a/spec/fixtures/sarifs/diff/sarif_all_passed.json
+++ b/spec/fixtures/sarifs/diff/sarif_all_passed.json
@@ -13,7 +13,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -45,7 +45,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -77,7 +77,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -109,7 +109,7 @@
           ],
           "properties": {
             "salusEnforced": false,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -151,7 +151,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },

--- a/spec/fixtures/sarifs/diff/sarif_all_passed.json
+++ b/spec/fixtures/sarifs/diff/sarif_all_passed.json
@@ -12,7 +12,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -43,7 +44,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -74,7 +76,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -105,7 +108,8 @@
 
           ],
           "properties": {
-            "salusEnforced": false
+            "salusEnforced": false,
+            "salusWarn": false
           }
         }
       },
@@ -146,7 +150,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },

--- a/spec/fixtures/sarifs/diff/sarif_succ.json
+++ b/spec/fixtures/sarifs/diff/sarif_succ.json
@@ -13,7 +13,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -45,7 +45,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -77,7 +77,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -109,7 +109,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -141,7 +141,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -173,7 +173,7 @@
           ],
           "properties": {
             "salusEnforced": false,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -215,7 +215,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },

--- a/spec/fixtures/sarifs/diff/sarif_succ.json
+++ b/spec/fixtures/sarifs/diff/sarif_succ.json
@@ -12,7 +12,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -43,7 +44,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -74,7 +76,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -105,7 +108,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -136,7 +140,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -167,7 +172,8 @@
 
           ],
           "properties": {
-            "salusEnforced": false
+            "salusEnforced": false,
+            "salusWarn": false
           }
         }
       },
@@ -208,7 +214,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },

--- a/spec/fixtures/sarifs/diff/v1.json
+++ b/spec/fixtures/sarifs/diff/v1.json
@@ -734,7 +734,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -1164,7 +1164,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -1196,7 +1196,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -1228,7 +1228,7 @@
           ],
           "properties": {
             "salusEnforced": false,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -1270,7 +1270,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },

--- a/spec/fixtures/sarifs/diff/v1.json
+++ b/spec/fixtures/sarifs/diff/v1.json
@@ -733,7 +733,8 @@
             }
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -1162,7 +1163,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -1193,7 +1195,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -1224,7 +1227,8 @@
 
           ],
           "properties": {
-            "salusEnforced": false
+            "salusEnforced": false,
+            "salusWarn": false
           }
         }
       },
@@ -1265,7 +1269,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },

--- a/spec/fixtures/sarifs/diff/v2.json
+++ b/spec/fixtures/sarifs/diff/v2.json
@@ -734,7 +734,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -1186,7 +1186,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -1245,7 +1245,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -1277,7 +1277,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -1309,7 +1309,7 @@
           ],
           "properties": {
             "salusEnforced": false,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -1351,7 +1351,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },

--- a/spec/fixtures/sarifs/diff/v2.json
+++ b/spec/fixtures/sarifs/diff/v2.json
@@ -733,7 +733,8 @@
             }
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -1184,7 +1185,8 @@
             }
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -1242,7 +1244,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -1273,7 +1276,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -1304,7 +1308,8 @@
 
           ],
           "properties": {
-            "salusEnforced": false
+            "salusEnforced": false,
+            "salusWarn": false
           }
         }
       },
@@ -1345,7 +1350,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },

--- a/spec/fixtures/sarifs/diff/v3.json
+++ b/spec/fixtures/sarifs/diff/v3.json
@@ -734,7 +734,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -1186,7 +1186,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -1273,7 +1273,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -1305,7 +1305,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -1337,7 +1337,7 @@
           ],
           "properties": {
             "salusEnforced": false,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -1379,7 +1379,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },

--- a/spec/fixtures/sarifs/diff/v3.json
+++ b/spec/fixtures/sarifs/diff/v3.json
@@ -733,7 +733,8 @@
             }
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -1184,7 +1185,8 @@
             }
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -1270,7 +1272,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -1301,7 +1304,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -1332,7 +1336,8 @@
 
           ],
           "properties": {
-            "salusEnforced": false
+            "salusEnforced": false,
+            "salusWarn": false
           }
         }
       },
@@ -1373,7 +1378,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },

--- a/spec/fixtures/sarifs/diff/v4.json
+++ b/spec/fixtures/sarifs/diff/v4.json
@@ -619,7 +619,8 @@
             }
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -985,7 +986,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -1016,7 +1018,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -1047,7 +1050,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -1078,7 +1082,8 @@
 
           ],
           "properties": {
-            "salusEnforced": false
+            "salusEnforced": false,
+            "salusWarn": false
           }
         }
       },
@@ -1119,7 +1124,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },

--- a/spec/fixtures/sarifs/diff/v4.json
+++ b/spec/fixtures/sarifs/diff/v4.json
@@ -620,7 +620,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -987,7 +987,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -1019,7 +1019,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -1051,7 +1051,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -1083,7 +1083,7 @@
           ],
           "properties": {
             "salusEnforced": false,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -1125,7 +1125,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },

--- a/spec/fixtures/sarifs/diff2/expected_sarif_diff.json
+++ b/spec/fixtures/sarifs/diff2/expected_sarif_diff.json
@@ -12,7 +12,8 @@
 
           ],
           "properties": {
-            "salusEnforced": false
+            "salusEnforced": false,
+            "salusWarn": false
           }
         }
       },
@@ -80,7 +81,8 @@
             }
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -131,7 +133,8 @@
 
           ],
           "properties": {
-            "salusEnforced": false
+            "salusEnforced": false,
+            "salusWarn": false
           }
         }
       },
@@ -194,7 +197,8 @@
             }
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -252,7 +256,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -283,7 +288,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -314,7 +320,8 @@
 
           ],
           "properties": {
-            "salusEnforced": false
+            "salusEnforced": false,
+            "salusWarn": false
           }
         }
       },
@@ -355,7 +362,8 @@
 
           ],
           "properties": {
-            "salusEnforced": false
+            "salusEnforced": false,
+            "salusWarn": false
           }
         }
       },

--- a/spec/fixtures/sarifs/diff2/expected_sarif_diff.json
+++ b/spec/fixtures/sarifs/diff2/expected_sarif_diff.json
@@ -13,7 +13,7 @@
           ],
           "properties": {
             "salusEnforced": false,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -82,7 +82,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -134,7 +134,7 @@
           ],
           "properties": {
             "salusEnforced": false,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -198,7 +198,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -257,7 +257,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -289,7 +289,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -321,7 +321,7 @@
           ],
           "properties": {
             "salusEnforced": false,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -363,7 +363,7 @@
           ],
           "properties": {
             "salusEnforced": false,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },

--- a/spec/fixtures/sarifs/diff2/report_sarif_master.json
+++ b/spec/fixtures/sarifs/diff2/report_sarif_master.json
@@ -734,7 +734,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -1164,7 +1164,7 @@
           ],
           "properties": {
             "salusEnforced": false,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -1228,7 +1228,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -1287,7 +1287,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -1319,7 +1319,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -1351,7 +1351,7 @@
           ],
           "properties": {
             "salusEnforced": false,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },

--- a/spec/fixtures/sarifs/diff2/report_sarif_master.json
+++ b/spec/fixtures/sarifs/diff2/report_sarif_master.json
@@ -733,7 +733,8 @@
             }
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -1162,7 +1163,8 @@
 
           ],
           "properties": {
-            "salusEnforced": false
+            "salusEnforced": false,
+            "salusWarn": false
           }
         }
       },
@@ -1225,7 +1227,8 @@
             }
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -1283,7 +1286,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -1314,7 +1318,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -1345,7 +1350,8 @@
 
           ],
           "properties": {
-            "salusEnforced": false
+            "salusEnforced": false,
+            "salusWarn": false
           }
         }
       },

--- a/spec/fixtures/sarifs/diff2/report_sarif_pr.json
+++ b/spec/fixtures/sarifs/diff2/report_sarif_pr.json
@@ -12,7 +12,8 @@
 
           ],
           "properties": {
-            "salusEnforced": false
+            "salusEnforced": false,
+            "salusWarn": false
           }
         }
       },
@@ -764,7 +765,8 @@
             }
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -1193,7 +1195,8 @@
 
           ],
           "properties": {
-            "salusEnforced": false
+            "salusEnforced": false,
+            "salusWarn": false
           }
         }
       },
@@ -1256,7 +1259,8 @@
             }
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -1314,7 +1318,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -1345,7 +1350,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -1376,7 +1382,8 @@
 
           ],
           "properties": {
-            "salusEnforced": false
+            "salusEnforced": false,
+            "salusWarn": false
           }
         }
       },
@@ -1417,7 +1424,8 @@
 
           ],
           "properties": {
-            "salusEnforced": false
+            "salusEnforced": false,
+            "salusWarn": false
           }
         }
       },

--- a/spec/fixtures/sarifs/diff2/report_sarif_pr.json
+++ b/spec/fixtures/sarifs/diff2/report_sarif_pr.json
@@ -13,7 +13,7 @@
           ],
           "properties": {
             "salusEnforced": false,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -766,7 +766,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -1196,7 +1196,7 @@
           ],
           "properties": {
             "salusEnforced": false,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -1260,7 +1260,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -1319,7 +1319,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -1351,7 +1351,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -1383,7 +1383,7 @@
           ],
           "properties": {
             "salusEnforced": false,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -1425,7 +1425,7 @@
           ],
           "properties": {
             "salusEnforced": false,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },

--- a/spec/fixtures/sarifs/diff3/expected_sarif_diff.json
+++ b/spec/fixtures/sarifs/diff3/expected_sarif_diff.json
@@ -12,7 +12,8 @@
 
           ],
           "properties": {
-            "salusEnforced": false
+            "salusEnforced": false,
+            "salusWarn": false
           }
         }
       },
@@ -80,7 +81,8 @@
             }
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -131,7 +133,8 @@
 
           ],
           "properties": {
-            "salusEnforced": false
+            "salusEnforced": false,
+            "salusWarn": false
           }
         }
       },
@@ -172,7 +175,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -203,7 +207,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -234,7 +239,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -265,7 +271,8 @@
 
           ],
           "properties": {
-            "salusEnforced": false
+            "salusEnforced": false,
+            "salusWarn": false
           }
         }
       },
@@ -306,7 +313,8 @@
 
           ],
           "properties": {
-            "salusEnforced": false
+            "salusEnforced": false,
+            "salusWarn": false
           }
         }
       },

--- a/spec/fixtures/sarifs/diff3/expected_sarif_diff.json
+++ b/spec/fixtures/sarifs/diff3/expected_sarif_diff.json
@@ -13,7 +13,7 @@
           ],
           "properties": {
             "salusEnforced": false,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -82,7 +82,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -134,7 +134,7 @@
           ],
           "properties": {
             "salusEnforced": false,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -176,7 +176,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -208,7 +208,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -240,7 +240,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -272,7 +272,7 @@
           ],
           "properties": {
             "salusEnforced": false,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -314,7 +314,7 @@
           ],
           "properties": {
             "salusEnforced": false,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },

--- a/spec/fixtures/sarifs/diff3/report_sarif_master.json
+++ b/spec/fixtures/sarifs/diff3/report_sarif_master.json
@@ -734,7 +734,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -1164,7 +1164,7 @@
           ],
           "properties": {
             "salusEnforced": false,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -1228,7 +1228,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -1287,7 +1287,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -1319,7 +1319,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -1351,7 +1351,7 @@
           ],
           "properties": {
             "salusEnforced": false,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },

--- a/spec/fixtures/sarifs/diff3/report_sarif_master.json
+++ b/spec/fixtures/sarifs/diff3/report_sarif_master.json
@@ -733,7 +733,8 @@
             }
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -1162,7 +1163,8 @@
 
           ],
           "properties": {
-            "salusEnforced": false
+            "salusEnforced": false,
+            "salusWarn": false
           }
         }
       },
@@ -1225,7 +1227,8 @@
             }
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -1283,7 +1286,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -1314,7 +1318,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -1345,7 +1350,8 @@
 
           ],
           "properties": {
-            "salusEnforced": false
+            "salusEnforced": false,
+            "salusWarn": false
           }
         }
       },

--- a/spec/fixtures/sarifs/diff3/report_sarif_pr.json
+++ b/spec/fixtures/sarifs/diff3/report_sarif_pr.json
@@ -12,7 +12,8 @@
 
           ],
           "properties": {
-            "salusEnforced": false
+            "salusEnforced": false,
+            "salusWarn": false
           }
         }
       },
@@ -764,7 +765,8 @@
             }
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -1193,7 +1195,8 @@
 
           ],
           "properties": {
-            "salusEnforced": false
+            "salusEnforced": false,
+            "salusWarn": false
           }
         }
       },
@@ -1256,7 +1259,8 @@
             }
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -1314,7 +1318,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -1345,7 +1350,8 @@
 
           ],
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           }
         }
       },
@@ -1376,7 +1382,8 @@
 
           ],
           "properties": {
-            "salusEnforced": false
+            "salusEnforced": false,
+            "salusWarn": false
           }
         }
       },
@@ -1417,7 +1424,8 @@
 
           ],
           "properties": {
-            "salusEnforced": false
+            "salusEnforced": false,
+            "salusWarn": false
           }
         }
       },

--- a/spec/fixtures/sarifs/diff3/report_sarif_pr.json
+++ b/spec/fixtures/sarifs/diff3/report_sarif_pr.json
@@ -13,7 +13,7 @@
           ],
           "properties": {
             "salusEnforced": false,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -766,7 +766,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -1196,7 +1196,7 @@
           ],
           "properties": {
             "salusEnforced": false,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -1260,7 +1260,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -1319,7 +1319,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -1351,7 +1351,7 @@
           ],
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -1383,7 +1383,7 @@
           ],
           "properties": {
             "salusEnforced": false,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },
@@ -1425,7 +1425,7 @@
           ],
           "properties": {
             "salusEnforced": false,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         }
       },

--- a/spec/fixtures/sorted_results/sorted_sarif.json
+++ b/spec/fixtures/sorted_results/sorted_sarif.json
@@ -62,7 +62,7 @@
           "name": "Semgrep",
           "properties": {
             "salusEnforced": true,
-            "salusWarn": false
+            "salusWarnMessage": false
           },
           "rules": [
             {
@@ -127,7 +127,7 @@
           "name": "BundleAudit",
           "properties": {
             "salusEnforced": false,
-            "salusWarn": false
+            "salusWarnMessage": false
           },
           "rules": [
 
@@ -165,7 +165,7 @@
           "name": "Bandit",
           "properties": {
             "salusEnforced": false,
-            "salusWarn": false
+            "salusWarnMessage": false
           },
           "rules": [
 

--- a/spec/fixtures/sorted_results/sorted_sarif.json
+++ b/spec/fixtures/sorted_results/sorted_sarif.json
@@ -61,7 +61,8 @@
           "informationUri": "https://github.com/coinbase/salus/blob/master/docs/scanners/semgrep.md",
           "name": "Semgrep",
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarn": false
           },
           "rules": [
             {
@@ -125,7 +126,8 @@
           "informationUri": "https://github.com/rubysec/bundler-audit/",
           "name": "BundleAudit",
           "properties": {
-            "salusEnforced": false
+            "salusEnforced": false,
+            "salusWarn": false
           },
           "rules": [
 
@@ -162,7 +164,8 @@
           "informationUri": "https://github.com/PyCQA/bandit",
           "name": "Bandit",
           "properties": {
-            "salusEnforced": false
+            "salusEnforced": false,
+            "salusWarn": false
           },
           "rules": [
 

--- a/spec/fixtures/sorted_results/sorted_sarif.json
+++ b/spec/fixtures/sorted_results/sorted_sarif.json
@@ -61,7 +61,8 @@
           "informationUri": "https://github.com/coinbase/salus/blob/master/docs/scanners/semgrep.md",
           "name": "Semgrep",
           "properties": {
-            "salusEnforced": true
+            "salusEnforced": true,
+            "salusWarnMessage": false
           },
           "rules": [
             {
@@ -125,7 +126,8 @@
           "informationUri": "https://github.com/rubysec/bundler-audit/",
           "name": "BundleAudit",
           "properties": {
-            "salusEnforced": false
+            "salusEnforced": false,
+            "salusWarnMessage": false
           },
           "rules": [
 
@@ -162,7 +164,8 @@
           "informationUri": "https://github.com/PyCQA/bandit",
           "name": "Bandit",
           "properties": {
-            "salusEnforced": false
+            "salusEnforced": false,
+            "salusWarnMessage": false
           },
           "rules": [
 

--- a/spec/fixtures/sorted_results/sorted_sarif.json
+++ b/spec/fixtures/sorted_results/sorted_sarif.json
@@ -61,8 +61,7 @@
           "informationUri": "https://github.com/coinbase/salus/blob/master/docs/scanners/semgrep.md",
           "name": "Semgrep",
           "properties": {
-            "salusEnforced": true,
-            "salusWarnMessage": false
+            "salusEnforced": true
           },
           "rules": [
             {
@@ -126,8 +125,7 @@
           "informationUri": "https://github.com/rubysec/bundler-audit/",
           "name": "BundleAudit",
           "properties": {
-            "salusEnforced": false,
-            "salusWarnMessage": false
+            "salusEnforced": false
           },
           "rules": [
 
@@ -164,8 +162,7 @@
           "informationUri": "https://github.com/PyCQA/bandit",
           "name": "Bandit",
           "properties": {
-            "salusEnforced": false,
-            "salusWarnMessage": false
+            "salusEnforced": false
           },
           "rules": [
 

--- a/spec/lib/salus/report_spec.rb
+++ b/spec/lib/salus/report_spec.rb
@@ -749,6 +749,7 @@ describe Salus::Report do
 
       it 'should deepsort sarif output' do
         expected_result = File.read("#{results_dir}/sorted_sarif.json")
+        puts "Fount report #{report.to_sarif}"
         sorted_sarif = JSON.parse(report.to_sarif)
         sorted_sarif['runs'].each do |result|
           # PROJECTROOT was taken out because it has the users local directory in the result json

--- a/spec/lib/salus/report_spec.rb
+++ b/spec/lib/salus/report_spec.rb
@@ -749,7 +749,6 @@ describe Salus::Report do
 
       it 'should deepsort sarif output' do
         expected_result = File.read("#{results_dir}/sorted_sarif.json")
-        puts "Fount report #{report.to_sarif}"
         sorted_sarif = JSON.parse(report.to_sarif)
         sorted_sarif['runs'].each do |result|
           # PROJECTROOT was taken out because it has the users local directory in the result json

--- a/spec/lib/salus/scanners/yarn_audit_spec.rb
+++ b/spec/lib/salus/scanners/yarn_audit_spec.rb
@@ -71,7 +71,7 @@ describe Salus::Scanners::YarnAudit do
 
       expect(scanner.report.to_h.fetch(:passed)).to eq(false)
       vulns = JSON.parse(scanner.report.to_h[:info][:stdout]).sort { |a, b| a["ID"] <=> b["ID"] }
-      expect(vulns.size).to eq(18)
+      expect(vulns.size).to eq(19)
 
       vulns.each do |vul|
         ["Package", "Patched in", "Dependency of", "More info", "Severity", "Title"].each do |attr|

--- a/spec/lib/sarif/base_sarif_spec.rb
+++ b/spec/lib/sarif/base_sarif_spec.rb
@@ -32,7 +32,7 @@ describe Sarif::BaseSarif do
           "informationUri" => "https://github.com/coinbase/salus",
           "properties" => {
             "salusEnforced": false,
-            "salusWarn": false
+            "salusWarnMessage": false
           }
         } })
     end

--- a/spec/lib/sarif/base_sarif_spec.rb
+++ b/spec/lib/sarif/base_sarif_spec.rb
@@ -31,7 +31,8 @@ describe Sarif::BaseSarif do
           "rules" => [],
           "informationUri" => "https://github.com/coinbase/salus",
           "properties" => {
-            "salusEnforced": false
+            "salusEnforced": false,
+            "salusWarn": false
           }
         } })
     end


### PR DESCRIPTION
Adding `salusWarn` flag to SARIF to allow differentiating between warn and enforced scanner.