### PR TITLE
show sha of hardcoded credential instead of actual credential

### DIFF
--- a/lib/salus/scanners/trufflehog.rb
+++ b/lib/salus/scanners/trufflehog.rb
@@ -1,3 +1,4 @@
+require 'digest'
 require 'json'
 require 'salus/scanners/base'
 
@@ -65,9 +66,10 @@ module Salus::Scanners
           id = parsed_v['DetectorName'] + '-' + parsed_v['DecoderName']
           if !exception_ids.include?(id)
             filtered_v = {}
-            filtered_v['Leaked Credential'] = parsed_v['Raw']
+            raw_credential = parsed_v['Raw']
+            filtered_v['SHA256 of Leaked Credential'] = Digest::SHA256.hexdigest(raw_credential)
             filtered_v['File'] = parsed_v.dig('SourceMetadata', 'Data', 'Filesystem', 'file')
-            filtered_v['Line Num'] = line_num(filtered_v['File'], filtered_v['Leaked Credential'])
+            filtered_v['Line Num'] = line_num(filtered_v['File'], raw_credential)
             filtered_v['ID'] = id
             filtered_v['Verified'] = parsed_v['Verified']
             parsed_vulns.push filtered_v

--- a/lib/sarif/trufflehog_sarif.rb
+++ b/lib/sarif/trufflehog_sarif.rb
@@ -51,12 +51,8 @@ module Sarif
           start_column: 1,
           uri: issue['File'],
           help_url: @uri,
-          code: issue['Leaked Credential']
+          code: issue['SHA256 of Leaked Credential']
       }
-    end
-
-    def self.snippet_possibly_in_git_diff?(snippet, lines_added)
-      lines_added.keys.any? { |newline| newline.include?(snippet) }
     end
   end
 end

--- a/spec/lib/salus/scanners/trufflehog_spec.rb
+++ b/spec/lib/salus/scanners/trufflehog_spec.rb
@@ -49,26 +49,25 @@ describe Salus::Scanners::Trufflehog do
 
       report_h = scanner.report.to_h
       expect(report_h[:passed]).to eq(false)
-      expected_log0 = { "Leaked Credential" => "216ce860c78081b83f255cad4d032361677"\
-                                               "e4aea87dacecd387e62505e1e4a50dd947b"\
-                                               "3ce9166b70d8b9aaa45215c1b512c518b53"\
-                                               "84e5067ee7d29011da0efb4",
+      expected_log0 = { "SHA256 of Leaked Credential" => "2d00fc02b2d554da2a58feb7bac"\
+                                                      "53673126f5c10f7c0a718e49e63"\
+                                                      "5c489bf505",
                         "File" => "logins.txt",
                         "Line Num" => 2,
                         "ID" => "FlatIO-PLAIN",
                         "Verified" => false }
-      expected_log1 = { "Leaked Credential" => "jdbc:postgresql://localhost:5432/test?user=test"\
-                                               "&password=ABCD&loggerLevel=DEBUG&&&"\
-                                               "loggerFile=./blah.jsp",
+      expected_log1 = { "SHA256 of Leaked Credential6" => "e364ca3424d2454bc630a574e16"\
+                                                      "9102b6d6be06189a2038badb969"\
+                                                      "cf47755abe",
                        "File" => "url.txt",
                         "Line Num" => 1,
                        "ID" => "JDBC-PLAIN",
                        "Verified" => false }
-      expected_log2 = { "Leaked Credential" => "jdbc:postgresql://localhost:2345/test?user=test"\
-                                               "&password=DCBA&loggerLevel=DEBUG&&&"\
-                                               "loggerFile=./blah.jsp",
+      expected_log2 = { "SHA256 of Leaked Credential" => "8f839fbea674797911361d91124"\
+                                                      "50478e280b982321c22363ca7a7"\
+                                                      "4f36a4bbd6",
                        "File" => "url.txt",
-                        "Line Num" => 2,
+                       "Line Num" => 2,
                        "ID" => "JDBC-PLAIN",
                        "Verified" => false }
       logs = JSON.parse(report_h[:logs])
@@ -93,10 +92,9 @@ describe Salus::Scanners::Trufflehog do
 
       report_h = scanner.report.to_h
       expect(report_h[:passed]).to eq(false)
-      expected_log0 = { "Leaked Credential" => "216ce860c78081b83f255cad4d032361677"\
-                                               "e4aea87dacecd387e62505e1e4a50dd947b"\
-                                               "3ce9166b70d8b9aaa45215c1b512c518b53"\
-                                               "84e5067ee7d29011da0efb4",
+      expected_log0 = { "SHA256 of Leaked Credential" => "2d00fc02b2d554da2a58feb7"\
+                                                      "bac53673126f5c10f7c0a718"\
+                                                      "e49e635c489bf505",
                         "File" => "logins.txt",
                         "Line Num" => 2,
                         "ID" => "FlatIO-PLAIN",

--- a/spec/lib/salus/scanners/trufflehog_spec.rb
+++ b/spec/lib/salus/scanners/trufflehog_spec.rb
@@ -56,7 +56,7 @@ describe Salus::Scanners::Trufflehog do
                         "Line Num" => 2,
                         "ID" => "FlatIO-PLAIN",
                         "Verified" => false }
-      expected_log1 = { "SHA256 of Leaked Credential6" => "e364ca3424d2454bc630a574e16"\
+      expected_log1 = { "SHA256 of Leaked Credential" => "e364ca3424d2454bc630a574e16"\
                                                       "9102b6d6be06189a2038badb969"\
                                                       "cf47755abe",
                        "File" => "url.txt",

--- a/spec/lib/sarif/trufflehog_sarif_spec.rb
+++ b/spec/lib/sarif/trufflehog_sarif_spec.rb
@@ -20,12 +20,9 @@ describe Sarif::TrufflehogSarif do
                             "artifactLocation" => { "uri" => "logins.txt",
                                                     "uriBaseId" => "%SRCROOT%" },
                                               "region" => { "snippet" => { "text" =>
-                                                            "216ce860c78081b83f255ca"\
-                                                            "d4d032361677e4aea87dace"\
-                                                            "cd387e62505e1e4a50dd947"\
-                                                            "b3ce9166b70d8b9aaa45215"\
-                                                            "c1b512c518b5384e5067ee7"\
-                                                            "d29011da0efb4" },
+                                                            "2d00fc02b2d554da2a58feb7bac"\
+                                                            "53673126f5c10f7c0a718e49e63"\
+                                                            "5c489bf505" },
                                                             "startColumn" => 1, "startLine" => 2 }
                           } }],
                           "message" => { "text" => "Leaked credential detected" },
@@ -36,10 +33,9 @@ describe Sarif::TrufflehogSarif do
                             "artifactLocation" => { "uri" => "url.txt",
                                                     "uriBaseId" => "%SRCROOT%" },
                             "region" => { "snippet" => { "text" =>
-                                                         "jdbc:postgresql://localhost:2345/"\
-                                                         "test?user=test&password=DCBA&"\
-                                                         "loggerLevel=DEBUG&&&"\
-                                                         "loggerFile=./blah.jsp" },
+                                                         "8f839fbea674797911361d91124"\
+                                                         "50478e280b982321c22363ca7a7"\
+                                                         "4f36a4bbd6" },
                                           "startColumn" => 1, "startLine" => 2 }
                           } }],
                           "message" => { "text" => "Leaked credential detected" },
