### PR TITLE
Support CWEs for Semgrep reporting

### DIFF
--- a/lib/salus/scanners/semgrep.rb
+++ b/lib/salus/scanners/semgrep.rb
@@ -127,6 +127,9 @@ module Salus::Scanners
                        else # id specified by user
                          hit['check_id']
                        end
+
+              cwes = hit.dig('extra', 'metadata', 'cwe')
+              cwes = [] if cwes.nil?
               all_hits << {
                 id: hit_id,
                 pattern: match['pattern'],
@@ -135,7 +138,8 @@ module Salus::Scanners
                 required: match["required"],
                 msg: msg,
                 hit: hit_to_string(hit, base_path),
-                severity: hit['extra']['severity']
+                severity: hit['extra']['severity'],
+                cwes: cwes
               }
             end
           end

--- a/lib/sarif/semgrep_sarif.rb
+++ b/lib/sarif/semgrep_sarif.rb
@@ -86,6 +86,7 @@ module Sarif
              else
                location[2]
              end
+      cwes = hit.fetch(:cwes, [])
       {
         id: hit[:id],
         name: "#{hit[:pattern]} / #{hit[:msg]} Forbidden Pattern Found",
@@ -97,7 +98,8 @@ module Sarif
         help_url: SEMGREP_URI,
         code: code,
         rule: "Pattern: #{hit[:pattern]}\nMessage: #{hit[:msg]}",
-        properties: { 'severity': hit[:severity] }
+        properties: { 'severity': hit[:severity] },
+        messageStrings: { "cwe": { "text": cwes.to_s } }
       }
     rescue StandardError => e
       bugsnag_notify(e.message)

--- a/spec/fixtures/semgrep/semgrep-config.yml
+++ b/spec/fixtures/semgrep/semgrep-config.yml
@@ -5,3 +5,6 @@ rules:
       message: $X == $X is always true
       languages: [python]
       severity: WARNING
+      metadata:
+        cwe:
+          - "CWE-676: Use of Potentially Dangerous Function"

--- a/spec/lib/salus/scanners/semgrep_spec.rb
+++ b/spec/lib/salus/scanners/semgrep_spec.rb
@@ -29,7 +29,8 @@ describe Salus::Scanners::Semgrep do
           forbidden: false,
           required: false,
           msg: "",
-          hit: "trivial.py:3:if 3 == 3:"
+          hit: "trivial.py:3:if 3 == 3:",
+          cwes: []
         )
 
         expect(info[:hits]).to include(
@@ -40,7 +41,8 @@ describe Salus::Scanners::Semgrep do
           forbidden: false,
           required: false,
           msg: "",
-          hit: "examples/trivial2.py:10:    if user.id == user.id:"
+          hit: "examples/trivial2.py:10:    if user.id == user.id:",
+          cwes: []
         )
 
         expect(info[:hits]).to include(
@@ -51,7 +53,8 @@ describe Salus::Scanners::Semgrep do
           forbidden: false,
           required: false,
           msg: "",
-          hit: "vendor/trivial2.py:10:    if user.id == user.id:"
+          hit: "vendor/trivial2.py:10:    if user.id == user.id:",
+          cwes: []
         )
 
         expect(info[:misses]).to be_empty
@@ -103,7 +106,8 @@ describe Salus::Scanners::Semgrep do
             forbidden: false,
             required: false,
             msg: "3 == 3 is always true\n\trule_id: semgrep-eqeq-test",
-            hit: "trivial.py:3:if 3 == 3:"
+            hit: "trivial.py:3:if 3 == 3:",
+            cwes: ["CWE-676: Use of Potentially Dangerous Function"]
           )
 
           expect(info[:hits]).to include(
@@ -114,7 +118,8 @@ describe Salus::Scanners::Semgrep do
             forbidden: false,
             required: false,
             msg: "user.id == user.id is always true\n\trule_id: semgrep-eqeq-test",
-            hit: "examples/trivial2.py:10:    if user.id == user.id:"
+            hit: "examples/trivial2.py:10:    if user.id == user.id:",
+            cwes: ["CWE-676: Use of Potentially Dangerous Function"]
           )
 
           expect(info[:hits]).to include(
@@ -125,7 +130,8 @@ describe Salus::Scanners::Semgrep do
             forbidden: false,
             required: false,
             msg: "user.id == user.id is always true\n\trule_id: semgrep-eqeq-test",
-            hit: "vendor/trivial2.py:10:    if user.id == user.id:"
+            hit: "vendor/trivial2.py:10:    if user.id == user.id:",
+            cwes: ["CWE-676: Use of Potentially Dangerous Function"]
           )
 
           expect(info[:misses]).to be_empty
