### PR TITLE
Fix warn_message bug

### DIFF
--- a/lib/sarif/base_sarif.rb
+++ b/lib/sarif/base_sarif.rb
@@ -50,7 +50,7 @@ module Sarif
           "rules" => rules,
           "properties" => {
             "salusEnforced": @required || false,
-            "salusWarnMessage": handle_warn_flag || @required
+            "salusWarnMessage": @required.nil? ? false : handle_warn_flag || @required
           }
         }
       }

--- a/lib/sarif/base_sarif.rb
+++ b/lib/sarif/base_sarif.rb
@@ -50,7 +50,7 @@ module Sarif
           "rules" => rules,
           "properties" => {
             "salusEnforced": @required || false,
-            "salusWarnMessage": handle_warn_flag
+            "salusWarnMessage": handle_warn_flag || @required
           }
         }
       }

--- a/spec/fixtures/sorted_results/sorted_sarif.json
+++ b/spec/fixtures/sorted_results/sorted_sarif.json
@@ -62,7 +62,7 @@
           "name": "Semgrep",
           "properties": {
             "salusEnforced": true,
-            "salusWarnMessage": false
+            "salusWarnMessage": true
           },
           "rules": [
             {


### PR DESCRIPTION
- With the introduction of `warn_message` feature, it sets the `warn_message` flag to false for enforced scanners as well which is incorrect. This PR takes that into account so that if it is enforced it will be set to `true`. 
- Update test case.