### PR TITLE
support for Gosec filter_errors

### DIFF
--- a/docs/scanners/gosec.md
+++ b/docs/scanners/gosec.md
@@ -37,6 +37,9 @@ The [Gosec Scanner](https://github.com/securego/gosec) is a static analysis tool
           changed_by: security-team
           notes: Currently no patch exists and determined that this vulnerability is not exploitable.
           expiration: "2021-04-27"
+      filter_errors:                     # filter out golang errors that match the messages
+        - error message 1
+        - error message 2
 ```
 ## Exceptions
 

--- a/lib/salus/scanners/gosec.rb
+++ b/lib/salus/scanners/gosec.rb
@@ -13,6 +13,7 @@ module Salus::Scanners
     def run
       @filter_errors = Set.new
       config_filter_errors = @config['filter_errors']
+
       if config_filter_errors.is_a?(Array) && config_filter_errors.size.positive?
         @filter_errors = Set.new(config_filter_errors)
       end
@@ -96,10 +97,12 @@ module Salus::Scanners
 
       if @filter_errors.size.positive?
         remove_errors(golang_errors)
+
         if golang_errors.empty? && found_issues.empty?
           shell_return.instance_variable_set(:@status, 0)
           shell_return.instance_variable_set(:@success, true)
         end
+
         new_stdout = JSON.pretty_generate(shell_return_json)
         shell_return.instance_variable_set(:@stdout, new_stdout)
       end
@@ -236,6 +239,7 @@ module Salus::Scanners
 
     def remove_errors(golang_errors)
       to_delete = {}
+
       golang_errors.each do |filename, data_maps|
         data_maps.each_with_index do |d, i|
           if d['error'].to_s != '' && @filter_errors.include?(d['error'])
@@ -244,6 +248,7 @@ module Salus::Scanners
           end
         end
       end
+
       to_delete.each do |filename, indexes|
         rindexes = indexes.reverse
         rindexes.each do |i|

--- a/lib/salus/scanners/gosec.rb
+++ b/lib/salus/scanners/gosec.rb
@@ -12,8 +12,9 @@ module Salus::Scanners
 
     def run
       @filter_errors = Set.new
-      if @config['filter_errors'].is_a?(Array) && @config['filter_errors'].size.positive?
-        @filter_errors = Set.new(@config['filter_errors'])
+      config_filter_errors = @config['filter_errors']
+      if config_filter_errors.is_a?(Array) && config_filter_errors.size.positive?
+        @filter_errors = Set.new(config_filter_errors)
       end
 
       # 'run_from_dirs' specifies a list of subdirs to run salus from

--- a/spec/fixtures/gosec/malformed_goapp2/hello.go
+++ b/spec/fixtures/gosec/malformed_goapp2/hello.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"fmt"
+)
+
+func main() {
+	fmt.Pintl("this has a typo")
+	fmt.Foo(0)
+
+	username := "admin"
+	var password = "f62e5bcda4fae4f82370da0c6f20697b8f8447ef"
+	fmt.Println("Doing something with: ", username, password)
+}

--- a/spec/lib/salus/scanners/gosec_spec.rb
+++ b/spec/lib/salus/scanners/gosec_spec.rb
@@ -77,6 +77,49 @@ describe Salus::Scanners::Gosec do
     end
   end
 
+  describe '#run with filter_errors' do
+    context 'filter_errors' do
+      it 'repo has 1 error, 0 vul. filter_error should remove error and pass scanner' do
+        repo = Salus::Repo.new('spec/fixtures/gosec/malformed_goapp')
+        config = { 'filter_errors' => ['Pintl not declared by package fmt'] }
+        scanner = Salus::Scanners::Gosec.new(repository: repo, config: config)
+        scanner.run
+        expect(scanner.report.passed?).to eq(true)
+        report_data = scanner.report.to_h
+        expect(report_data[:errors]).to be_empty
+        expect(report_data[:logs]).to be_nil
+      end
+
+      it 'repo has 2 errors, 1 vul. If 2 errors filtered, scanner still fails' do
+        repo = Salus::Repo.new('spec/fixtures/gosec/malformed_goapp2')
+        config = { 'filter_errors' => ['Pintl not declared by package fmt',
+                                       'Foo not declared by package fmt'] }
+        scanner = Salus::Scanners::Gosec.new(repository: repo, config: config)
+        scanner.run
+        expect(scanner.report.passed?).to eq(false)
+        report_data = scanner.report.to_h
+        expect(report_data[:errors]).to be_empty
+        logs = JSON.parse(report_data[:logs])
+        expect(logs['Golang errors']).to be_empty
+      end
+
+      it 'repo has 2 errors, 1 vul. If 1 error filtered, 1 error/vul remain' do
+        repo = Salus::Repo.new('spec/fixtures/gosec/malformed_goapp2')
+        config = { 'filter_errors' => ['Foo not declared by package fmt'] }
+        scanner = Salus::Scanners::Gosec.new(repository: repo, config: config)
+        scanner.run
+        expect(scanner.report.passed?).to eq(false)
+        report_data = scanner.report.to_h
+        expect(report_data[:errors]).to be_empty
+        logs = JSON.parse(report_data[:logs])
+        expected_err = { "/home/spec/fixtures/gosec/malformed_goapp2/hello.go" =>
+                        [{ "line" => 8, "column" => 6,
+                          "error" => "Pintl not declared by package fmt" }] }
+        expect(logs['Golang errors']).to eq(expected_err)
+      end
+    end
+  end
+
   describe '#run from multiple subdirs' do
     context 'go project with multiple sub-projects' do
       let(:repo) { 'spec/fixtures/gosec/multi_goapps' }

--- a/spec/lib/salus/scanners/gosec_spec.rb
+++ b/spec/lib/salus/scanners/gosec_spec.rb
@@ -84,6 +84,7 @@ describe Salus::Scanners::Gosec do
         config = { 'filter_errors' => ['Pintl not declared by package fmt'] }
         scanner = Salus::Scanners::Gosec.new(repository: repo, config: config)
         scanner.run
+
         expect(scanner.report.passed?).to eq(true)
         report_data = scanner.report.to_h
         expect(report_data[:errors]).to be_empty
@@ -96,6 +97,7 @@ describe Salus::Scanners::Gosec do
                                        'Foo not declared by package fmt'] }
         scanner = Salus::Scanners::Gosec.new(repository: repo, config: config)
         scanner.run
+
         expect(scanner.report.passed?).to eq(false)
         report_data = scanner.report.to_h
         expect(report_data[:errors]).to be_empty
@@ -108,6 +110,7 @@ describe Salus::Scanners::Gosec do
         config = { 'filter_errors' => ['Foo not declared by package fmt'] }
         scanner = Salus::Scanners::Gosec.new(repository: repo, config: config)
         scanner.run
+
         expect(scanner.report.passed?).to eq(false)
         report_data = scanner.report.to_h
         expect(report_data[:errors]).to be_empty


### PR DESCRIPTION
Support for Gosec `filter_errors`.

Can be used in `salus.yaml` like below to filter out golang errors that match the error messages in `filter_errors`.
```yaml
scanner_configs:
  Gosec:
    filter_errors:
      - Foo not declared by package fmt
      - Bar not declared by package fmt
 ```

Tested with new unit tests and local docker runs.