@@ -183,7 +189,8 @@ describe Salus::Scanners::Semgrep do
             forbidden: true,
             required: false,
             msg: "3 == 3 is always true\n\trule_id: semgrep-eqeq-test",
-            hit: "trivial.py:3:if 3 == 3:"
+            hit: "trivial.py:3:if 3 == 3:",
+            cwes: ["CWE-676: Use of Potentially Dangerous Function"]
           )
 
           expect(info[:hits]).to include(
@@ -194,7 +201,8 @@ describe Salus::Scanners::Semgrep do
             forbidden: true,
             required: false,
             msg: "user.id == user.id is always true\n\trule_id: semgrep-eqeq-test",
-            hit: "examples/trivial2.py:10:    if user.id == user.id:"
+            hit: "examples/trivial2.py:10:    if user.id == user.id:",
+            cwes: ["CWE-676: Use of Potentially Dangerous Function"]
           )
 
           expect(info[:hits]).to include(
@@ -205,7 +213,8 @@ describe Salus::Scanners::Semgrep do
             forbidden: true,
             required: false,
             msg: "user.id == user.id is always true\n\trule_id: semgrep-eqeq-test",
-            hit: "vendor/trivial2.py:10:    if user.id == user.id:"
+            hit: "vendor/trivial2.py:10:    if user.id == user.id:",
+            cwes: ["CWE-676: Use of Potentially Dangerous Function"]
           )
 
           expect(info[:misses]).to be_empty
@@ -236,7 +245,8 @@ describe Salus::Scanners::Semgrep do
             forbidden: false,
             required: true,
             msg: "3 == 3 is always true\n\trule_id: semgrep-eqeq-test",
-            hit: "trivial.py:3:if 3 == 3:"
+            hit: "trivial.py:3:if 3 == 3:",
+            cwes: ["CWE-676: Use of Potentially Dangerous Function"]
           )
 
           expect(info[:hits]).to include(
@@ -247,7 +257,8 @@ describe Salus::Scanners::Semgrep do
             forbidden: false,
             required: true,
             msg: "user.id == user.id is always true\n\trule_id: semgrep-eqeq-test",
-            hit: "examples/trivial2.py:10:    if user.id == user.id:"
+            hit: "examples/trivial2.py:10:    if user.id == user.id:",
+            cwes: ["CWE-676: Use of Potentially Dangerous Function"]
           )
 
           expect(info[:hits]).to include(
@@ -258,7 +269,8 @@ describe Salus::Scanners::Semgrep do
             forbidden: false,
             required: true,
             msg: "user.id == user.id is always true\n\trule_id: semgrep-eqeq-test",
-            hit: "vendor/trivial2.py:10:    if user.id == user.id:"
+            hit: "vendor/trivial2.py:10:    if user.id == user.id:",
+            cwes: ["CWE-676: Use of Potentially Dangerous Function"]
           )
 
           expect(info[:misses]).to be_empty
@@ -321,7 +333,8 @@ describe Salus::Scanners::Semgrep do
             forbidden: false,
             required: false,
             msg: "Found unverified db query\n\trule_id: unverified-db-query",
-            hit: "pattern-not/test.py:2:db_query(\"SELECT * FROM ...\")"
+            hit: "pattern-not/test.py:2:db_query(\"SELECT * FROM ...\")",
+            cwes: []
           )
 
           expect(info[:misses]).to be_empty
@@ -356,7 +369,8 @@ describe Salus::Scanners::Semgrep do
           forbidden: false,
           required: false,
           msg: "Useless equality test.",
-          hit: "trivial.py:3:if 3 == 3:"
+          hit: "trivial.py:3:if 3 == 3:",
+          cwes: []
         )
 
         expect(info[:hits]).to include(
@@ -367,7 +381,8 @@ describe Salus::Scanners::Semgrep do
           forbidden: false,
           required: false,
           msg: "Useless equality test.",
-          hit: "examples/trivial2.py:10:    if user.id == user.id:"
+          hit: "examples/trivial2.py:10:    if user.id == user.id:",
+          cwes: []
         )
 
         expect(info[:hits]).to include(
@@ -378,7 +393,8 @@ describe Salus::Scanners::Semgrep do
           forbidden: false,
           required: false,
           msg: "Useless equality test.",
-          hit: "vendor/trivial2.py:10:    if user.id == user.id:"
+          hit: "vendor/trivial2.py:10:    if user.id == user.id:",
+          cwes: []
         )
 
         expect(info[:misses]).to be_empty
