### PR TITLE
support normalized semgrep exceptions

### DIFF
--- a/docs/scanners/semgrep.md
+++ b/docs/scanners/semgrep.md
@@ -110,7 +110,7 @@ scanner_configs:
 
 Please see [semgrep's documentation on how to use an inline comment to allowlist findings](https://semgrep.dev/docs/ignoring-files-folders-code/#reference-summary).
 
-You can also whitelist all findings for specific ids, like
+You can also whitelist all findings for specific ids in the salus config, like
 ```yaml
 scanner_configs:
   Semgrep:

--- a/docs/scanners/semgrep.md
+++ b/docs/scanners/semgrep.md
@@ -110,7 +110,18 @@ scanner_configs:
 
 Please see [semgrep's documentation on how to use an inline comment to allowlist findings](https://semgrep.dev/docs/ignoring-files-folders-code/#reference-summary).
 
-We do not currently support allowling semgrep findings in the salus config.
+You can also whitelist all findings for specific ids, like
+```yaml
+scanner_configs:
+  Semgrep:
+    exceptions:
+      - advisory_id: myid1
+        changed_by: engineer1
+        notes: false positive because ...
+      - advisory_id: myid2
+        changed_by: engineer2
+        notes: false positive because ...
+```
 
 ## Limitations of Semgrep
 

--- a/lib/salus/scanners/semgrep.rb
+++ b/lib/salus/scanners/semgrep.rb
@@ -78,6 +78,7 @@ module Salus::Scanners
         )
 
         enforce_explicit_ignoring
+        command += add_exclude_rules(fetch_exception_ids)
 
         # run semgrep
         shell_return = run_shell(command)
@@ -320,6 +321,15 @@ module Salus::Scanners
       list_of_errors&.map do |err|
         error_to_string(err)
       end&.join("\n")
+    end
+
+    def add_exclude_rules(advisory_ids)
+      exclude_rules = []
+      advisory_ids.map do |id|
+        exclude_rules.push("--exclude-rule")
+        exclude_rules.push(id)
+      end
+      exclude_rules
     end
 
     def self.supported_languages

--- a/lib/salus/scanners/semgrep.rb
+++ b/lib/salus/scanners/semgrep.rb
@@ -325,7 +325,7 @@ module Salus::Scanners
 
     def add_exclude_rules(advisory_ids)
       exclude_rules = []
-      advisory_ids.map do |id|
+      advisory_ids.each do |id|
         exclude_rules.push("--exclude-rule")
         exclude_rules.push(id)
       end

--- a/spec/lib/salus/scanners/semgrep_spec.rb
+++ b/spec/lib/salus/scanners/semgrep_spec.rb
@@ -131,6 +131,32 @@ describe Salus::Scanners::Semgrep do
           expect(info[:misses]).to be_empty
         end
 
+        it "should report not report findings that have been allowlisted" do
+          repo = Salus::Repo.new("spec/fixtures/semgrep")
+          config = {
+            "matches" => [
+              {
+                "config" => "semgrep-config.yml",
+                "forbidden" => false
+              }
+            ],
+            "exceptions" => [
+              {
+                "advisory_id" => "semgrep-eqeq-test",
+                "changed_by" => "me",
+                "notes" => "..."
+              }
+            ]
+          }
+          scanner = Salus::Scanners::Semgrep.new(repository: repo, config: config)
+          scanner.run
+
+          expect(scanner.report.passed?).to eq(true)
+
+          info = scanner.report.to_h.fetch(:info)
+          expect(info).to be_empty
+        end
+
         it "should report forbidden matches" do
           repo = Salus::Repo.new("spec/fixtures/semgrep")
           config = {

--- a/spec/lib/salus/scanners/semgrep_spec.rb
+++ b/spec/lib/salus/scanners/semgrep_spec.rb
@@ -154,7 +154,8 @@ describe Salus::Scanners::Semgrep do
           expect(scanner.report.passed?).to eq(true)
 
           info = scanner.report.to_h.fetch(:info)
-          expect(info).to be_empty
+          expect(info[:hits]).to be_empty
+          expect(info[:misses]).to be_empty
         end
 
         it "should report forbidden matches" do


### PR DESCRIPTION
Support normalized semgrep exceptions in salus config, like
```yaml
    exceptions:
      - advisory_id: myid1
        changed_by: me
        notes: my notes
```

Tested with
* new spec
* `docker build ...`, `docker run ...`, with allowlisting none, subset, and all findings.