@@ -50,10 +46,9 @@ describe Sarif::TrufflehogSarif do
                             "artifactLocation" => { "uri" => "url.txt",
                                                     "uriBaseId" => "%SRCROOT%" },
                             "region" => { "snippet" => { "text" =>
-                                                         "jdbc:postgresql://localhost:5432/"\
-                                                         "test?user=test&password=ABCD&"\
-                                                         "loggerLevel=DEBUG&&&"\
-                                                         "loggerFile=./blah.jsp" },
+                                                         "e364ca3424d2454bc630a574e16"\
+                                                         "9102b6d6be06189a2038badb969"\
+                                                         "cf47755abe" },
                                           "startColumn" => 1, "startLine" => 1 }
                           } }],
                           "message" => { "text" => "Leaked credential detected" },
@@ -71,30 +66,6 @@ describe Sarif::TrufflehogSarif do
         sarif_report = JSON.parse(report.to_sarif)
         result = sarif_report["runs"][0]["results"]
         expect(result).to be_empty
-      end
-    end
-  end
-
-  describe 'sarif diff' do
-    context 'git diff support' do
-      let(:new_lines_in_git_diff) do
-        git_diff_file = 'spec/fixtures/sarifs/diff/git_diff_10.txt'
-        git_diff = File.read(git_diff_file)
-        Sarif::BaseSarif.new_lines_in_git_diff(git_diff)
-      end
-
-      it 'should find code in git diff' do
-        snippet = 'jdbc:postgresql://localhost:2345/test?user=test&'\
-                  'password=DCBA&loggerLevel=DEBUG&&&loggerFile=./blah.jsp'
-        r = Sarif::TrufflehogSarif.snippet_possibly_in_git_diff?(snippet, new_lines_in_git_diff)
-        expect(r).to be true
-      end
-
-      it 'should not find code in git diff if snippet not in git diff' do
-        snippet = 'jdbc:postgresql://localhost:80/test?user=test&'\
-                  'password=abcd&loggerLevel=DEBUG&&&loggerFile=./blah.jsp'
-        r = Sarif::TrufflehogSarif.snippet_possibly_in_git_diff?(snippet, new_lines_in_git_diff)
-        expect(r).to be false
       end
     end
   end


### PR DESCRIPTION
For TruffleHog, show sha256 of hardcoded credentials instead of raw credentials.