@@ -412,7 +428,8 @@ describe Salus::Scanners::Semgrep do
           forbidden: true,
           required: false,
           msg: "",
-          hit: "trivial.py:3:if 3 == 3:"
+          hit: "trivial.py:3:if 3 == 3:",
+          cwes: []
         )
 
         expect(info[:hits]).to include(
@@ -423,7 +440,8 @@ describe Salus::Scanners::Semgrep do
           forbidden: true,
           required: false,
           msg: "",
-          hit: "examples/trivial2.py:10:    if user.id == user.id:"
+          hit: "examples/trivial2.py:10:    if user.id == user.id:",
+          cwes: []
         )
 
         expect(info[:hits]).to include(
@@ -434,7 +452,8 @@ describe Salus::Scanners::Semgrep do
           forbidden: true,
           required: false,
           msg: "",
-          hit: "vendor/trivial2.py:10:    if user.id == user.id:"
+          hit: "vendor/trivial2.py:10:    if user.id == user.id:",
+          cwes: []
         )
 
         expect(info[:misses]).to be_empty
@@ -470,7 +489,8 @@ describe Salus::Scanners::Semgrep do
           forbidden: false,
           required: true,
           msg: "Useless equality test.",
-          hit: "trivial.py:3:if 3 == 3:"
+          hit: "trivial.py:3:if 3 == 3:",
+          cwes: []
         )
 
         expect(info[:hits]).to include(
@@ -481,7 +501,8 @@ describe Salus::Scanners::Semgrep do
           forbidden: false,
           required: true,
           msg: "Useless equality test.",
-          hit: "examples/trivial2.py:10:    if user.id == user.id:"
+          hit: "examples/trivial2.py:10:    if user.id == user.id:",
+          cwes: []
         )
 
         expect(info[:hits]).to include(
@@ -492,7 +513,8 @@ describe Salus::Scanners::Semgrep do
           forbidden: false,
           required: true,
           msg: "Useless equality test.",
-          hit: "vendor/trivial2.py:10:    if user.id == user.id:"
+          hit: "vendor/trivial2.py:10:    if user.id == user.id:",
+          cwes: []
         )
 
         expect(info[:misses]).to be_empty
@@ -564,7 +586,8 @@ describe Salus::Scanners::Semgrep do
           forbidden: true,
           required: false,
           msg: "Useless equality test.",
-          hit: "trivial.py:3:if 3 == 3:"
+          hit: "trivial.py:3:if 3 == 3:",
+          cwes: []
         )
 
         expect(info[:hits]).to include(
@@ -575,7 +598,8 @@ describe Salus::Scanners::Semgrep do
           forbidden: true,
           required: false,
           msg: "Useless equality test.",
-          hit: "vendor/trivial2.py:10:    if user.id == user.id:"
+          hit: "vendor/trivial2.py:10:    if user.id == user.id:",
+          cwes: []
         )
 
         expect(info[:hits]).not_to include(
@@ -586,7 +610,8 @@ describe Salus::Scanners::Semgrep do
           forbidden: true,
           required: false,
           msg: "Useless equality test.",
-          hit: "examples/trivial2.py:10:    if user.id == user.id:"
+          hit: "examples/trivial2.py:10:    if user.id == user.id:",
+          cwes: []
         )
       end
     end
@@ -621,7 +646,8 @@ describe Salus::Scanners::Semgrep do
           forbidden: true,
           required: false,
           msg: "Useless equality test.",
-          hit: "trivial.py:3:if 3 == 3:"
+          hit: "trivial.py:3:if 3 == 3:",
+          cwes: []
         )
 
         expect(info[:hits]).not_to include(
@@ -632,7 +658,8 @@ describe Salus::Scanners::Semgrep do
           forbidden: true,
           required: false,
           msg: "Useless equality test.",
-          hit: "vendor/trivial2.py:10:    if user.id == user.id:"
+          hit: "vendor/trivial2.py:10:    if user.id == user.id:",
+          cwes: []
         )
 
         expect(info[:hits]).not_to include(
@@ -643,7 +670,8 @@ describe Salus::Scanners::Semgrep do
           forbidden: true,
           required: false,
           msg: "Useless equality test.",
-          hit: "examples/trivial2.py:10:    if user.id == user.id:"
+          hit: "examples/trivial2.py:10:    if user.id == user.id:",
+          cwes: []
         )
       end
     end
