### PR TITLE
Adding support for sub-directory for match pattern in Semgrep

### DIFF
--- a/docs/scanners/semgrep.md
+++ b/docs/scanners/semgrep.md
@@ -73,6 +73,7 @@ Each simple rule in salus.yaml **must** include
 * `pattern` - the single pattern
 * `forbidden: true` or `required: true
 * `language`- Any of: c, go, java, javascript, or python
+* `sub-dir` - this pattern will apply only to the sub-dir listed. This should be a valid sub-directory under the directory defined by "directories" under "recursion" config
 
 The user can **optionally** provide
 * `exclude` - Skip any file or directory that matches this pattern

--- a/lib/salus/scanners/semgrep.rb
+++ b/lib/salus/scanners/semgrep.rb
@@ -80,7 +80,6 @@ module Salus::Scanners
         enforce_explicit_ignoring
 
         # run semgrep
-        puts "Swaraj, ", command
         shell_return = run_shell(command)
 
         # check to make sure it's successful

--- a/lib/salus/scanners/semgrep.rb
+++ b/lib/salus/scanners/semgrep.rb
@@ -249,7 +249,7 @@ module Salus::Scanners
           "--lang",
           match['language'],
           *exclude_flags,
-          base_path
+          base_path + "#{match['sub-dir']}"
         ].compact
         user_message = "pattern \"#{pattern}\""
       end

--- a/lib/salus/scanners/semgrep.rb
+++ b/lib/salus/scanners/semgrep.rb
@@ -80,6 +80,7 @@ module Salus::Scanners
         enforce_explicit_ignoring
 
         # run semgrep
+        puts "Swaraj, ", command
         shell_return = run_shell(command)
 
         # check to make sure it's successful
@@ -249,7 +250,7 @@ module Salus::Scanners
           "--lang",
           match['language'],
           *exclude_flags,
-          base_path + "#{match['sub-dir']}"
+          base_path + match['sub-dir'].to_s
         ].compact
         user_message = "pattern \"#{pattern}\""
       end

--- a/spec/lib/salus/scanners/yarn_audit_spec.rb
+++ b/spec/lib/salus/scanners/yarn_audit_spec.rb
@@ -71,7 +71,7 @@ describe Salus::Scanners::YarnAudit do
 
       expect(scanner.report.to_h.fetch(:passed)).to eq(false)
       vulns = JSON.parse(scanner.report.to_h[:info][:stdout]).sort { |a, b| a["ID"] <=> b["ID"] }
-      expect(vulns.size).to eq(18)
+      expect(vulns.size).to eq(19)
 
       vulns.each do |vul|
         ["Package", "Patched in", "Dependency of", "More info", "Severity", "Title"].each do |attr|


### PR DESCRIPTION
Adding support for sub-directory for match pattern in Semgrep
Tested using the following pattern
```
- pattern: "$STRUCT.Peld(..., request)"
          message: "PII exception"
          language: go
          sub-dir: "/admin-api/internal"
```

semgrep command run
```
semgrep
--json
--disable-version-check
--pattern
$STRUCT.PbField(..., request)
--lang
go
/home/repo/$$$/$$$/$$$/$$$$$
```