### PR TITLE
allow semgrep config to be from root dir

### DIFF
--- a/docs/scanners/semgrep.md
+++ b/docs/scanners/semgrep.md
@@ -20,7 +20,7 @@ In adddition, simple rules can be specified directly in salus.yaml.
 
 In salus.yaml, you can specify a set of semgrep rules with a path to a [Semgrep config file](https://github.com/returntocorp/semgrep/blob/develop/docs/configuration-files.md).  You **must** specify
 
-* `config` - a full Semgrep config file
+* `config` - a full Semgrep config file/directory. This config can either be nested inside the repo, or start with `/` if the path also contains `semgrep`.
 * Either `required: true` or `forbidden: true`
   - If a found pattern is forbidden or if a not found pattern is required, then the scanner will fail and the `message` will be show to the developer in the report.
 

--- a/lib/salus/scanners/semgrep.rb
+++ b/lib/salus/scanners/semgrep.rb
@@ -224,6 +224,8 @@ module Salus::Scanners
         config = match['config']
         config_val = if config.start_with?('https:')
                        config
+                     elsif config.start_with?('/') && config.include?('semgrep')
+                       config
                      else
                        File.join(base_path, config)
                      end

--- a/spec/lib/salus/scanners/semgrep_spec.rb
+++ b/spec/lib/salus/scanners/semgrep_spec.rb
@@ -917,6 +917,37 @@ describe Salus::Scanners::Semgrep do
     end
   end
 
+  describe '#build_command_and_message' do
+    let(:scanner) { Salus::Scanners::Semgrep.new(repository: Salus::Repo.new(''), config: {}) }
+
+    it 'config for relative path' do
+      match = { "config" => "myrules.yaml", "forbidden" => true, "required" => false,
+                "strict" => false, "message" => "" }
+      cmd = scanner.build_command_and_message(match, false, '/home/repo', nil)[0]
+      expected_cmd = ["semgrep", "--json", "--disable-version-check",
+                      "--config", "/home/repo/myrules.yaml", "/home/repo"]
+      expect(cmd).to eq(expected_cmd)
+    end
+
+    it 'config for url' do
+      match = { "config" => "https://localhost/rules", "forbidden" => true, "required" => false,
+                "strict" => false, "message" => "" }
+      cmd = scanner.build_command_and_message(match, false, '/home/repo', nil)[0]
+      expected_cmd = ["semgrep", "--json", "--disable-version-check",
+                      "--config", "https://localhost/rules", "/home/repo"]
+      expect(cmd).to eq(expected_cmd)
+    end
+
+    it 'config for absolute path' do
+      match = { "config" => "/home/semgrep_rules", "forbidden" => true, "required" => false,
+                "strict" => false, "message" => "" }
+      cmd = scanner.build_command_and_message(match, false, '/home/repo', nil)[0]
+      expected_cmd = ["semgrep", "--json", "--disable-version-check",
+                      "--config", "/home/semgrep_rules", "/home/repo"]
+      expect(cmd).to eq(expected_cmd)
+    end
+  end
+
   describe '#version_valid?' do
     context 'scanner version is valid' do
       it 'should return true' do


### PR DESCRIPTION
Allow semgrep config to be from root dir.

Tested with new unit tests and docker.