@@ -678,7 +706,8 @@ describe Salus::Scanners::Semgrep do
           forbidden: true,
           required: false,
           msg: "Useless equality test.",
-          hit: "trivial.py:3:if 3 == 3:"
+          hit: "trivial.py:3:if 3 == 3:",
+          cwes: []
         )
 
         expect(info[:hits]).to include(
@@ -689,7 +718,8 @@ describe Salus::Scanners::Semgrep do
           forbidden: true,
           required: false,
           msg: "Useless equality test.",
-          hit: "vendor/trivial2.py:10:    if user.id == user.id:"
+          hit: "vendor/trivial2.py:10:    if user.id == user.id:",
+          cwes: []
         )
 
         expect(info[:hits]).not_to include(
@@ -700,7 +730,8 @@ describe Salus::Scanners::Semgrep do
           forbidden: true,
           required: false,
           msg: "Useless equality test.",
-          hit: "examples/trivial2.py:10:    if user.id == user.id:"
+          hit: "examples/trivial2.py:10:    if user.id == user.id:",
+          cwes: []
         )
       end
     end
@@ -735,7 +766,8 @@ describe Salus::Scanners::Semgrep do
           forbidden: true,
           required: false,
           msg: "Useless equality test.",
-          hit: "trivial.py:3:if 3 == 3:"
+          hit: "trivial.py:3:if 3 == 3:",
+          cwes: []
         )
 
         expect(info[:hits]).not_to include(
@@ -745,7 +777,8 @@ describe Salus::Scanners::Semgrep do
           forbidden: true,
           required: false,
           msg: "Useless equality test.",
-          hit: "examples/trivial2.py:10:    if user.id == user.id:"
+          hit: "examples/trivial2.py:10:    if user.id == user.id:",
+          cwes: []
         )
       end
     end

--- a/spec/lib/sarif/semgrep_sarif_spec.rb
+++ b/spec/lib/sarif/semgrep_sarif_spec.rb
@@ -87,6 +87,23 @@ describe Sarif::SemgrepSarif do
         # semgrep-eqeq-test is the user-specified id in the semgrep config
         matches = result.select { |r| r["ruleId"] == "semgrep-eqeq-test" }
         expect(matches.size).to eq(3)
+
+        rules = sarif_report['runs'][0]['tool']['driver']['rules']
+
+        # rubocop:disable Layout/LineLength
+        expect(rules).to eq([{ "fullDescription" => { "text" => "errors reported by scanner" },
+          "help" => { "markdown" => "[More info](https://github.com/coinbase/salus/blob/master/docs/scanners/semgrep.md).", "text" => "More info: https://github.com/coinbase/salus/blob/master/docs/scanners/semgrep.md" },
+          "helpUri" => "https://github.com/coinbase/salus/blob/master/docs/scanners/semgrep.md",
+          "id" => "SAL002",
+          "messageStrings" => {},
+          "name" => "Syntax error" },
+                             { "fullDescription" => { "text" => "user.id == user.id is always true\n\trule_id: semgrep-eqeq-test. Pattern in semgrep-config.yml is forbidden." },
+                              "help" => { "markdown" => "[More info](https://github.com/coinbase/salus/blob/master/docs/scanners/semgrep.md).", "text" => "More info: https://github.com/coinbase/salus/blob/master/docs/scanners/semgrep.md" },
+                              "helpUri" => "https://github.com/coinbase/salus/blob/master/docs/scanners/semgrep.md",
+                              "id" => "semgrep-eqeq-test",
+                              "messageStrings" => { "cwe" => { "text" => "[\"CWE-676: Use of Potentially Dangerous Function\"]" } },
+                              "name" => " / user.id == user.id is always true\n\trule_id: semgrep-eqeq-test Forbidden Pattern Found" }])
+        # rubocop:enable Layout/LineLength
       end
 
       it 'contains info about missing required vulnerabilities' do


### PR DESCRIPTION
Adde support for CWEs in Semgrep SARIF.  When a rules metadata contains a cwe array we pass it along in the SARIF message strings cwe field.