### PR TITLE
fix: Rescue when there is an error calling cargo-audit

### DIFF
--- a/lib/salus/scanners/cargo_audit.rb
+++ b/lib/salus/scanners/cargo_audit.rb
@@ -62,9 +62,14 @@ module Salus::Scanners
     end
 
     def version
-      shell_return = run_shell('cargo-audit --version')
-      # stdout looks like "cargo-audit 0.12.0\n"
-      shell_return.stdout&.split&.dig(1)
+      begin
+        shell_return = run_shell('cargo-audit --version')
+        # stdout looks like "cargo-audit 0.12.0\n"
+        shell_return.stdout&.split&.dig(1)
+      rescue SystemCallError
+        # If there is an error calling cargo-audit, return an empty version
+        ''
+      end
     end
 
     def self.supported_languages


### PR DESCRIPTION
Fixes #828

This is a pretty naive fix, but should at least take care of the current issue. A more holistic solution would likely be to move check to a higher level, and not load the plugins if their underlying tools are not present.