### PR TITLE
Fixed regression on reporting

### DIFF
--- a/lib/salus/report.rb
+++ b/lib/salus/report.rb
@@ -336,15 +336,16 @@ module Salus
 
       @report_uris.each do |directive|
         if @report_filter == 'all' || satisfies_filter?(directive, filter_key, filter_value)
+          puts "Publishing to #{directive['uri']}"
           publish_report(directive)
         end
-      end
-    rescue StandardError => e
-      raise e if ENV['RUNNING_SALUS_TESTS']
+      rescue StandardError => e
+        raise e if ENV['RUNNING_SALUS_TESTS']
 
-      puts "Could not send Salus report: (#{e.class}: #{e.message}), #{e.backtrace}"
-      e = "Could not send Salus report. Exception: #{e}, Build info: #{builds}, #{e.backtrace}"
-      bugsnag_notify(e)
+        puts "Could not send Salus report: (#{e.class}: #{e.message}), #{e.backtrace}"
+        e = "Could not send Salus report. Exception: #{e}, Build info: #{builds}, #{e.backtrace}"
+        bugsnag_notify(e)
+      end
     end
 
     def safe_local_report_path?(path)


### PR DESCRIPTION
https://github.com/coinbase/salus/pull/471 introduced a regression in reporting.  Previously Salus would attempt to send reports to all configured endpoints [desired behavior].  #471 introduced a regression where sends would stop on the first failing endpoint.  This PR fixes that regression and adds a spec to ensure we don't re-introduce it in the future.